### PR TITLE
Prevent device GET/SET on generic method when expected connection sta…

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
@@ -201,7 +201,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             get {
                 bool val = false;
                 try {
-                    if (Connected && _hasCooler) {
+                    if (ShouldBeConnected && _hasCooler) {
                         val = device.CoolerOn;
                     }
                 } catch (Exception) {
@@ -211,7 +211,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
             set {
                 try {
-                    if (Connected && _hasCooler) {
+                    if (ShouldBeConnected && _hasCooler) {
                         device.CoolerOn = value;
                         RaisePropertyChanged();
                     }
@@ -286,7 +286,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int Gain {
             get {
                 int val = -1;
-                if (Connected && CanGetGain) {
+                if (ShouldBeConnected && CanGetGain) {
                     try {
                         if (Gains.Count > 0) {
                             val = (int)Gains[device.Gain];
@@ -301,7 +301,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 return val;
             }
             set {
-                if (Connected && CanSetGain) {
+                if (ShouldBeConnected && CanSetGain) {
                     try {
                         if (Gains.Count > 0) {
                             short idx = (short)Gains.IndexOf(value);
@@ -379,7 +379,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int GainMax {
             get {
                 int val = -1;
-                if (Connected) {
+                if (ShouldBeConnected) {
                     if (_canGetGainMinMax) {
                         try {
                             val = device.GainMax;
@@ -403,7 +403,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int GainMin {
             get {
                 int val = -1;
-                if (Connected) {
+                if (ShouldBeConnected) {
                     if (_canGetGainMinMax) {
                         try {
                             val = device.GainMin;
@@ -455,7 +455,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             get {
                 double val = -1;
                 try {
-                    if (Connected && _hasLastExposureInfo) {
+                    if (ShouldBeConnected && _hasLastExposureInfo) {
                         val = device.LastExposureDuration;
                     }
                 } catch (ASCOM.InvalidOperationException) {
@@ -470,7 +470,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             get {
                 string val = string.Empty;
                 try {
-                    if (Connected && _hasLastExposureInfo) {
+                    if (ShouldBeConnected && _hasLastExposureInfo) {
                         val = device.LastExposureStartTime;
                     }
                 } catch (ASCOM.InvalidOperationException) {
@@ -521,7 +521,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public short ReadoutMode {
             get => GetProperty<short>(nameof(Camera.ReadoutMode), 0);
             set {
-                if (Connected && (value != ReadoutMode) && (value < ReadoutModes.Count)) {
+                if (ShouldBeConnected && (value != ReadoutMode) && (value < ReadoutModes.Count)) {
                     try {
                         device.ReadoutMode = value;
                     } catch (InvalidValueException ex) {
@@ -728,7 +728,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int OffsetMin {
             get {
                 var offsetMin = 0;
-                if (Connected && CanSetOffset) {
+                if (ShouldBeConnected && CanSetOffset) {
                     if (offsetValueMode) {
                         offsetMin = device.OffsetMin;
                     } else {
@@ -744,7 +744,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int OffsetMax {
             get {
                 var offsetMax = 0;
-                if (Connected && CanSetOffset) {
+                if (ShouldBeConnected && CanSetOffset) {
                     if (offsetValueMode) {
                         offsetMax = device.OffsetMax;
                     } else {
@@ -762,7 +762,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public int Offset {
             get {
                 var offset = -1;
-                if (Connected && CanSetOffset) {
+                if (ShouldBeConnected && CanSetOffset) {
                     if (offsetValueMode) {
                         offset = device.Offset;
                     } else {
@@ -773,7 +773,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
             set {
                 try {
-                    if (Connected && CanSetOffset) {
+                    if (ShouldBeConnected && CanSetOffset) {
                         if (offsetValueMode) {
                             if (value < OffsetMin) {
                                 value = OffsetMin;

--- a/NINA.Equipment/Equipment/MyDome/AscomDome.cs
+++ b/NINA.Equipment/Equipment/MyDome/AscomDome.cs
@@ -125,7 +125,7 @@ namespace NINA.Equipment.Equipment.MyDome {
             }
         }
 
-        public bool CanSyncAzimuth => Connected && device.CanSyncAzimuth;
+        public bool CanSyncAzimuth => ShouldBeConnected && device.CanSyncAzimuth;
 
         protected override string ConnectionLostMessage => Loc.Instance["LblDomeConnectionLost"];
 
@@ -133,7 +133,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public async Task SlewToAzimuth(double azimuth, CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSetAzimuth) {
                     using (ct.Register(async () => await StopSlewing())) {
                         await (device?.SlewToAzimuthAsync(azimuth, ct) ?? Task.CompletedTask);
@@ -150,7 +150,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public Task StopSlewing() {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 // ASCOM only allows you to stop all movement, which includes both shutter and slewing. If the shutter was opening or closing
                 // when this command is received, try and continue the operation afterwards
                 return Task.Run(async () => {
@@ -177,7 +177,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public Task StopAll() {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 return Task.Run(() => device?.AbortSlew());
             } else {
                 Logger.Warning("Dome is not connected");
@@ -187,7 +187,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public async Task OpenShutter(CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSetShutter) {
                     if (ShutterStatus == ShutterState.ShutterOpen) {
                         return;
@@ -232,7 +232,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public async Task CloseShutter(CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSetShutter) {
                     if (ShutterStatus == ShutterState.ShutterClosed) {
                         return;
@@ -271,7 +271,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public async Task FindHome(CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanFindHome) {
                     if (AtHome == true) {
                         Logger.Info("Dome already AtHome. Not submitting a FindHome request");
@@ -313,7 +313,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public async Task Park(CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanPark) {
                     // ASCOM domes make no promise that a slew operation can take place if one is already in progress, so we do a hard abort up front to ensure Park works
                     if (Slewing == true) {
@@ -359,7 +359,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public void SetPark() {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSetPark) {
                     device.SetPark();
                 } else {
@@ -373,7 +373,7 @@ namespace NINA.Equipment.Equipment.MyDome {
         }
 
         public void SyncToAzimuth(double azimuth) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSyncAzimuth) {
                     device.SyncToAzimuth(azimuth);
                 } else {

--- a/NINA.Equipment/Equipment/MyFocuser/AscomFocuser.cs
+++ b/NINA.Equipment/Equipment/MyFocuser/AscomFocuser.cs
@@ -67,7 +67,7 @@ namespace NINA.Equipment.Equipment.MyFocuser {
                 }
             }
             set {
-                if (Connected && TempCompAvailable) {
+                if (ShouldBeConnected && TempCompAvailable) {
                     SetProperty(nameof(Focuser.TempComp), value);
                 }
             }
@@ -86,7 +86,7 @@ namespace NINA.Equipment.Equipment.MyFocuser {
         private static TimeSpan SameFocuserPositionTimeout = TimeSpan.FromMinutes(1);
 
         private async Task MoveInternalAbsolute(int position, CancellationToken ct, int waitInMs = 1000) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 var reEnableTempComp = TempComp;
                 if (reEnableTempComp) {
                     TempComp = false;
@@ -122,7 +122,7 @@ namespace NINA.Equipment.Equipment.MyFocuser {
         }
 
         private async Task MoveInternalRelative(int position, CancellationToken ct, int waitInMs = 1000) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 var reEnableTempComp = TempComp;
                 if (reEnableTempComp) {
                     TempComp = false;
@@ -153,7 +153,7 @@ namespace NINA.Equipment.Equipment.MyFocuser {
         private bool _canHalt;
 
         public void Halt() {
-            if (Connected && _canHalt) {
+            if (ShouldBeConnected && _canHalt) {
                 try {
                     device.Halt();
                 } catch (MethodNotImplementedException) {

--- a/NINA.Equipment/Equipment/MyRotator/AscomRotator.cs
+++ b/NINA.Equipment/Equipment/MyRotator/AscomRotator.cs
@@ -85,7 +85,7 @@ namespace NINA.Equipment.Equipment.MyRotator {
         }
 
         public async Task<bool> Move(float angle, CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (angle >= 360) {
                     angle = AstroUtil.EuclidianModulus(angle, 360);
                 }
@@ -103,7 +103,7 @@ namespace NINA.Equipment.Equipment.MyRotator {
         }
 
         public async Task<bool> MoveAbsoluteMechanical(float targetPosition, CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 var movement = targetPosition - MechanicalPosition;
                 return await Move(movement, ct);
             }
@@ -111,7 +111,7 @@ namespace NINA.Equipment.Equipment.MyRotator {
         }
 
         public async Task<bool> MoveAbsolute(float targetPosition, CancellationToken ct) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 return await Move(targetPosition - Position, ct);
             }
             return false;

--- a/NINA.Equipment/Equipment/MyTelescope/AscomTelescope.cs
+++ b/NINA.Equipment/Equipment/MyTelescope/AscomTelescope.cs
@@ -260,7 +260,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public Coordinates TargetCoordinates {
             get {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     return _targetCoordinates;
                 }
                 return null;
@@ -275,7 +275,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public PierSide? TargetSideOfPier {
             get {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     return targetSideOfPier;
                 } else {
                     return null;
@@ -452,7 +452,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
         }
 
         public void MoveAxis(TelescopeAxes axis, double rate) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanSlew) {
                     if (!AtPark) {
                         var actualRate = rate;
@@ -498,7 +498,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
         }
 
         public void PulseGuide(GuideDirections direction, int duration) {
-            if (Connected) {
+            if (ShouldBeConnected) {
                 if (CanPulseGuide) {
                     if (!AtPark) {
                         try {
@@ -543,7 +543,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
             }
         }
 
-        public bool CanSetTrackingEnabled => Connected && GetProperty(nameof(Telescope.CanSetTracking), false);
+        public bool CanSetTrackingEnabled => ShouldBeConnected && GetProperty(nameof(Telescope.CanSetTracking), false);
 
         public bool TrackingEnabled {
             get => GetProperty(nameof(Telescope.Tracking), false);
@@ -558,7 +558,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
         }
 
         public async Task<bool> SlewToCoordinates(Coordinates coordinates, CancellationToken token) {
-            if (Connected && !AtPark) {
+            if (ShouldBeConnected && !AtPark) {
                 try {
                     TrackingEnabled = true;
                     TargetCoordinates = coordinates.Transform(EquatorialSystem);
@@ -588,7 +588,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
         }
 
         public async Task<bool> SlewToAltAz(TopocentricCoordinates coordinates, CancellationToken token) {
-            if (Connected && !AtPark && CanSlewAltAz) {
+            if (ShouldBeConnected && !AtPark && CanSlewAltAz) {
                 try {
                     TrackingEnabled = false;
                     TargetCoordinates = coordinates.Transform(EquatorialSystem);
@@ -707,7 +707,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public bool CanMovePrimaryAxis {
             get {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     return device.CanMoveAxis(ASCOM.Common.DeviceInterfaces.TelescopeAxis.Primary);
                 }
                 return false;
@@ -716,7 +716,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public bool CanMoveSecondaryAxis {
             get {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     return device.CanMoveAxis(ASCOM.Common.DeviceInterfaces.TelescopeAxis.Secondary);
                 }
                 return false;
@@ -734,7 +734,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
                 return primaryMovingRate;
             }
             set {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     primaryMovingRate = GetAdjustedMovingRate(value, primaryMovingRate, ASCOM.Common.DeviceInterfaces.TelescopeAxis.Primary);
                     RaisePropertyChanged();
                 }
@@ -752,7 +752,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
                 return secondaryMovingRate;
             }
             set {
-                if (Connected) {
+                if (ShouldBeConnected) {
                     secondaryMovingRate = GetAdjustedMovingRate(value, secondaryMovingRate, ASCOM.Common.DeviceInterfaces.TelescopeAxis.Secondary);
                     RaisePropertyChanged();
                 }
@@ -916,7 +916,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public TrackingRate TrackingRate {
             get {
-                if (!Connected || !TrackingEnabled) {
+                if (!ShouldBeConnected || !TrackingEnabled) {
                     return new TrackingRate() { TrackingMode = TrackingMode.Stopped };
                 } else if (!CanSetTrackingEnabled) {
                     return new TrackingRate() { TrackingMode = TrackingMode.Sidereal };
@@ -956,7 +956,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
                     throw new ArgumentException("TrackingMode cannot be set to Custom. Use SetCustomTrackingRate");
                 }
 
-                if (Connected && device.CanSetTracking) {
+                if (ShouldBeConnected && device.CanSetTracking) {
                     try {
                         // Set the mode regardless of whether it is the same as what is currently set
                         // Some ASCOM drivers incorrectly report custom rates as Sidereal, and this can help force set the tracking mode to the desired value

--- a/NINA.Test/Dome/DomeVMTest.cs
+++ b/NINA.Test/Dome/DomeVMTest.cs
@@ -153,6 +153,7 @@ namespace NINA.Test.Dome {
         [Test]
         public async Task Test_DomeDisconnected_DomeFollowEnabled_NoStart() {
             var sut = await CreateSUT();
+            await sut.Disconnect();
             domeConnected = false;
             sut.FollowEnabled = true;
             mockDomeFollower.Verify(x => x.Start(), Times.Never);

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -933,7 +933,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
 
         public double ExposureMin {
             get {
-                if (Cam?.Connected != true) {
+                if (CameraInfo?.Connected != true) {
                     return 0.0;
                 }
                 // Guard against bad values reported by a driver
@@ -960,7 +960,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
         }
 
         public string Action(string actionName, string actionParameters) {
-            if (Cam?.Connected == true) {
+            if (CameraInfo?.Connected == true) {
                 return Cam.Action(actionName, actionParameters);
             } else {
                 Notification.ShowError(Loc.Instance["LblTelescopeNotConnectedForCommand"] + ": " + actionName);
@@ -969,7 +969,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
         }
 
         public string SendCommandString(string command, bool raw = true) {
-            if (Cam?.Connected == true) {
+            if (CameraInfo?.Connected == true) {
                 return Cam.SendCommandString(command, raw);
             } else {
                 Notification.ShowError(Loc.Instance["LblTelescopeNotConnectedForCommand"] + ": " + command);
@@ -978,7 +978,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
         }
 
         public bool SendCommandBool(string command, bool raw = true) {
-            if (Cam?.Connected == true) {
+            if (CameraInfo?.Connected == true) {
                 return Cam.SendCommandBool(command, raw);
             } else {
                 Notification.ShowError(Loc.Instance["LblTelescopeNotConnectedForCommand"] + ": " + command);
@@ -987,7 +987,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
         }
 
         public void SendCommandBlind(string command, bool raw = true) {
-            if (Cam?.Connected == true) {
+            if (CameraInfo?.Connected == true) {
                 Cam.SendCommandBlind(command, raw);
             } else {
                 Notification.ShowError(Loc.Instance["LblTelescopeNotConnectedForCommand"] + ": " + command);

--- a/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
@@ -635,7 +635,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
 
         public bool CanSyncAzimuth {
             get {
-                if (Dome?.Connected != true || TelescopeInfo?.Connected != true) {
+                if (DomeInfo?.Connected != true || TelescopeInfo?.Connected != true) {
                     return false;
                 }
                 return Dome.CanSyncAzimuth;
@@ -643,7 +643,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         public async Task<bool> SlewToAzimuth(double degrees, CancellationToken token) {
-            if (Dome?.Connected == true) {
+            if (DomeInfo?.Connected == true) {
                 try {
                     var from = DomeInfo.Azimuth;
                     Logger.Info($"Slewing dome to azimuth {degrees}°");
@@ -714,7 +714,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
 
         public bool FollowEnabled {
             get {
-                if (Dome?.Connected == true) {
+                if (DomeInfo?.Connected == true) {
                     return followEnabled;
                 } else {
                     return false;
@@ -730,7 +730,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         private void OnFollowChanged(bool followEnabled) {
-            if (followEnabled && Dome?.Connected == true) {
+            if (followEnabled && DomeInfo?.Connected == true) {
                 this.domeFollower.Start();
                 Logger.Info($"Dome following enabled");
             } else {
@@ -771,7 +771,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         public async Task<bool> EnableFollowing(CancellationToken cancellationToken) {
-            if (!Dome.Connected) {
+            if (!DomeInfo.Connected) {
                 return false;
             }
 
@@ -784,7 +784,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         public async Task<bool> DisableFollowing(CancellationToken cancellationToken) {
-            if (!Dome.Connected) {
+            if (!DomeInfo.Connected) {
                 return false;
             }
 
@@ -798,7 +798,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
 
         public void UpdateDeviceInfo(SafetyMonitorInfo deviceInfo) {
             SafetyMonitorInfo = deviceInfo;
-            if (Dome?.Connected == true && profileService.ActiveProfile.DomeSettings.CloseOnUnsafe) {
+            if (DomeInfo?.Connected == true && profileService.ActiveProfile.DomeSettings.CloseOnUnsafe) {
                 //Close dome when state switches from safe to unsafe
                 if (deviceInfo.Connected && !deviceInfo.IsSafe && Dome?.ShutterStatus == ShutterState.ShutterOpen) {
                     lock (lockObj) {
@@ -819,7 +819,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         public string Action(string actionName, string actionParameters) {
-            if (Dome?.Connected == true) {
+            if (DomeInfo?.Connected == true) {
                 return Dome.Action(actionName, actionParameters);
             } else {
                 Notification.ShowError(Loc.Instance["LblTelescopeNotConnectedForCommand"] + ": " + actionName);
@@ -828,15 +828,15 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
         }
 
         public string SendCommandString(string command, bool raw = true) {
-            return Dome?.Connected == true ? Dome.SendCommandString(command, raw) : null;
+            return DomeInfo?.Connected == true ? Dome.SendCommandString(command, raw) : null;
         }
 
         public bool SendCommandBool(string command, bool raw = true) {
-            return Dome?.Connected == true ? Dome.SendCommandBool(command, raw) : false;
+            return DomeInfo?.Connected == true ? Dome.SendCommandBool(command, raw) : false;
         }
 
         public void SendCommandBlind(string command, bool raw = true) {
-            if (Dome?.Connected == true) {
+            if (DomeInfo?.Connected == true) {
                 Dome.SendCommandBlind(command, raw);
             }
         }

--- a/NINA.WPF.Base/ViewModel/Equipment/FlatDevice/FlatDeviceVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/FlatDevice/FlatDeviceVM.cs
@@ -136,7 +136,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FlatDevice {
         }
 
         public Task<bool> SetBrightness(int value, IProgress<ApplicationStatus> progress, CancellationToken token) {
-            if (FlatDevice == null || !FlatDevice.Connected) return Task.FromResult(false);
+            if (FlatDevice == null || !FlatDeviceInfo.Connected) return Task.FromResult(false);
             return Task.Run(async () => {
                 try {
                     var from = FlatDeviceInfo.Brightness;
@@ -306,8 +306,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FlatDevice {
         public async Task<bool> OpenCover(IProgress<ApplicationStatus> progress, CancellationToken token) {
             await ssOpen.WaitAsync(token);
             try {
-                if (FlatDevice.Connected == false) return false;
-                if (!FlatDevice.SupportsOpenClose) return false;
+                if (FlatDeviceInfo.Connected == false) return false;
+                if (!FlatDeviceInfo.SupportsOpenClose) return false;
                 if (FlatDevice.CoverState == CoverState.Open) return true;
                 Logger.Info("Opening Flat Device Cover");
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblOpeningCover"] });
@@ -335,8 +335,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FlatDevice {
         public async Task<bool> CloseCover(IProgress<ApplicationStatus> progress, CancellationToken token) {
             await ssClose.WaitAsync(token);
             try {
-                if (FlatDevice.Connected == false) return false;
-                if (!FlatDevice.SupportsOpenClose) return false;
+                if (FlatDeviceInfo.Connected == false) return false;
+                if (!FlatDeviceInfo.SupportsOpenClose) return false;
                 if (FlatDevice.CoverState == CoverState.Closed) return true;
                 Logger.Info("Closing Flat Device Cover");
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblClosingCover"] });
@@ -413,7 +413,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FlatDevice {
         }
 
         public Task<bool> ToggleLight(bool onOff, IProgress<ApplicationStatus> progress, CancellationToken token) {
-            if (FlatDevice == null || FlatDevice.Connected == false) return Task.FromResult(false);
+            if (FlatDevice == null || FlatDeviceInfo.Connected == false) return Task.FromResult(false);
             return Task.Run(async () => {
                 try {
                     if (FlatDevice.LightOn == onOff) {

--- a/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
@@ -109,7 +109,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
 
         private void HaltFocuser() {
             Logger.Info("Halting Focuser");
-            if (Focuser?.Connected != true) return;
+            if (FocuserInfo?.Connected != true) return;
             try {
                 Focuser.Halt();
             } catch (Exception ex) {
@@ -178,7 +178,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
         public async Task<int> MoveFocuserRelative(int offset, CancellationToken ct) {
             await ss.WaitAsync(ct);
             try {
-                if (Focuser?.Connected != true) return -1;
+                if (FocuserInfo?.Connected != true) return -1;
                 var pos = Position + offset;
                 pos = await MoveFocuserInternal(pos, ct);
                 return pos;

--- a/NINA.WPF.Base/ViewModel/Equipment/Rotator/RotatorVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Rotator/RotatorVM.cs
@@ -234,7 +234,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Rotator {
         }
 
         public async Task<float> MoveRelative(float offset, TimeSpan waitTime, CancellationToken ct) {
-            if (Rotator?.Connected == true) {
+            if (RotatorInfo?.Connected == true) {
                 return await MoveMechanical(Rotator.MechanicalPosition + offset, waitTime, ct);
             }
             return -1;

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -230,7 +230,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             bool success = false;
             Logger.Info("Mount ordered to unpark");
 
-            if (!Telescope.Connected) {
+            if (!TelescopeInfo.Connected) {
                 Logger.Error("Mount is not connected");
                 return false;
             }
@@ -285,8 +285,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             await Task.Run(async () => {
                 IsParkingOrHoming = true;
 
-                if (Telescope.Connected) {
-                    if (Telescope.CanFindHome) {
+                if (TelescopeInfo.Connected) {
+                    if (TelescopeInfo.CanFindHome) {
                         if (!Telescope.AtHome) {
                             if (!Telescope.AtPark) {
                                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -914,7 +914,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             // Add a generous timeout of 10 minutes - just to prevent the procedure being stuck
             timeoutCts.CancelAfter(TimeSpan.FromMinutes(10));
             try {
-                if (Telescope?.Connected == true) {
+                if (TelescopeInfo?.Connected == true) {
                     if (Telescope?.Slewing == true && Telescope?.TrackingEnabled == false) {
                         Logger.Warning("Slew issued while telesope is possibly in the process of parking!");
                     }
@@ -1028,7 +1028,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
         }
 
         public async Task WaitForSlew(CancellationToken cancellationToken) {
-            if (Telescope?.Connected == true) {
+            if (TelescopeInfo?.Connected == true) {
                 while (Telescope?.Slewing == true && !cancellationToken.IsCancellationRequested) {
                     await Task.Delay(1000);
                 }
@@ -1057,12 +1057,12 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
         }
 
         public bool SetTrackingMode(TrackingMode trackingMode) {
-            if(Telescope?.Connected != true) {
+            if(TelescopeInfo?.Connected != true) {
                 Logger.Warning("Cannot set tracking mode as the mount is not connected");
                 return false;
             }
 
-            if(Telescope.AtPark) {
+            if(TelescopeInfo.AtPark) {
                 Logger.Warning("Cannot set tracking mode as the mount is parked");
                 return false;
             }
@@ -1086,7 +1086,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
         }
 
         public bool SetCustomTrackingRate(SiderealShiftTrackingRate rate) {
-            if (Telescope?.Connected == true) {
+            if (TelescopeInfo?.Connected == true) {
                 if (rate.Enabled) {
                     Telescope.SetCustomTrackingRate(rightAscensionRate: rate.RASecondsPerSiderealSecond, declinationRate: rate.DecArcsecsPerSec);
                 } else {
@@ -1118,24 +1118,24 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
         }
 
         public string Action(string actionName, string actionParameters = "") {
-            return Telescope?.Connected == true ? Telescope.Action(actionName, actionParameters) : null;
+            return TelescopeInfo?.Connected == true ? Telescope.Action(actionName, actionParameters) : null;
         }
 
         public string SendCommandString(string command, bool raw = true) {
-            return Telescope?.Connected == true ? Telescope.SendCommandString(command, raw) : null;
+            return TelescopeInfo?.Connected == true ? Telescope.SendCommandString(command, raw) : null;
         }
 
         public bool SendCommandBool(string command, bool raw = true) {
-            return Telescope?.Connected == true ? Telescope.SendCommandBool(command, raw) : false;
+            return TelescopeInfo?.Connected == true ? Telescope.SendCommandBool(command, raw) : false;
         }
 
         public void SendCommandBlind(string command, bool raw = true) {
-            if (Telescope?.Connected == true) {
+            if (TelescopeInfo?.Connected == true) {
                 Telescope.SendCommandBlind(command, raw);
             }
         }
         public PierSide DestinationSideOfPier(Coordinates coordinates) {
-            if (Telescope?.Connected == true) {
+            if (TelescopeInfo?.Connected == true) {
                 return Telescope.DestinationSideOfPier(coordinates);
             }
             return PierSide.pierUnknown;


### PR DESCRIPTION
…te is false

Further reduce polling of connected flag and rely on the background updates to identify connection losses

<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
Device states are polled sometimes slightly after disconnection. Most likely some UI databindings onto the device still are in the process of query while disconnecting. This change adds a "connection expecatation" flag that is used to determine if a device should be connected or not without having to further poll the device. 
Additionally this new flag is used for most connection checks as it will be sufficient. For the real device connection drop the background workers that constantly query the device state are still managing this in a central place.

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
