### PR TITLE
Remove fields from device polling that likely never change

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/CameraInfo.cs
+++ b/NINA.Equipment/Equipment/MyCamera/CameraInfo.cs
@@ -183,6 +183,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
             set { if (pixelSize != value) { pixelSize = value; RaisePropertyChanged(); } }
         }
 
+        private bool hasBattery;
+
+        public bool HasBattery {
+            get => hasBattery;
+            set { if (hasBattery != value) { hasBattery = value; RaisePropertyChanged(); } }
+        }
+
         private int battery;
 
         public int Battery {

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -414,6 +414,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                                 TemperatureSetPoint = Cam.TemperatureSetPoint,
                                 XSize = Cam.CameraXSize,
                                 YSize = Cam.CameraYSize,
+                                HasBattery = Cam.HasBattery,
                                 Battery = Cam.BatteryLevel,
                                 BitDepth = Cam.BitDepth,
                                 ElectronsPerADU = Cam.ElectronsPerADU,
@@ -612,21 +613,21 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
             cameraValues.Add(nameof(CameraInfo.ExposureMin), _cam?.ExposureMin ?? 0);
             cameraValues.Add(nameof(CameraInfo.PixelSize), _cam?.PixelSizeX ?? 0);
 
-            if (_cam != null && _cam.CanSetGain) {
+            if (_cam != null && CameraInfo.CanSetGain) {
                 cameraValues.Add(nameof(CameraInfo.Gain), _cam?.Gain ?? -1);
                 cameraValues.Add(nameof(CameraInfo.DefaultGain), DefaultGain);
             }
 
-            if (_cam != null && _cam.CanSetOffset) {
+            if (_cam != null && CameraInfo.CanSetOffset) {
                 cameraValues.Add(nameof(CameraInfo.Offset), _cam?.Offset ?? -1);
                 cameraValues.Add(nameof(CameraInfo.DefaultOffset), DefaultOffset);
             }
 
-            if (_cam != null && _cam.CanSetUSBLimit) {
+            if (_cam != null && CameraInfo.CanSetUSBLimit) {
                 cameraValues.Add(nameof(CameraInfo.USBLimit), _cam?.USBLimit ?? -1);
             }
 
-            if (_cam != null && _cam.HasBattery) {
+            if (_cam != null && CameraInfo.HasBattery) {
                 cameraValues.Add(nameof(CameraInfo.Battery), _cam?.BatteryLevel ?? -1);
             }
 

--- a/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeVM.cs
@@ -235,13 +235,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
             Dictionary<string, object> domeValues = new Dictionary<string, object> {
                 { nameof(DomeInfo.Connected), Dome?.Connected ?? false },
                 { nameof(DomeInfo.ShutterStatus), Dome?.ShutterStatus ?? ShutterState.ShutterError },
-                { nameof(DomeInfo.DriverCanFollow), Dome?.DriverCanFollow ?? false },
-                { nameof(DomeInfo.CanSetShutter), Dome?.CanSetShutter ?? false },
-                { nameof(DomeInfo.CanSetPark), Dome?.CanSetPark ?? false },
-                { nameof(DomeInfo.CanSetAzimuth), Dome?.CanSetAzimuth ?? false },
-                { nameof(DomeInfo.CanSyncAzimuth), Dome?.CanSyncAzimuth ?? false },
-                { nameof(DomeInfo.CanPark), Dome?.CanPark ?? false },
-                { nameof(DomeInfo.CanFindHome), Dome?.CanFindHome ?? false },
                 { nameof(DomeInfo.AtPark), Dome?.AtPark ?? false },
                 { nameof(DomeInfo.AtHome), Dome?.AtHome ?? false },
                 { nameof(DomeInfo.DriverFollowing), Dome?.DriverFollowing ?? false },
@@ -261,27 +254,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
 
             domeValues.TryGetValue(nameof(DomeInfo.ShutterStatus), out o);
             DomeInfo.ShutterStatus = (ShutterState)(o ?? ShutterState.ShutterError);
-
-            domeValues.TryGetValue(nameof(DomeInfo.DriverCanFollow), out o);
-            DomeInfo.DriverCanFollow = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanSetShutter), out o);
-            DomeInfo.CanSetShutter = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanSetPark), out o);
-            DomeInfo.CanSetPark = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanSetAzimuth), out o);
-            DomeInfo.CanSetAzimuth = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanSyncAzimuth), out o);
-            DomeInfo.CanSyncAzimuth = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanPark), out o);
-            DomeInfo.CanPark = (bool)(o ?? false);
-
-            domeValues.TryGetValue(nameof(DomeInfo.CanFindHome), out o);
-            DomeInfo.CanFindHome = (bool)(o ?? false);
 
             domeValues.TryGetValue(nameof(DomeInfo.AtPark), out o);
             DomeInfo.AtPark = (bool)(o ?? false);

