### PR TITLE
Sun/Moon rise and set improvements

### DIFF
--- a/NINA.Astrometry/AstroUtil.cs
+++ b/NINA.Astrometry/AstroUtil.cs
@@ -330,36 +330,63 @@ namespace NINA.Astrometry {
             return au * conversionFactor;
         }
 
+        [Obsolete("Use method with elevation parameter instead")]
         public static RiseAndSetEvent GetNightTimes(DateTime date, double latitude, double longitude) {
-            var riseAndSet = new AstronomicalTwilightRiseAndSet(date, latitude, longitude);
+            return GetNightTimes(date, latitude, longitude, 0d);
+        }
+
+        public static RiseAndSetEvent GetNightTimes(DateTime date, double latitude, double longitude, double elevation) {
+            var riseAndSet = new AstronomicalTwilightRiseAndSet(date, latitude, longitude, elevation);
             var t = riseAndSet.Calculate().Result;
 
             return riseAndSet;
         }
 
+        [Obsolete("Use method with elevation parameter instead")]
         public static RiseAndSetEvent GetNauticalNightTimes(DateTime date, double latitude, double longitude) {
-            var riseAndSet = new NauticalTwilightRiseAndSet(date, latitude, longitude);
+            return GetNauticalNightTimes(date, latitude, longitude, 0d);
+        }
+
+        public static RiseAndSetEvent GetNauticalNightTimes(DateTime date, double latitude, double longitude, double elevation) {
+            var riseAndSet = new NauticalTwilightRiseAndSet(date, latitude, longitude, elevation);
             var t = riseAndSet.Calculate().Result;
 
             return riseAndSet;
         }
 
+        [Obsolete("Use method with elevation parameter instead")]
         public static RiseAndSetEvent GetCivilNightTimes(DateTime date, double latitude, double longitude) {
-            var riseAndSet = new CivilTwilightRiseAndSet(date, latitude, longitude);
+            return GetCivilNightTimes(date, latitude, longitude, 0d);
+        }
+
+        public static RiseAndSetEvent GetCivilNightTimes(DateTime date, double latitude, double longitude, double elevation) {
+            var riseAndSet = new CivilTwilightRiseAndSet(date, latitude, longitude, elevation);
             var t = riseAndSet.Calculate().Result;
 
             return riseAndSet;
         }
 
+
+        [Obsolete("Use method with elevation parameter instead")]
         public static RiseAndSetEvent GetMoonRiseAndSet(DateTime date, double latitude, double longitude) {
-            var riseAndSet = new MoonRiseAndSet(date, latitude, longitude);
+            return GetMoonRiseAndSet(date, latitude, longitude, 0d);
+        }
+
+        public static RiseAndSetEvent GetMoonRiseAndSet(DateTime date, double latitude, double longitude, double elevation) {
+            var riseAndSet = new MoonRiseAndSet(date, latitude, longitude, elevation);
             var t = riseAndSet.Calculate().Result;
 
             return riseAndSet;
         }
 
