### PR TITLE
[3.3] Support alt-az mounts with lateral offsets in domes

### DIFF
--- a/NINA.Core/Enum/MountTypeEnum.cs
+++ b/NINA.Core/Enum/MountTypeEnum.cs
@@ -30,5 +30,8 @@ namespace NINA.Core.Enum {
 
         [Description("LblForkOnWedge")]
         FORK_ON_WEDGE,
+
+        [Description("LblAltitudeAzimuth")]
+        ALT_AZ,
     }
 }

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -3899,7 +3899,7 @@ In case a longer duration is needed, a duration can be specified and the applica
     <value>GEM Axis Length</value>
   </data>
   <data name="LblDomeGemAxisLengthTooltip" xml:space="preserve">
-    <value>If Alt/Az, this should be 0. For an EQ mount, slew RA to +/- 90 degrees, and measure the lateral distance (in mm) from the axis to center of the telescope aperture</value>
+    <value>On an EQ mount, slew RA to +/- 90 degrees, and measure the lateral distance (in mm) from the axis to center of the telescope aperture</value>
   </data>
   <data name="LblDomeLateralAxisLength" xml:space="preserve">
     <value>Lateral Axis Length</value>
@@ -7187,6 +7187,12 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   </data>
   <data name="LblAltitudeAzimuth" xml:space="preserve">
     <value>Altitude-Azimuth</value>
+  </data>
+	<data name="LblDomeVerticalAxisLength" xml:space="preserve">
+    <value>Vertical axis length</value>
+  </data>
+  <data name="LblDomeVerticalAxisLengthTooltip" xml:space="preserve">
+    <value>For piggy-backed OTAs on an Alt-Az mounted telescope. This should be the distance between the center of the main OTA and the piggy-backed OTA</value>
   </data>
   <data name="LblRefuseUnparkWithoutShutterOpen" xml:space="preserve">
     <value>Refuse mount unpark if shutter is not open</value>

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7185,6 +7185,9 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblCivilDawn" xml:space="preserve">
     <value>Civil dawn</value>
   </data>
+  <data name="LblAltitudeAzimuth" xml:space="preserve">
+    <value>Altitude-Azimuth</value>
+  </data>
   <data name="LblRefuseUnparkWithoutShutterOpen" xml:space="preserve">
     <value>Refuse mount unpark if shutter is not open</value>
   </data>

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7338,6 +7338,9 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblCivilDawn" xml:space="preserve">
     <value>Civil dawn</value>
   </data>
+  <data name="LblAltitudeAzimuth" xml:space="preserve">
+    <value>Altitude-Azimuth</value>
+  </data>
   <data name="LblRefuseUnparkWithoutShutterOpen" xml:space="preserve">
     <value>Refuse mount unpark if shutter is not open</value>
   </data>

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -3929,13 +3929,13 @@ In case a longer duration is needed, a duration can be specified and the applica
     <value>GEM Axis Length</value>
   </data>
   <data name="LblDomeGemAxisLengthTooltip" xml:space="preserve">
-    <value>If Alt/Az, this should be 0. For an EQ mount, slew RA to +/- 90 degrees, and measure the lateral distance (in mm) from the axis to center of the telescope aperture</value>
+    <value>On an EQ mount, slew RA to +/- 90 degrees, and measure the lateral distance (in mm) from the axis to center of the telescope aperture</value>
   </data>
-  <data name="LblDomeLateralAxisLength" xml:space="preserve">
-    <value>Lateral Axis Length</value>
+  <data name="LblDomeLateralAxisOffset" xml:space="preserve">
+    <value>Lateral axis offset</value>
   </data>
-  <data name="LblDomeLateralAxisLengthTooltip" xml:space="preserve">
-    <value>In a side-by-side configuration, this is the distance (laterally, in mm) from the saddle to the OTA center. Positive is to the right along the OTA axis.</value>
+  <data name="LblDomeLateralAxisOffsetTooltip" xml:space="preserve">
+    <value>The distance laterally on Y the axis from the central axis to the OTA center. Positive is to the right along the OTA axis.</value>
   </data>
   <data name="LblDomeRadius" xml:space="preserve">
     <value>Dome Radius</value>
