### PR TITLE
Add new QHY USB driver name to driver version check

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -1774,6 +1774,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         private void DriverVersionCheck() {
             // Minimum driver versions. Key: Driver name. Value: Minimum driver version
             var driverDatabase = new Dictionary<string, string> {
+                { "QHYCameras_IO", "25.4.10.1516" },
                 { "QHY5IIISeries_IO", "21.10.18.0" },
                 { "QHY5II_IO", "0.0.9.0" },
                 { "QHY8LBASE", "0.0.9.0" },


### PR DESCRIPTION
## 🚀 Purpose

With USB+firmware driver release dated 2025.04.10, QHY combined both the USB2 and USB3 drivers into a single new driver, `QHYCameras_IO`. This supersedes the `QHY5IIISeries_IO` and `QHY5II_IO` drivers. Without this addition, the driver version check code searches all driver names in the list which can take quite a while to finish.

## 🧪 How Was It Tested?

Hooking up a QHY268M and QHY183M and testing connect speed with driver 25.4.10.1516 installed.

## ✅ PR Checklist

- [ x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)