+
+        [Obsolete("Use method with elevation parameter instead")]
         public static RiseAndSetEvent GetSunRiseAndSet(DateTime date, double latitude, double longitude) {
-            var riseAndSet = new SunRiseAndSet(date, latitude, longitude);
+            return GetSunRiseAndSet(date, latitude, longitude, 0d);
+        }
+
+        public static RiseAndSetEvent GetSunRiseAndSet(DateTime date, double latitude, double longitude, double elevation) {
+            var riseAndSet = new SunRiseAndSet(date, latitude, longitude, elevation);
             var t = riseAndSet.Calculate().Result;
 
             return riseAndSet;
@@ -695,11 +722,12 @@ namespace NINA.Astrometry {
             return GetAltitude(hourAngle, observerInfo.Latitude, tuple.Item2.Dec);
         }
 
-        public static double CalculateAltitudeForStandardRefraction(double currentAltitude, double latitude, double longitude) {
+        public static double CalculateAltitudeForStandardRefraction(double currentAltitude, double latitude, double longitude, double elevation) {
             var zenithDistance = 90d - currentAltitude;
             var location = new NOVAS.OnSurface() {
                 Latitude = latitude,
-                Longitude = longitude
+                Longitude = longitude,
+                Height = elevation
             };
             var refraction = NOVAS.Refract(ref location, NOVAS.RefractionOption.StandardRefraction, zenithDistance);
             return currentAltitude + refraction;

--- a/NINA.Astrometry/Body/BasicBody.cs
+++ b/NINA.Astrometry/Body/BasicBody.cs
@@ -19,15 +19,17 @@ namespace NINA.Astrometry.Body {
 
     public abstract class BasicBody {
 
-        public BasicBody(DateTime date, double latitude, double longitude) {
+        public BasicBody(DateTime date, double latitude, double longitude, double elevation) {
             this.Date = date;
             this.Latitude = latitude;
             this.Longitude = longitude;
+            Elevation = elevation;
         }
 
         public DateTime Date { get; private set; }
         public double Latitude { get; private set; }
         public double Longitude { get; private set; }
+        public double Elevation { get; }
         public double Distance { get; protected set; }
         public double Altitude { get; protected set; }
 
@@ -42,12 +44,13 @@ namespace NINA.Astrometry.Body {
 
                 var location = new NOVAS.OnSurface() {
                     Latitude = Latitude,
-                    Longitude = Longitude
+                    Longitude = Longitude,
+                    Height = Elevation
                 };
 
                 var observer = new NOVAS.Observer() {
                     OnSurf = location,
-                    Where = (short)NOVAS.ObserverLocation.EarthGeoCenter
+                    Where = (short)NOVAS.ObserverLocation.EarthSurface
                 };
 
                 var obj = new NOVAS.CelestialObject() {
@@ -59,7 +62,7 @@ namespace NINA.Astrometry.Body {
 
                 var objPosition = new NOVAS.SkyPosition();
 
-                NOVAS.Place(jd + AstroUtil.SecondsToDays(deltaT), obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
+                NOVAS.Place(jd, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
                 this.Distance = AstroUtil.AUToKilometer(objPosition.Dis);
 
                 var siderealTime = AstroUtil.GetLocalSiderealTime(Date, Longitude);

--- a/NINA.Astrometry/Body/Moon.cs
+++ b/NINA.Astrometry/Body/Moon.cs
@@ -18,7 +18,7 @@ namespace NINA.Astrometry.Body {
 
     public class Moon : BasicBody {
 
-        public Moon(DateTime date, double latitude, double longitude) : base(date, latitude, longitude) {
+        public Moon(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation) {
         }
 
         public override double Radius => 1738; // https://de.wikipedia.org/wiki/Monddurchmesser

--- a/NINA.Astrometry/Body/Sun.cs
+++ b/NINA.Astrometry/Body/Sun.cs
@@ -18,7 +18,7 @@ namespace NINA.Astrometry.Body {
 
     public class Sun : BasicBody {
 
-        public Sun(DateTime date, double latitude, double longitude) : base(date, latitude, longitude) {
+        public Sun(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation) {
         }
 
         public override double Radius => 696342; // https://de.wikipedia.org/wiki/Sonnenradius

--- a/NINA.Astrometry/Interfaces/ITwilightCalculator.cs
+++ b/NINA.Astrometry/Interfaces/ITwilightCalculator.cs
@@ -18,6 +18,8 @@ namespace NINA.Astrometry.Interfaces {
 
     public interface ITwilightCalculator {
 
+        [Obsolete("Use method with elevation parameter instead")]
         TimeSpan GetTwilightDuration(DateTime date, double latitude, double longitude);
+        TimeSpan GetTwilightDuration(DateTime date, double latitude, double longitude, double elevation);
     }
 }

--- a/NINA.Astrometry/NighttimeCalculator.cs
+++ b/NINA.Astrometry/NighttimeCalculator.cs
@@ -57,17 +57,18 @@ namespace NINA.Astrometry {
                 var referenceDate = GetReferenceDate(selectedDate);
                 var latitude = profileService.ActiveProfile.AstrometrySettings.Latitude;
                 var longitude = profileService.ActiveProfile.AstrometrySettings.Longitude;
+                var elevation = profileService.ActiveProfile.AstrometrySettings.Elevation;
 
                 var key = $"{referenceDate:yyyy-MM-dd-HH-mm-ss}_{latitude.ToString("0.000000", CultureInfo.InvariantCulture)}_{longitude.ToString("0.000000", CultureInfo.InvariantCulture)}";
 
                 if (Cache.TryGetValue(key, out var nighttimeData)) {
                     return nighttimeData;
                 } else {
-                    var twilightRiseAndSet = AstroUtil.GetNightTimes(referenceDate, latitude, longitude);
-                    var civilTwilightRiseAndSet = AstroUtil.GetCivilNightTimes(referenceDate, latitude, longitude);
-                    var nauticalTwilightRiseAndSet = AstroUtil.GetNauticalNightTimes(referenceDate, latitude, longitude);
-                    var moonRiseAndSet = AstroUtil.GetMoonRiseAndSet(referenceDate, latitude, longitude);
-                    var sunRiseAndSet = AstroUtil.GetSunRiseAndSet(referenceDate, latitude, longitude);
+                    var twilightRiseAndSet = AstroUtil.GetNightTimes(referenceDate, latitude, longitude, elevation);
+                    var civilTwilightRiseAndSet = AstroUtil.GetCivilNightTimes(referenceDate, latitude, longitude, elevation);
+                    var nauticalTwilightRiseAndSet = AstroUtil.GetNauticalNightTimes(referenceDate, latitude, longitude, elevation);
+                    var moonRiseAndSet = AstroUtil.GetMoonRiseAndSet(referenceDate, latitude, longitude, elevation);
+                    var sunRiseAndSet = AstroUtil.GetSunRiseAndSet(referenceDate, latitude, longitude, elevation);
                     var moonPhase = AstroUtil.GetMoonPhase(referenceDate);
                     var illumination = AstroUtil.GetMoonIllumination(referenceDate);
 

--- a/NINA.Astrometry/RiseAndSet/AstronomicalTwilightRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/AstronomicalTwilightRiseAndSet.cs
@@ -19,7 +19,7 @@ namespace NINA.Astrometry.RiseAndSet {
 
     public class AstronomicalTwilightRiseAndSet : SunCustomRiseAndSet {
 
-        public AstronomicalTwilightRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude, -18) {
+        public AstronomicalTwilightRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation, -18) {
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/CivilTwilightRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/CivilTwilightRiseAndSet.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace NINA.Astrometry.RiseAndSet {
     internal class CivilTwilightRiseAndSet : SunCustomRiseAndSet {
 
-        public CivilTwilightRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude, -6) {
+        public CivilTwilightRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation, -6) {
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/CustomRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/CustomRiseAndSet.cs
@@ -22,12 +22,12 @@ namespace NINA.Astrometry.RiseAndSet {
         private DateTime? rise;
         private DateTime? set;
 
-        public CustomRiseAndSet(DateTime? rise, DateTime? set) : base(DateTime.Now, 0, 0) {
+        public CustomRiseAndSet(DateTime? rise, DateTime? set) : base(DateTime.Now, 0, 0, 0) {
             this.rise = rise;
             this.set = set;
         }
 
-        public CustomRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude) {
+        public CustomRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation) {
         }
 
         public override Task<bool> Calculate() {

--- a/NINA.Astrometry/RiseAndSet/MoonCustomRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/MoonCustomRiseAndSet.cs
@@ -8,26 +8,18 @@ using System.Threading.Tasks;
 namespace NINA.Astrometry.RiseAndSet {
     public class MoonCustomRiseAndSet : RiseAndSetEvent {
 
-        public MoonCustomRiseAndSet(DateTime date, double latitude, double longitude, double moonAltitude) : base(date, latitude, longitude) {
+        public MoonCustomRiseAndSet(DateTime date, double latitude, double longitude, double elevation, double moonAltitude) : base(date, latitude, longitude, elevation) {
             MoonAltitude = moonAltitude;
         }
 
         public double MoonAltitude { get; }
 
         protected override double AdjustAltitude(BasicBody body) {
-            /* Readjust moon altitude based on earth radius and refraction */
-            var horizon = 90.0 - MoonAltitude;
-            var location = new NOVAS.OnSurface() {
-                Latitude = Latitude,
-                Longitude = Longitude
-            };
-            var refraction = NOVAS.Refract(ref location, NOVAS.RefractionOption.StandardRefraction, horizon); ;
-            var altitude = body.Altitude - AstroUtil.ToDegree(Earth.Radius) / body.Distance + AstroUtil.ToDegree(body.Radius) / body.Distance + refraction;
-            return altitude - MoonAltitude;
+            return body.Altitude - MoonAltitude;
         }
 
         protected override BasicBody GetBody(DateTime date) {
-            return new Moon(date, Latitude, Longitude);
+            return new Moon(date, Latitude, Longitude, Elevation);
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/MoonRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/MoonRiseAndSet.cs
@@ -19,7 +19,7 @@ namespace NINA.Astrometry.RiseAndSet {
 
     public class MoonRiseAndSet : MoonCustomRiseAndSet {
 
-        public MoonRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude, 0) {
+        public MoonRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation, -0.583) {
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/NauticalTwilightRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/NauticalTwilightRiseAndSet.cs
@@ -19,7 +19,7 @@ namespace NINA.Astrometry.RiseAndSet {
 
     public class NauticalTwilightRiseAndSet : SunCustomRiseAndSet {
 
-        public NauticalTwilightRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude, -12) {
+        public NauticalTwilightRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation, -12) {
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/RiseAndSetEvent.cs
+++ b/NINA.Astrometry/RiseAndSet/RiseAndSetEvent.cs
@@ -20,15 +20,17 @@ namespace NINA.Astrometry.RiseAndSet {
 
     public abstract class RiseAndSetEvent {
 
-        public RiseAndSetEvent(DateTime date, double latitude, double longitude) {
+        public RiseAndSetEvent(DateTime date, double latitude, double longitude, double elevation) {
             this.Date = date;
             this.Latitude = latitude;
             this.Longitude = longitude;
+            Elevation = elevation;
         }
 
         public DateTime Date { get; private set; }
         public double Latitude { get; private set; }
         public double Longitude { get; private set; }
+        public double Elevation { get; private set; }
         public virtual DateTime? Rise { get; private set; }
         public virtual DateTime? Set { get; private set; }
 
@@ -59,7 +61,8 @@ namespace NINA.Astrometry.RiseAndSet {
 
                     var location = new NOVAS.OnSurface() {
                         Latitude = Latitude,
-                        Longitude = Longitude
+                        Longitude = Longitude,
+                        Height = Elevation
                     };
 
                     // Adjust altitude for the three body parameters

--- a/NINA.Astrometry/RiseAndSet/SunCustomRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/SunCustomRiseAndSet.cs
@@ -7,26 +7,18 @@ using System.Threading.Tasks;
 
 namespace NINA.Astrometry.RiseAndSet {
     public class SunCustomRiseAndSet : RiseAndSetEvent {
-        public SunCustomRiseAndSet(DateTime date, double latitude, double longitude, double sunAltitude) : base(date, latitude, longitude) {
+        public SunCustomRiseAndSet(DateTime date, double latitude, double longitude, double elevation, double sunAltitude) : base(date, latitude, longitude, elevation) {
             SunAltitude = sunAltitude;
         }
 
         private double SunAltitude { get; }
 
         protected override double AdjustAltitude(BasicBody body) {
-            /* Readjust altitude based on earth radius and refraction */
-            var zenithDistance = 90d - SunAltitude;
-            var location = new NOVAS.OnSurface() {
-                Latitude = Latitude,
-                Longitude = Longitude
-            };
-            var refraction = NOVAS.Refract(ref location, NOVAS.RefractionOption.StandardRefraction, zenithDistance);
-            var altitude = body.Altitude - AstroUtil.ToDegree(Earth.Radius) / body.Distance + AstroUtil.ToDegree(body.Radius) / body.Distance + refraction;
-            return altitude - SunAltitude;
+            return body.Altitude - SunAltitude;
         }
 
         protected override BasicBody GetBody(DateTime date) {
-            return new Sun(date, Latitude, Longitude);
+            return new Sun(date, Latitude, Longitude, Elevation);
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/SunRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/SunRiseAndSet.cs
@@ -19,7 +19,7 @@ namespace NINA.Astrometry.RiseAndSet {
 
     public class SunRiseAndSet : SunCustomRiseAndSet {
 
-        public SunRiseAndSet(DateTime date, double latitude, double longitude) : base(date, latitude, longitude, 0) {
+        public SunRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation, -0.833) {
         }
     }
 }

--- a/NINA.Astrometry/TwilightCalculator.cs
+++ b/NINA.Astrometry/TwilightCalculator.cs
@@ -19,9 +19,14 @@ namespace NINA.Astrometry {
 
     public class TwilightCalculator : ITwilightCalculator {
 
+        [Obsolete("Use method with elevation parameter instead")]
         public TimeSpan GetTwilightDuration(DateTime date, double latitude, double longitude) {
-            var nightRise = AstroUtil.GetNightTimes(date, latitude, longitude).Rise;
-            var sunRiseAndSet = AstroUtil.GetSunRiseAndSet(date, latitude, longitude);
+            return GetTwilightDuration(date, latitude, longitude, 0.0);
+        }
+
+        public TimeSpan GetTwilightDuration(DateTime date, double latitude, double longitude, double elevation) {
+            var nightRise = AstroUtil.GetNightTimes(date, latitude, longitude, elevation).Rise;
+            var sunRiseAndSet = AstroUtil.GetSunRiseAndSet(date, latitude, longitude, elevation);
             if (nightRise == null) {
                 return sunRiseAndSet.Rise - sunRiseAndSet.Set ?? TimeSpan.Zero;
             }            

--- a/NINA.Sequencer/Conditions/LoopForSunMoonAltitudeBase.cs
+++ b/NINA.Sequencer/Conditions/LoopForSunMoonAltitudeBase.cs
@@ -38,11 +38,11 @@ namespace NINA.Sequencer.SequenceItem.Utility {
 
                 case ComparisonOperatorEnum.GREATER_THAN:
                 case ComparisonOperatorEnum.GREATER_THAN_OR_EQUAL:
-                    if (Data.CurrentAltitude > Data.Offset) { check = false; }
+                    if (Data.CurrentAltitude > GetDataOffset()) { check = false; }
                     break;
 
                 default:
-                    if (Data.CurrentAltitude <= Data.Offset) { check = false; }
+                    if (Data.CurrentAltitude <= GetDataOffset()) { check = false; }
                     break;
             }
 
@@ -51,6 +51,8 @@ namespace NINA.Sequencer.SequenceItem.Utility {
             }
             return check;
         }
+
+        protected abstract double GetDataOffset();
 
         public override string ToString() {
             return $"Condition: {GetType().Name}, " +

--- a/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
@@ -52,9 +52,8 @@ namespace NINA.Sequencer.Conditions {
         private double lastCalculationOffset = double.NaN;
         private ComparisonOperatorEnum lastCalculationComparator = ComparisonOperatorEnum.EQUALS;
 
-        //h = -0.583 degrees -: Moon's upper limb touches the horizon; atmospheric refraction accounted for
         public override void CalculateExpectedTime() {
-            Data.CurrentAltitude = AstroUtil.CalculateAltitudeForStandardRefraction(AstroUtil.GetMoonAltitude(DateTime.Now, Data.Observer), Data.Observer.Latitude, Data.Observer.Longitude);
+            Data.CurrentAltitude = AstroUtil.GetMoonAltitude(DateTime.Now, Data.Observer);
             if (!Check(null, null, true)) {
                 Data.ExpectedDateTime = DateTime.Now;
                 Data.ExpectedTime = Loc.Instance["LblNow"];
@@ -62,7 +61,7 @@ namespace NINA.Sequencer.Conditions {
             } else {
                 var referenceDate = NighttimeCalculator.GetReferenceDate(DateTime.Now);
                 // Only calculate every day or when the parameters have changed
-                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != Data.Offset || lastCalculationComparator != Data.Comparator) {
+                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != GetDataOffset() || lastCalculationComparator != Data.Comparator) {
                     Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate);
                     if (Data.ExpectedDateTime < DateTime.Now) {
                         Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate.AddDays(1));
@@ -72,15 +71,20 @@ namespace NINA.Sequencer.Conditions {
                         Data.ExpectedTime = "--";
                     }
                     lastCalculation = referenceDate;
-                    lastCalculationOffset = Data.Offset;
+                    lastCalculationOffset = GetDataOffset();
                     lastCalculationComparator = Data.Comparator;
                 }
             }
         }
 
+        protected override double GetDataOffset() {
+            // Moonrise/Moonset calculations are a special case where we adjust for the upper limp of the Moon touching the horizon including atmospheric refraction.
+            return Data.Offset != 0 ? Data.Offset : -0.583;
+        }
+
         private DateTime CalculateExpectedDateTime(DateTime time) {
             // The MoonRiseAndSet already models refraction and moon disk size
-            var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Offset);
+            var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
             AsyncContext.Run(customRiseAndSet.Calculate);
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN || Data.Comparator == ComparisonOperatorEnum.GREATER_THAN_OR_EQUAL ? customRiseAndSet.Rise : customRiseAndSet.Set) ?? DateTime.MaxValue;
         }

--- a/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
@@ -51,12 +51,8 @@ namespace NINA.Sequencer.Conditions {
         private double lastCalculationOffset = double.NaN;
         private ComparisonOperatorEnum lastCalculationComparator = ComparisonOperatorEnum.EQUALS;
 
-        //h = 0 degrees: Center of Sun's disk touches a mathematical horizon
-        //h = -0.25 degrees: Sun's upper limb touches a mathematical horizon
-        //h = -0.583 degrees: Center of Sun's disk touches the horizon; atmospheric refraction accounted for
-        //h = -0.833 degrees: Sun's upper limb touches the horizon; atmospheric refraction accounted for
         public override void CalculateExpectedTime() {
-            Data.CurrentAltitude = AstroUtil.CalculateAltitudeForStandardRefraction(AstroUtil.GetSunAltitude(DateTime.Now, Data.Observer) + AstroUtil.ArcminToDegree(0.25), Data.Observer.Latitude, Data.Observer.Longitude);
+            Data.CurrentAltitude = AstroUtil.GetMoonAltitude(DateTime.Now, Data.Observer);
 
             if (!Check(null, null, true)) {
                 Data.ExpectedDateTime = DateTime.Now;
@@ -65,7 +61,7 @@ namespace NINA.Sequencer.Conditions {
             } else {
                 var referenceDate = NighttimeCalculator.GetReferenceDate(DateTime.Now);
                 // Only calculate every day or when the parameters have changed
-                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != Data.Offset || lastCalculationComparator != Data.Comparator) {
+                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != GetDataOffset() || lastCalculationComparator != Data.Comparator) {
                     Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate);
                     if (Data.ExpectedDateTime < DateTime.Now) {
                         Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate.AddDays(1));
@@ -75,17 +71,21 @@ namespace NINA.Sequencer.Conditions {
                         Data.ExpectedTime = "--";
                     }
                     lastCalculation = referenceDate;
-                    lastCalculationOffset = Data.Offset;
+                    lastCalculationOffset = GetDataOffset();
                     lastCalculationComparator = Data.Comparator;
                 }
             }
         }
 
         private DateTime CalculateExpectedDateTime(DateTime time) {
-            // The SunRiseAndSet already models refraction and sun disk size
-            var customRiseAndSet = new SunCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Offset);
+            var customRiseAndSet = new SunCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
             AsyncContext.Run(customRiseAndSet.Calculate);
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN || Data.Comparator == ComparisonOperatorEnum.GREATER_THAN_OR_EQUAL ? customRiseAndSet.Rise : customRiseAndSet.Set) ?? DateTime.MaxValue;
+        }
+
+        protected override double GetDataOffset() {
+            // Sunrise/Sunset calculations are a special case where we adjust for the upper limp of the Sun touching the horizon including atmospheric refraction.
+            return Data.Offset != 0 ? Data.Offset : -0.833;
         }
     }
 }

--- a/NINA.Sequencer/SequenceItem/FlatDevice/SkyFlat.cs
+++ b/NINA.Sequencer/SequenceItem/FlatDevice/SkyFlat.cs
@@ -213,8 +213,8 @@ namespace NINA.Sequencer.SequenceItem.FlatDevice {
 
                 GetIterations().ResetProgress();
 
-                springTwilight = twilightCalculator.GetTwilightDuration(new DateTime(DateTime.Now.Year, 03, 20), 30.0, 0d).TotalMilliseconds;
-                todayTwilight = twilightCalculator.GetTwilightDuration(DateTime.Now, profileService.ActiveProfile.AstrometrySettings.Latitude, profileService.ActiveProfile.AstrometrySettings.Longitude).TotalMilliseconds;
+                springTwilight = twilightCalculator.GetTwilightDuration(new DateTime(DateTime.Now.Year, 03, 20), 30.0, 0d, 0d).TotalMilliseconds;
+                todayTwilight = twilightCalculator.GetTwilightDuration(DateTime.Now, profileService.ActiveProfile.AstrometrySettings.Latitude, profileService.ActiveProfile.AstrometrySettings.Longitude, 0d).TotalMilliseconds;
 
                 Logger.Info($"Determining Sky Flat Exposure Time. Min {MinExposure}, Max {MaxExposure}, Target {HistogramTargetPercentage * 100}%, Tolerance {HistogramTolerancePercentage * 100}%");
                 var exposureDetermination = await DetermineExposureTime(MinExposure, MaxExposure, progress, token);

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
@@ -75,9 +75,9 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         private bool MustWait() {
             switch (Data.Comparator) {
                 case ComparisonOperatorEnum.GREATER_THAN:
-                    return Data.CurrentAltitude > Data.Offset;
+                    return Data.CurrentAltitude > GetDataOffset();
                 default:
-                    return Data.CurrentAltitude <= Data.Offset;
+                    return Data.CurrentAltitude <= GetDataOffset();
             }
         }
 
@@ -85,9 +85,8 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         private double lastCalculationOffset = double.NaN;
         private ComparisonOperatorEnum lastCalculationComparator = ComparisonOperatorEnum.EQUALS;
 
-        // See MoonAltitudeCondition for explanation of the constant
         public override void CalculateExpectedTime() {
-            Data.CurrentAltitude = AstroUtil.GetMoonAltitude(DateTime.Now, Data.Observer) + .583;
+            Data.CurrentAltitude = AstroUtil.GetMoonAltitude(DateTime.Now, Data.Observer);
 
             if (!MustWait()) {
                 Data.ExpectedDateTime = DateTime.Now;
@@ -96,7 +95,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
             } else {
                 var referenceDate = NighttimeCalculator.GetReferenceDate(DateTime.Now);
                 // Only calculate every day or when the parameters have changed
-                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != Data.Offset || lastCalculationComparator != Data.Comparator) {
+                if (Data.ExpectedDateTime == DateTime.MinValue || lastCalculation < referenceDate || lastCalculationOffset != GetDataOffset() || lastCalculationComparator != Data.Comparator) {
                     Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate);
                     if (Data.ExpectedDateTime < DateTime.Now) {
                         Data.ExpectedDateTime = CalculateExpectedDateTime(referenceDate.AddDays(1));
@@ -106,15 +105,14 @@ namespace NINA.Sequencer.SequenceItem.Utility {
                         Data.ExpectedTime = "--";
                     }
                     lastCalculation = referenceDate;
-                    lastCalculationOffset = Data.Offset;
+                    lastCalculationOffset = GetDataOffset();
                     lastCalculationComparator = Data.Comparator;
                 }
             }
         }
 
         private DateTime CalculateExpectedDateTime(DateTime time) {
-            // The MoonRiseAndSet already models refraction and moon disk size
-            var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Offset);
+            var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
             AsyncContext.Run(customRiseAndSet.Calculate);
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN ? customRiseAndSet.Set : customRiseAndSet?.Rise) ?? DateTime.MaxValue;
         }
@@ -126,6 +124,11 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         public bool Validate() {
             CalculateExpectedTime();
             return true;
+        }
+
+        private double GetDataOffset() {
+            // Moonrise/Moonset calculations are a special case where we adjust for the upper limp of the Moon touching the horizon including atmospheric refraction.
+            return Data.Offset != 0 ? Data.Offset : -0.583;
         }
     }
 }

--- a/NINA.Test/NighttimeDataTest.cs
+++ b/NINA.Test/NighttimeDataTest.cs
@@ -47,11 +47,11 @@ namespace NINA.Test {
             referenceDate = NighttimeCalculator.GetReferenceDate(date);
             latitude = 41.0;
             longitude = 70.3;
-            civilTwilightRiseAndSet = AstroUtil.GetCivilNightTimes(referenceDate, latitude, longitude);
-            nauticalTwilightRiseAndSet = AstroUtil.GetNauticalNightTimes(referenceDate, latitude, longitude);
-            twilightRiseAndSet = AstroUtil.GetNightTimes(referenceDate, latitude, longitude);
-            moonRiseAndSet = AstroUtil.GetMoonRiseAndSet(referenceDate, latitude, longitude);
-            sunRiseAndSet = AstroUtil.GetSunRiseAndSet(referenceDate, latitude, longitude);
+            civilTwilightRiseAndSet = AstroUtil.GetCivilNightTimes(referenceDate, latitude, longitude, 0);
+            nauticalTwilightRiseAndSet = AstroUtil.GetNauticalNightTimes(referenceDate, latitude, longitude, 0);
+            twilightRiseAndSet = AstroUtil.GetNightTimes(referenceDate, latitude, longitude, 0);
+            moonRiseAndSet = AstroUtil.GetMoonRiseAndSet(referenceDate, latitude, longitude, 0);
+            sunRiseAndSet = AstroUtil.GetSunRiseAndSet(referenceDate, latitude, longitude, 0);
             moonPhase = MoonPhase.FullMoon;
             illumination = 100.0;
         }

--- a/NINA.Test/Sequencer/SequenceItem/FlatDevice/SkyFlatExposureDeterminationTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/FlatDevice/SkyFlatExposureDeterminationTest.cs
@@ -33,9 +33,9 @@ namespace NINA.Test.Sequencer.SequenceItem.FlatDevice {
 
             var spring = new DateTime(2024, 03, 20);
             var now = new DateTime(2024, month, day, hour, minute, 0);
-            twilightCalculator.GetTwilightDuration(spring, 30.0, 0d);
-            var springTwilight = twilightCalculator.GetTwilightDuration(spring, 30.0, 0d).TotalMilliseconds;
-            var todayTwilight = twilightCalculator.GetTwilightDuration(now, latitude, longitude).TotalMilliseconds;
+            twilightCalculator.GetTwilightDuration(spring, 30.0, 0d, 0);
+            var springTwilight = twilightCalculator.GetTwilightDuration(spring, 30.0, 0d, 0).TotalMilliseconds;
+            var todayTwilight = twilightCalculator.GetTwilightDuration(now, latitude, longitude, 0).TotalMilliseconds;
 
             dt.Setup(x => x.Now).Returns(now);
             var sut = new SkyFlatExposureDetermination(Stopwatch.StartNew(), 5, springTwilight, todayTwilight, dt.Object);
@@ -66,8 +66,8 @@ namespace NINA.Test.Sequencer.SequenceItem.FlatDevice {
             var spring = new DateTime(2024, 03, 20);
             var now = new DateTime(2024, month, day, hour, minute, 0);
 
-            var springTwilight = twilightCalculator.GetTwilightDuration(spring, 30.0, 0d).TotalMilliseconds;
-            var todayTwilight = twilightCalculator.GetTwilightDuration(now, latitude, longitude).TotalMilliseconds;
+            var springTwilight = twilightCalculator.GetTwilightDuration(spring, 30.0, 0d, 0).TotalMilliseconds;
+            var todayTwilight = twilightCalculator.GetTwilightDuration(now, latitude, longitude, 0).TotalMilliseconds;
 
             dt.Setup(x => x.Now).Returns(now);
             var sut = new SkyFlatExposureDetermination(Stopwatch.StartNew(), 5, springTwilight, todayTwilight, dt.Object);

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/CivilDawnProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/CivilDawnProviderTest.cs
@@ -22,7 +22,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, null, null, null, riseAndSetEvent);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/CivilDuskProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/CivilDuskProviderTest.cs
@@ -22,7 +22,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, null, null, null, riseAndSetEvent);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/DawnProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/DawnProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, riseAndSetEvent, null, null, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/DuskProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/DuskProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, riseAndSetEvent, null, null, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/NauticalDawnProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/NauticalDawnProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, riseAndSetEvent, null, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/NauticalDuskProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/NauticalDuskProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, riseAndSetEvent, null, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/SunriseProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/SunriseProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new SunRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new SunRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, null, riseAndSetEvent, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/NINA.Test/Sequencer/Utility/DateTimeProvider/SunsetProviderTest.cs
+++ b/NINA.Test/Sequencer/Utility/DateTimeProvider/SunsetProviderTest.cs
@@ -38,7 +38,7 @@ namespace NINA.Test.Sequencer.Utility.DateTimeProvider {
             var customDateTimeMock = new Mock<ICustomDateTime>();
             customDateTimeMock.SetupGet(x => x.Now).Returns(referenceDate);
 
-            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0);
+            var riseAndSetEvent = new CustomRiseAndSet(referenceDate, 0, 0, 0);
             var nighttimeData = new NighttimeData(referenceDate, referenceDate, AstroUtil.MoonPhase.Unknown, null, null, null, riseAndSetEvent, null, null);
 
             var nightTimeCalculatorMock = new Mock<INighttimeCalculator>();

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,9 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - PlayerOne Filter Wheel native driver will no longer incorrectly log an error while the wheel is moving
 - Ascom device instances that fail to connect are now properly disposed
 - When Smart Exposure was interrupted and the filter was manually changed afterwards, the instruction will now make sure the filter is set to the correct one before proceeding with the next exposure
-
+- Sunrise, sunset, moonrise, and moonset now account for your location's elevation for increased accuracy.
+- Sequencer conditions and instructions now better handle transitions near the horizon, preventing sudden jumps in sun and moon altitude caused by atmospheric refraction effects breaking down below horizon.
+ 
 ### **Device Management**
 - **Device Chooser Enhancements**  
   - A stored device ID that is currently unavailable will now appear as an "Offline Device" instead of "No Device," differentiating between having no device selected and an unavailable saved device.  


### PR DESCRIPTION

<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
- Remove refraction correction for sun and moon calculations to prevent "jumps" when crossing the horizon
- Astronomical Dusk was not calculated correctly for certain latitudes
- Add special handling for moon/sun wait instructions and loop conditions when setting the value to 0 to meet the general expectation of refracted rise/set

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->
Calculated times have been cross checked with timeanddate.com

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [x] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->
Jumping altitude:
https://bitbucket.org/Isbeorn/nina/issues/1381/sudden-discontinuity-in-currentsunaltitude
Inconsistent dusk calculation:
https://discord.com/channels/436650817295089664/1384139475747213412

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
