### PR TITLE
ASCOM Device State utilization

### DIFF
--- a/NINA.Core/Utility/AsyncCommand.cs
+++ b/NINA.Core/Utility/AsyncCommand.cs
@@ -117,7 +117,7 @@ namespace NINA.Core.Utility {
             observable.PropertyChanged += (object sender, PropertyChangedEventArgs e) => {
                 foreach (var propertyName in propertyNames) {
                     if (e.PropertyName == propertyName) {
-                        Application.Current.Dispatcher.Invoke(value.NotifyCanExecuteChanged);
+                        Application.Current.Dispatcher.BeginInvoke(value.NotifyCanExecuteChanged);
                         return;
                     }
                 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
   - Added native support for the new SVBony camera series 
 - **ASCOM Device Name Query**  
   - N.I.N.A. now queries the ASCOM device name after connecting to the driver.  
+- **ASCOM Device State**
+    - For drivers that implement the new ASCOM 7 Device State the application will now use the state when possible instead of polling individual fields
 
 ### **User Interface & Usability**
 - **Framing Assistant Improvements**  


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
ASCOM 7 Interfaces introduce a new DeviceState field to reduce polling.
This PR utilizes the genereric GetProperty to hook into the DeviceState when possible and uses this object instead of the individual property. This should reduce overall polling.
It's a bit unfortunate that the device state definition is only a small sub set of fields possible, so the benefit will be limited to only those fields.

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