@@ -7341,6 +7341,12 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblAltitudeAzimuth" xml:space="preserve">
     <value>Altitude-Azimuth</value>
   </data>
+  <data name="LblDomeVerticalAxisOffset" xml:space="preserve">
+    <value>Vertical axis offset</value>
+  </data>
+  <data name="LblDomeVerticalAxisOffsetTooltip" xml:space="preserve">
+    <value>For piggy-backed OTAs on an Alt-Az mounted telescope. This should be the distance between the center of the main OTA and the piggy-backed OTA, in mm</value>
+  </data>
   <data name="LblRefuseUnparkWithoutShutterOpen" xml:space="preserve">
     <value>Refuse mount unpark if shutter is not open</value>
   </data>
@@ -7373,6 +7379,12 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   </data>
   <data name="Lbl_TimeProvider_NoSunset" xml:space="preserve">
     <value>There is no sunset at your location today.</value>
+  </data>
+  <data name="LblSlitMaximumAltitude" xml:space="preserve">
+    <value>Slit maximum altitude</value>
+  </data>
+  <data name="LblSlitMaximumAltitudeTooltip" xml:space="preserve">
+    <value>The maximum altitude angle, in degrees, that the arc of the slit reaches from the horizon. Generally, dome slits extend for some distance past zenith (90°) but may also not be able to reach zenith due to limitations of the dome's shutter</value>
   </data>
   <data name="LblUnableToConnectTo" xml:space="preserve">
     <value>Unable to connect to {0}</value>
@@ -8051,5 +8063,8 @@ This is useful when a built-in trigger has the timing you need, but you want cus
   </data>
   <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription" xml:space="preserve">
     <value>Instructions that run after conditions are safe again.</value>
+  </data>
+  <data name="LblDomeLateralAxisLength" xml:space="preserve">
+    <value>Lateral axis length</value>
   </data>
 </root>

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -236,14 +236,14 @@ namespace NINA.Equipment.Equipment.MyDome {
                 (float)domeSettings.ScopePositionUpDown_mm                           // Z: Up
             ));
 
-            // Lateral axis offset (side-by-side)
-            var lateralOffset = Matrix4x4.CreateTranslation(new Vector3(
+            // Account for any lateral axis and vertical axis offsets to accomodate side-by-side or piggyback telescopes
+            var offsets = Matrix4x4.CreateTranslation(new Vector3(
                 0.0f,
                 -(float)domeSettings.LateralAxis_mm,
-                0.0f
+                (float)domeSettings.GemAxis_mm  // Reusing GemAxis_mm for vertical offset in Alt-Az mounts since the basic meaning is the same
             ));
 
-            return mountOffset * (azimuthRotation * altitudeRotation * lateralOffset);
+            return mountOffset * (azimuthRotation * altitudeRotation * offsets);
         }
     }
 }

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -226,11 +226,14 @@ namespace NINA.Equipment.Equipment.MyDome {
             // Azimuth rotation: scope rotates around the dome’s vertical axis (z-axis)
             var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-topocentric.Azimuth.Radians));
 
+            // Determine hemisphere direction
+            var latitudeFactor = siteLatitude.Radians >= 0 ? 1.0 : -1.0;
+
             // Mount offset from dome center
             var mountOffset = Matrix4x4.CreateTranslation(new Vector3(
-                (float)domeSettings.ScopePositionNorthSouth_mm,
-                (float)domeSettings.ScopePositionEastWest_mm,
-                (float)domeSettings.ScopePositionUpDown_mm
+                (float)(domeSettings.ScopePositionNorthSouth_mm * latitudeFactor),   // X: North
+                (float)(-domeSettings.ScopePositionEastWest_mm * latitudeFactor),    // Y: East
+                (float)domeSettings.ScopePositionUpDown_mm                           // Z: Up
             ));
 
             // Lateral axis offset (side-by-side)

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -221,7 +221,7 @@ namespace NINA.Equipment.Equipment.MyDome {
             var topocentric = scopeCoordinates.Transform(siteLatitude, siteLongitude, 0d); // elevation not critical here
 
             // Altitude rotation: scope tilts up from horizontal
-            var altitudeRotation = Matrix4x4.CreateRotationY((float)(-topocentric.Altitude.Radians));
+            var altitudeRotation = Matrix4x4.CreateRotationY((float)(topocentric.Altitude.Radians));
 
             // Azimuth rotation: scope rotates around the dome’s vertical axis (z-axis)
             var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-topocentric.Azimuth.Radians));

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -223,7 +223,7 @@ namespace NINA.Equipment.Equipment.MyDome {
             // Altitude rotation: scope tilts up from horizontal
             var altitudeRotation = Matrix4x4.CreateRotationY((float)(topocentric.Altitude.Radians));
 
-            // Azimuth rotation: scope rotates around the dome’s vertical axis (z-axis)
+            // Azimuth rotation: scope rotates around the dome's vertical axis (z-axis)
             var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-topocentric.Azimuth.Radians));
 
             // Determine hemisphere direction