--- a/NINA.WPF.Base/ViewModel/Equipment/Rotator/RotatorVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Rotator/RotatorVM.cs
@@ -248,9 +248,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Rotator {
             rotatorValues.TryGetValue(nameof(RotatorInfo.Position), out o);
             RotatorInfo.Position = (float)(o ?? 0f);
 
-            rotatorValues.TryGetValue(nameof(RotatorInfo.StepSize), out o);
-            RotatorInfo.StepSize = (float)(o ?? 0f);
-
             rotatorValues.TryGetValue(nameof(RotatorInfo.IsMoving), out o);
             RotatorInfo.IsMoving = (bool)(o ?? false);
 
@@ -271,7 +268,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Rotator {
             rotatorValues.Add(nameof(RotatorInfo.Connected), Rotator?.Connected ?? false);
             rotatorValues.Add(nameof(RotatorInfo.Position), Rotator?.Position ?? 0);
             rotatorValues.Add(nameof(RotatorInfo.IsMoving), Rotator?.IsMoving ?? false);
-            rotatorValues.Add(nameof(RotatorInfo.StepSize), Rotator?.StepSize ?? 0);
             rotatorValues.Add(nameof(RotatorInfo.Reverse), Rotator?.Reverse ?? false);
             rotatorValues.Add(nameof(RotatorInfo.Synced), Rotator?.Synced ?? false);
             rotatorValues.Add(nameof(RotatorInfo.MechanicalPosition), Rotator?.MechanicalPosition ?? 0f);

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -619,32 +619,11 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             telescopeValues.TryGetValue(nameof(TelescopeInfo.AtHome), out o);
             TelescopeInfo.AtHome = (bool)(o ?? false);
 
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.SiteLatitude), out o);
-            TelescopeInfo.SiteLatitude = (double)(o ?? double.NaN);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.SiteLongitude), out o);
-            TelescopeInfo.SiteLongitude = (double)(o ?? double.NaN);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.SiteElevation), out o);
-            TelescopeInfo.SiteElevation = (double)(o ?? double.NaN);
-
             telescopeValues.TryGetValue(nameof(TelescopeInfo.TrackingRate), out o);
             TelescopeInfo.TrackingRate = (TrackingRate)(o ?? TrackingRate.STOPPED);
 
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanSetTrackingEnabled), out o);
-            TelescopeInfo.CanSetTrackingEnabled = (bool)(o ?? false);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanSetDeclinationRate), out o);
-            TelescopeInfo.CanSetDeclinationRate = (bool)(o ?? false);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanSetRightAscensionRate), out o);
-            TelescopeInfo.CanSetRightAscensionRate = (bool)(o ?? false);
-
             telescopeValues.TryGetValue(nameof(TelescopeInfo.TrackingEnabled), out o);
             TelescopeInfo.TrackingEnabled = (bool)(o ?? false);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.TrackingModes), out o);
-            TelescopeInfo.TrackingModes = (IList<TrackingMode>)(o ?? ImmutableList<TrackingMode>.Empty);
 
             telescopeValues.TryGetValue(nameof(Coordinates), out o);
             TelescopeInfo.Coordinates = (Coordinates)(o ?? null);
@@ -673,20 +652,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             telescopeValues.TryGetValue(nameof(TelescopeInfo.GuideRateDeclinationArcsecPerSec), out o);
             TelescopeInfo.GuideRateDeclinationArcsecPerSec = (double)(o ?? double.NaN);
 
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.AlignmentMode), out o);
-            TelescopeInfo.AlignmentMode = (AlignmentMode)(o ?? AlignmentMode.GermanPolar);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanPulseGuide), out o);
-            TelescopeInfo.CanPulseGuide = (bool)(o ?? false);
-
             telescopeValues.TryGetValue(nameof(TelescopeInfo.IsPulseGuiding), out o);
             TelescopeInfo.IsPulseGuiding = (bool)(o ?? false);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanSetPierSide), out o);