@@ -243,7 +243,7 @@ namespace NINA.Equipment.Equipment.MyDome {
                 0.0f
             ));
 
-            return mountOffset * azimuthRotation * altitudeRotation * lateralOffset;
+            return mountOffset * (azimuthRotation * altitudeRotation * lateralOffset);
         }
     }
 }

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -24,8 +24,8 @@ using NINA.Core.Utility.Notification;
 namespace NINA.Equipment.Equipment.MyDome {
 
     public class DomeSynchronization : IDomeSynchronization {
-        private static double TWO_PI = 2.0 * Math.PI;
-        private static double HALF_PI = Math.PI / 2.0;
+        private const double TWO_PI = 2.0 * Math.PI;
+        private const double HALF_PI = Math.PI / 2.0;
 
         private readonly IProfileService profileService;
 
@@ -42,7 +42,6 @@ namespace NINA.Equipment.Equipment.MyDome {
             PierSide sideOfPier) {
             return TargetDomeCoordinates(scopeCoordinates: scopeCoordinates, localSiderealTime: localSiderealTime, siteLatitude: siteLatitude, siteLongitude: siteLongitude, siteElevation: 0, sideOfPier: sideOfPier);
         }
-
 
         /// <summary>
         /// Gets the dome coordinates required so the scope points directly out of the shutter. This works for Alt-Az, EQ mounts, and fork mounts on a wedge
@@ -77,16 +76,17 @@ namespace NINA.Equipment.Equipment.MyDome {
             PierSide sideOfPier) {
             scopeCoordinates = scopeCoordinates.Transform(Epoch.JNOW);
             var domeSettings = profileService.ActiveProfile.DomeSettings;
+
             // To calculate the effect of rotations in the southern hemisphere we augment a few of the rotations to pretend as if it were the northern hemisphere,
             // and then add 180 degrees to the final result
-
             var origin = new Vector4(0, 0, 0, 1);
-            Matrix4x4 scopeOriginTranslation;
-            if (domeSettings.MountType == MountTypeEnum.EQUATORIAL) {
-                scopeOriginTranslation = CalculateGEM(scopeCoordinates, localSiderealTime, siteLatitude, sideOfPier);
-            } else {
-                scopeOriginTranslation = CalculateForkOnWedge(scopeCoordinates, localSiderealTime, siteLatitude);
-            }
+
+            var scopeOriginTranslation = domeSettings.MountType switch {
+                MountTypeEnum.EQUATORIAL => CalculateGEM(scopeCoordinates, localSiderealTime, siteLatitude, sideOfPier),
+                MountTypeEnum.FORK_ON_WEDGE => CalculateForkOnWedge(scopeCoordinates, localSiderealTime, siteLatitude),
+                MountTypeEnum.ALT_AZ => CalculateAltAz(scopeCoordinates, siteLatitude, siteLongitude),
+                _ => throw new NotSupportedException($"Unsupported mount type: {domeSettings.MountType}"),
+            };
 
             var scopeApertureOrigin = scopeOriginTranslation * origin;
 
@@ -206,6 +206,41 @@ namespace NINA.Equipment.Equipment.MyDome {
                     (float)domeSettings.GemAxis_mm));
 
             return mountOffset * latitudeAdjustment * raRotationAdjustment * decRotationAdjustment * gemAdjustment;
+        }
+
+        private Matrix4x4 CalculateAltAz(
+            Coordinates scopeCoordinates,
+            Angle siteLatitude,
+            Angle siteLongitude) {
+            var domeSettings = profileService.ActiveProfile.DomeSettings;
+
+            // Alt-Az mounts rotate in altitude (around the y-axis) and azimuth (around the z-axis)
+            // Altitude is Dec, Azimuth is Azimuth derived from RA/Dec + LST
+
+            // Convert scope RA/Dec to horizontal coordinates (Alt/Az)
+            var topocentric = scopeCoordinates.Transform(siteLatitude, siteLongitude, 0d); // elevation not critical here
+
+            // Altitude rotation: scope tilts up from horizontal
+            var altitudeRotation = Matrix4x4.CreateRotationY((float)(-topocentric.Altitude.Radians));
+
+            // Azimuth rotation: scope rotates around the dome’s vertical axis (z-axis)
+            var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-topocentric.Azimuth.Radians));
+
+            // Mount offset from dome center
+            var mountOffset = Matrix4x4.CreateTranslation(new Vector3(
+                (float)domeSettings.ScopePositionNorthSouth_mm,
+                (float)domeSettings.ScopePositionEastWest_mm,
+                (float)domeSettings.ScopePositionUpDown_mm
+            ));
+
+            // Lateral axis offset (side-by-side)
+            var lateralOffset = Matrix4x4.CreateTranslation(new Vector3(
+                0.0f,
+                -(float)domeSettings.LateralAxis_mm,
+                0.0f
+            ));
+
+            return mountOffset * azimuthRotation * altitudeRotation * lateralOffset;
         }
     }
 }

--- a/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
+++ b/NINA.Equipment/Equipment/MyDome/DomeSynchronization.cs
@@ -19,6 +19,7 @@ using Accord.Math;
 using NINA.Core.Enum;
 using NINA.Equipment.Interfaces;
 using NINA.Core.Locale;
+using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
 
 namespace NINA.Equipment.Equipment.MyDome {
@@ -28,6 +29,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         private const double HALF_PI = Math.PI / 2.0;
 
         private readonly IProfileService profileService;
+        private bool flippedDome = false;
 
         public DomeSynchronization(IProfileService profileService) {
             this.profileService = profileService;
@@ -84,7 +86,7 @@ namespace NINA.Equipment.Equipment.MyDome {
             var scopeOriginTranslation = domeSettings.MountType switch {
                 MountTypeEnum.EQUATORIAL => CalculateGEM(scopeCoordinates, localSiderealTime, siteLatitude, sideOfPier),
                 MountTypeEnum.FORK_ON_WEDGE => CalculateForkOnWedge(scopeCoordinates, localSiderealTime, siteLatitude),
-                MountTypeEnum.ALT_AZ => CalculateAltAz(scopeCoordinates, siteLatitude, siteLongitude),
+                MountTypeEnum.ALT_AZ => CalculateAltAz(scopeCoordinates, siteLatitude, siteLongitude, siteElevation),
                 _ => throw new NotSupportedException($"Unsupported mount type: {domeSettings.MountType}"),
             };
 
@@ -211,39 +213,66 @@ namespace NINA.Equipment.Equipment.MyDome {
         private Matrix4x4 CalculateAltAz(
             Coordinates scopeCoordinates,
             Angle siteLatitude,
-            Angle siteLongitude) {
+            Angle siteLongitude,
+            double siteElevation) {
             var domeSettings = profileService.ActiveProfile.DomeSettings;
 
-            // Alt-Az mounts rotate in altitude (around the y-axis) and azimuth (around the z-axis)
-            // Altitude is Dec, Azimuth is Azimuth derived from RA/Dec + LST
-
             // Convert scope RA/Dec to horizontal coordinates (Alt/Az)
-            var topocentric = scopeCoordinates.Transform(siteLatitude, siteLongitude, 0d); // elevation not critical here
+            var topocentric = scopeCoordinates.Transform(siteLatitude, siteLongitude, siteElevation);
 
             // Altitude rotation: scope tilts up from horizontal
             var altitudeRotation = Matrix4x4.CreateRotationY((float)(topocentric.Altitude.Radians));
+            var azimuth = topocentric.Azimuth;
+
+            // Adaptive threshold: telescope is considered to be beyond the top edge of the shutter if this altitude is exceeded
+            double verticalClearanceAngleDeg = Math.Atan2(Math.Abs(domeSettings.GemAxis_mm), domeSettings.DomeRadius_mm) * (180.0 / Math.PI);
+            double zenithThresholdDeg = 90.0 - verticalClearanceAngleDeg;
+            double zOffsetAngle = topocentric.Altitude.Degree + verticalClearanceAngleDeg;
+
+            // Check if telescope is vertically offset and near zenith and whether it is beyond the zenith threshold
+            if (domeSettings.GemAxis_mm != 0d && topocentric.Altitude.Degree >= zenithThresholdDeg) {
+
+                // If the line of sight is higher than the slit can accommodate, rotate the dome to the opposing azimuth
+                if (zOffsetAngle > domeSettings.SlitMaximumAltitude_degrees) {
+                    azimuth = Angle.ByDegree((azimuth.Degree + 180.0) % 360.0);
+
+                    if (!flippedDome) {
+                        Logger.Info("Dome azimuth flipped due to pointing inside zenith threshold. " +
+                            $"Mount Alt: {topocentric.Altitude.Degree:F2}°, Mount Az: {topocentric.Azimuth.Degree:F2}°, Dome Az: {azimuth.Degree:F2}°, z-Offset Alt: {zOffsetAngle:F2}°");
+                    }
+
+                    flippedDome = true;
+                } else {
+                    if (flippedDome) {
+                        Logger.Info("Dome azimuth unflipped after telescope moved away from zenith threshold. " +
+                            $"Mount Alt: {topocentric.Altitude.Degree:F2}°, Mount Az: {topocentric.Azimuth.Degree:F2}°, Dome Az: {azimuth.Degree:F2}°, z-Offset Alt: {zOffsetAngle:F2}°");
+                    }
+
+                    flippedDome = false;
+                }
+            }
 
             // Azimuth rotation: scope rotates around the dome's vertical axis (z-axis)
-            var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-topocentric.Azimuth.Radians));
+            var azimuthRotation = Matrix4x4.CreateRotationZ((float)(-azimuth.Radians));
 
             // Determine hemisphere direction
             var latitudeFactor = siteLatitude.Radians >= 0 ? 1.0 : -1.0;
 
             // Mount offset from dome center
             var mountOffset = Matrix4x4.CreateTranslation(new Vector3(
-                (float)(domeSettings.ScopePositionNorthSouth_mm * latitudeFactor),   // X: North
-                (float)(-domeSettings.ScopePositionEastWest_mm * latitudeFactor),    // Y: East
-                (float)domeSettings.ScopePositionUpDown_mm                           // Z: Up
+                (float)(domeSettings.ScopePositionNorthSouth_mm * latitudeFactor),   // X: North-South
+                (float)(-domeSettings.ScopePositionEastWest_mm * latitudeFactor),    // Y: East-West
+                (float)domeSettings.ScopePositionUpDown_mm                           // Z: Up-Down
             ));
 
-            // Lateral axis offset (side-by-side)
-            var lateralOffset = Matrix4x4.CreateTranslation(new Vector3(
+            // Account for any lateral axis and vertical axis offsets to accomodate side-by-side or piggyback telescopes
+            var offsets = Matrix4x4.CreateTranslation(new Vector3(
                 0.0f,
-                -(float)domeSettings.LateralAxis_mm,
-                0.0f
+                (float)domeSettings.LateralAxis_mm,
+                (float)domeSettings.GemAxis_mm
             ));
 
-            return mountOffset * (azimuthRotation * altitudeRotation * lateralOffset);
+            return mountOffset * (azimuthRotation * altitudeRotation * offsets);
         }
     }
 }

--- a/NINA.Profile/DomeSettings.cs
+++ b/NINA.Profile/DomeSettings.cs
@@ -30,12 +30,13 @@ namespace NINA.Profile {
 
         protected override void SetDefaultValues() {
             Id = "No_Device";
-            LastDeviceName = "";
+            LastDeviceName = string.Empty;
             ScopePositionEastWest_mm = 0.0;
             ScopePositionNorthSouth_mm = 0.0;
             ScopePositionUpDown_mm = 0.0;
             DomeRadius_mm = 0.0;
             GemAxis_mm = 0.0;
+            LateralAxis_mm = 0.0;
             AzimuthTolerance_degrees = 2.0;
             FindHomeBeforePark = false;
             DomeSyncTimeoutSeconds = 120;

--- a/NINA.Profile/DomeSettings.cs
+++ b/NINA.Profile/DomeSettings.cs
@@ -30,18 +30,20 @@ namespace NINA.Profile {
 
         protected override void SetDefaultValues() {
             Id = "No_Device";
-            LastDeviceName = "";
+            LastDeviceName = string.Empty;
             ScopePositionEastWest_mm = 0.0;
             ScopePositionNorthSouth_mm = 0.0;
             ScopePositionUpDown_mm = 0.0;
             DomeRadius_mm = 0.0;
             GemAxis_mm = 0.0;
+            LateralAxis_mm = 0.0;
             AzimuthTolerance_degrees = 2.0;
             FindHomeBeforePark = false;
             DomeSyncTimeoutSeconds = 120;
             SettleTimeSeconds = 1;
             SyncSlewDomeWhenMountSlews = false;
             SynchronizeDuringMountSlew = false;
+            SlitMaximumAltitude_degrees  = 100d;
         }
 
         private string id = string.Empty;
@@ -338,6 +340,19 @@ namespace NINA.Profile {
             set {
                 if (settleTimeSeconds != value) {
                     settleTimeSeconds = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double slitMaximumAltitude_degrees;
+
+        [DataMember]
+        public double SlitMaximumAltitude_degrees {
+            get => slitMaximumAltitude_degrees;
+            set {
+                if (slitMaximumAltitude_degrees != value) {
+                    slitMaximumAltitude_degrees = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Profile/Interfaces/IDomeSettings.cs
+++ b/NINA.Profile/Interfaces/IDomeSettings.cs
@@ -40,5 +40,6 @@ namespace NINA.Profile.Interfaces {
         MountTypeEnum MountType { get; set; }
         double DecOffsetHorizontal_mm { get; set; }
         int SettleTimeSeconds { get; set; }
+        double SlitMaximumAltitude_degrees { get; set; }
     }
 }

--- a/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
@@ -647,7 +647,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
             if (DomeInfo?.Connected == true) {
                 try {
                     var from = DomeInfo.Azimuth;
-                    Logger.Info($"Slewing dome to azimuth {degrees}°");
+                    Logger.Info($"Slewing dome to azimuth {degrees:F2}°");
                     progress.Report(new ApplicationStatus() { Status = Loc.Instance["LblSlew"] });
                     await Dome?.SlewToAzimuth(degrees, token);
                     var waitForUpdate = updateTimer.WaitForNextUpdate(token);

--- a/NINA/View/Options/DomeView.xaml
+++ b/NINA/View/Options/DomeView.xaml
@@ -212,6 +212,39 @@
                         Margin="0,5,0,0"
                         VerticalAlignment="Center"
                         Columns="2">
+                        <UniformGrid.Style>
+                            <Style TargetType="{x:Type UniformGrid}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="1">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </UniformGrid.Style>
+                        <TextBlock
+                            Width="250"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblDomeVerticalAxisLength}">
+                            <TextBlock.ToolTip>
+                                <TextBlock Text="{ns:Loc LblDomeVerticalAxisLengthTooltip}" />
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                        <ninactrl:UnitTextBox
+                            MinWidth="80"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Text="{Binding GemAxis_mm, UpdateSourceTrigger=LostFocus}"
+                            Unit="mm" />
+                    </UniformGrid>
+                    <UniformGrid
+                        Margin="0,5,0,0"
+                        VerticalAlignment="Center"
+                        Columns="2">
                         <TextBlock
                             Width="250"
                             HorizontalAlignment="Left"

--- a/NINA/View/Options/DomeView.xaml
+++ b/NINA/View/Options/DomeView.xaml
@@ -152,6 +152,9 @@
                                     <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="1">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </DataTrigger>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="2">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </UniformGrid.Style>
@@ -180,6 +183,9 @@
                             <Style TargetType="{x:Type UniformGrid}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="2">
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </DataTrigger>
                                 </Style.Triggers>

--- a/NINA/View/Options/DomeView.xaml
+++ b/NINA/View/Options/DomeView.xaml
@@ -59,7 +59,7 @@
                             SelectedItem="{Binding MountType}" />
                     </UniformGrid>
                     <UniformGrid
-                        Margin="0,5,0,0"
+                        Margin="0,10,0,0"
                         VerticalAlignment="Center"
                         Columns="2">
                         <TextBlock
@@ -101,7 +101,7 @@
                             Unit="mm" />
                     </UniformGrid>
                     <UniformGrid
-                        Margin="0,5,0,0"
+                        Margin="0,5,0,5"
                         VerticalAlignment="Center"
                         Columns="2">
                         <TextBlock
@@ -121,27 +121,7 @@
                             Text="{Binding ScopePositionUpDown_mm, UpdateSourceTrigger=LostFocus}"
                             Unit="mm" />
                     </UniformGrid>
-                    <UniformGrid
-                        Margin="0,5,0,0"
-                        VerticalAlignment="Center"
-                        Columns="2">
-                        <TextBlock
-                            Width="250"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            Text="{ns:Loc LblDomeRadius}">
-                            <TextBlock.ToolTip>
-                                <TextBlock Text="{ns:Loc LblDomeRadiusTooltip}" />
-                            </TextBlock.ToolTip>
-                        </TextBlock>
-                        <ninactrl:UnitTextBox
-                            MinWidth="80"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            Text="{Binding DomeRadius_mm, UpdateSourceTrigger=LostFocus}"
-                            Unit="mm" />
-                    </UniformGrid>
+                    
                     <UniformGrid
                         Margin="0,5,0,0"
                         VerticalAlignment="Center"
@@ -212,13 +192,46 @@
                         Margin="0,5,0,0"
                         VerticalAlignment="Center"
                         Columns="2">
+                        <UniformGrid.Style>
+                            <Style TargetType="{x:Type UniformGrid}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ElementName=PART_MountTypeList, Path=SelectedItem}" Value="1">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </UniformGrid.Style>
                         <TextBlock
                             Width="250"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            Text="{ns:Loc LblDomeLateralAxisLength}">
+                            Text="{ns:Loc LblDomeVerticalAxisOffset}">
                             <TextBlock.ToolTip>
-                                <TextBlock Text="{ns:Loc LblDomeLateralAxisLengthTooltip}" />
+                                <TextBlock Text="{ns:Loc LblDomeVerticalAxisOffsetTooltip}" />
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                        <ninactrl:UnitTextBox
+                            MinWidth="80"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Text="{Binding GemAxis_mm, UpdateSourceTrigger=LostFocus}"
+                            Unit="mm" />
+                    </UniformGrid>
+                    <UniformGrid
+                        Margin="0,5,0,0"
+                        VerticalAlignment="Center"
+                        Columns="2">
+                        <TextBlock
+                            Width="250"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblDomeLateralAxisOffset}">
+                            <TextBlock.ToolTip>
+                                <TextBlock Text="{ns:Loc LblDomeLateralAxisOffsetTooltip}" />
                             </TextBlock.ToolTip>
                         </TextBlock>
                         <ninactrl:UnitTextBox
@@ -227,6 +240,28 @@
                             VerticalAlignment="Center"
                             VerticalContentAlignment="Center"
                             Text="{Binding LateralAxis_mm, UpdateSourceTrigger=LostFocus}"
+                            Unit="mm" />
+                    </UniformGrid>
+
+                    <UniformGrid
+                        Margin="0,10,0,0"
+                        VerticalAlignment="Center"
+                        Columns="2">
+                        <TextBlock
+                            Width="250"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblDomeRadius}">
+                            <TextBlock.ToolTip>
+                                <TextBlock Text="{ns:Loc LblDomeRadiusTooltip}" />
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                        <ninactrl:UnitTextBox
+                            MinWidth="80"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Text="{Binding DomeRadius_mm, UpdateSourceTrigger=LostFocus}"
                             Unit="mm" />
                     </UniformGrid>
                     <UniformGrid
@@ -256,6 +291,27 @@
                                 </Binding>
                             </TextBox.Text>
                         </ninactrl:UnitTextBox>
+                    </UniformGrid>
+                    <UniformGrid
+                        Margin="0,5,0,0"
+                        VerticalAlignment="Center"
+                        Columns="2">
+                        <TextBlock
+                            Width="250"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblSlitMaximumAltitude}">
+                            <TextBlock.ToolTip>
+                                <TextBlock Text="{ns:Loc LblSlitMaximumAltitudeTooltip}" />
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                        <ninactrl:UnitTextBox
+                            MinWidth="80"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Text="{Binding SlitMaximumAltitude_degrees, UpdateSourceTrigger=LostFocus}"
+                            Unit="°" />
                     </UniformGrid>
                 </StackPanel>
             </GroupBox>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
   - N.I.N.A. now queries the ASCOM device name after connecting to the driver.  
 - **ASCOM Device State**
     - For drivers that implement the new ASCOM 7 Device State the application will now use the state when possible instead of polling individual fields
+- **Domes with Alt-Az mounts**
+  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthhal rotation for an alt-az mount
 - ** Dome/Roof safety **
     - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 - ** Switch Polling**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - **ASCOM Device State**
     - For drivers that implement the new ASCOM 7 Device State the application will now use the state when possible instead of polling individual fields
 - **Domes with Alt-Az mounts**
-  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthhal rotation for an alt-az mount
+  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthal rotation for an alt-az mount, or any side-by-side or piggy-backed telescopes mounted on a main telescope.
 - ** Dome/Roof safety **
     - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 - ** Switch Polling**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,7 +56,7 @@ This allows you to safely return to a stable release if needed.
     - The image history panel now offers FWHM and eccentricity as selectable metrics
     - The image statistics and image history panels can display FWHM, HFR and HFR deviation in either pixels or arcseconds, based on the active profile's camera pixel size and telescope focal length
 - **Domes with Alt-Az mounts**
-  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthhal rotation for an alt-az mount
+  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthal rotation for an alt-az mount, or any side-by-side or piggy-backed telescopes mounted on a main telescope.
 
 ## Behavioral Changes
 - Unparking the mount no longer automatically starts sidereal tracking. Tracking will begin automatically during a slew to a target, as usual.
@@ -182,7 +182,7 @@ This allows you to safely return to a stable release if needed.
   - N.I.N.A. now queries the ASCOM device name after connecting to the driver.  
 - **ASCOM Device State**
     - For drivers that implement the new ASCOM 7 Device State, the application will now use the state when possible instead of polling individual fields
-- **Dome/Roof Safety**
+- ** Dome/Roof safety **
     - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 - **Switch Polling**
     - Switches are now polled sequentially instead of in parallel for their status updates, to accommodate drivers that do not handle concurrent access properly.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,6 +55,8 @@ This allows you to safely return to a stable release if needed.
     - Native FWHM and eccentricity measurements are now calculated and exposed alongside HFR
     - The image history panel now offers FWHM and eccentricity as selectable metrics
     - The image statistics and image history panels can display FWHM, HFR and HFR deviation in either pixels or arcseconds, based on the active profile's camera pixel size and telescope focal length
+- **Domes with Alt-Az mounts**
+  - Alt-Az mounts are a new mount configuration that is supported under Options > Dome. This permits one to define mount and OTA offsets that result in proper dome azimuthhal rotation for an alt-az mount
 
 ## Behavioral Changes
 - Unparking the mount no longer automatically starts sidereal tracking. Tracking will begin automatically during a slew to a target, as usual.


### PR DESCRIPTION
This PR adds specific support for alt-az mounts under domes, with support for specifying an OTA's lateral offset from the mount's center. A new `ALT_AZ` member is added to `MountTypeEnum`. 

RA/Dec of the mount is converted to Alt-Az values for Y and Z axis rotation. Offsets are applied for mount position in the 4 cardinal directions and up/down positioning, then applies any lateral offset. The `latitudeFactor` reverses the orientation for the southern hemisphere.