-            TelescopeInfo.CanSetPierSide = (bool)(o ?? false);
-
-            telescopeValues.TryGetValue(nameof(TelescopeInfo.CanSlew), out o);
-            TelescopeInfo.CanSlew = (bool)(o ?? false);
 
             telescopeValues.TryGetValue(nameof(TelescopeInfo.UTCDate), out o);
             TelescopeInfo.UTCDate = (DateTime)(o ?? DateTime.MinValue);
@@ -696,16 +663,11 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
 
         private Dictionary<string, object> GetTelescopeValues() {
             Dictionary<string, object> telescopeValues = new Dictionary<string, object>();
-
             telescopeValues.Add(nameof(TelescopeInfo.Connected), _telescope?.Connected ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.AtPark), _telescope?.AtPark ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.AtHome), _telescope?.AtHome ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.CanSetTrackingEnabled), _telescope?.CanSetTrackingEnabled ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.CanSetDeclinationRate), _telescope?.CanSetDeclinationRate ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.CanSetRightAscensionRate), _telescope?.CanSetRightAscensionRate ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.TrackingRate), _telescope?.TrackingRate ?? TrackingRate.STOPPED);
             telescopeValues.Add(nameof(TelescopeInfo.TrackingEnabled), _telescope?.TrackingEnabled ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.TrackingModes), _telescope?.TrackingModes ?? ImmutableList<TrackingMode>.Empty);
             telescopeValues.Add(nameof(TelescopeInfo.Altitude), _telescope?.Altitude ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.AltitudeString), _telescope?.AltitudeString ?? string.Empty);
             telescopeValues.Add(nameof(TelescopeInfo.Azimuth), _telescope?.Azimuth ?? double.NaN);
@@ -717,9 +679,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             telescopeValues.Add(nameof(TelescopeInfo.Declination), _telescope?.Declination ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.SiderealTime), _telescope?.SiderealTime ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.HoursToMeridianString), _telescope?.HoursToMeridianString ?? string.Empty);
-            telescopeValues.Add(nameof(TelescopeInfo.SiteLongitude), _telescope?.SiteLongitude ?? double.NaN);
-            telescopeValues.Add(nameof(TelescopeInfo.SiteLatitude), _telescope?.SiteLatitude ?? double.NaN);
-            telescopeValues.Add(nameof(TelescopeInfo.SiteElevation), _telescope?.SiteElevation ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.Coordinates), _telescope?.Coordinates ?? null);
             telescopeValues.Add(nameof(TelescopeInfo.TimeToMeridianFlip), _telescope?.TimeToMeridianFlip ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.TimeToMeridianFlipString), _telescope?.TimeToMeridianFlipString ?? string.Empty);
@@ -729,11 +688,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             telescopeValues.Add(nameof(TelescopeInfo.Slewing), _telescope?.Slewing ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.GuideRateRightAscensionArcsecPerSec), _telescope?.GuideRateRightAscensionArcsecPerSec ?? double.NaN);
             telescopeValues.Add(nameof(TelescopeInfo.GuideRateDeclinationArcsecPerSec), _telescope?.GuideRateDeclinationArcsecPerSec ?? double.NaN);
-            telescopeValues.Add(nameof(TelescopeInfo.AlignmentMode), _telescope?.AlignmentMode ?? null);
-            telescopeValues.Add(nameof(TelescopeInfo.CanPulseGuide), _telescope?.CanPulseGuide ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.IsPulseGuiding), _telescope?.IsPulseGuiding ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.CanSetPierSide), _telescope?.CanSetPierSide ?? false);
-            telescopeValues.Add(nameof(TelescopeInfo.CanSlew), _telescope?.CanSlew ?? false);
             telescopeValues.Add(nameof(TelescopeInfo.UTCDate), _telescope?.UTCDate ?? null);
             return telescopeValues;
         }


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
The background device polls query some fields that are unnecessary to update, as they likely never change after device connection. This PR removes those fields from the polling.

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
