### PR TITLE
Add option to disallow mount unpark for a non-open shutter/roof

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7185,4 +7185,13 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblCivilDawn" xml:space="preserve">
     <value>Civil dawn</value>
   </data>
+  <data name="LblRefuseUnparkWithoutShutterOpen" xml:space="preserve">
+    <value>Refuse mount unpark if shutter is not open</value>
+  </data>
+  <data name="LblRefuseUnparkWithoutShutterOpenError" xml:space="preserve">
+    <value>Cannot unpark the mount while the dome shutter or roof is not open</value>
+  </data>
+  <data name="LblRefuseUnparkWithoutShutterOpenTooltip" xml:space="preserve">
+    <value>Reject attempts to unpark the mount if the shutter or roof state is Closed, Closing, Opening, or Errored. Unparking the mount will be permitted only if the shutter or roof reports an Open state</value>
+  </data>
 </root>

--- a/NINA.Profile/DomeSettings.cs
+++ b/NINA.Profile/DomeSettings.cs
@@ -278,6 +278,19 @@ namespace NINA.Profile {
             }
         }
 
+        private bool refuseUnparkWithoutShutterOpen = false;
+
+        [DataMember]
+        public bool RefuseUnparkWithoutShutterOpen {
+            get => refuseUnparkWithoutShutterOpen;
+            set {
+                if (refuseUnparkWithoutShutterOpen != value) {
+                    refuseUnparkWithoutShutterOpen = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         private bool parkDomeBeforeShutterMove = false;
 
         [DataMember]

--- a/NINA.Profile/Interfaces/IDomeSettings.cs
+++ b/NINA.Profile/Interfaces/IDomeSettings.cs
@@ -34,6 +34,7 @@ namespace NINA.Profile.Interfaces {
         bool CloseOnUnsafe { get; set; }
         bool ParkMountBeforeShutterMove { get; set; }
         bool RefuseUnsafeShutterMove { get; set; }
+        bool RefuseUnparkWithoutShutterOpen { get; set; }
         bool RefuseUnsafeShutterOpenSansSafetyDevice { get; set; }
         bool ParkDomeBeforeShutterMove { get; set; }
         MountTypeEnum MountType { get; set; }

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -237,9 +237,9 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             }
 
             if (profileService.ActiveProfile.DomeSettings.RefuseUnparkWithoutShutterOpen) {
-                var shutterState = domeMediator.GetInfo().ShutterStatus;
-                if (shutterState != ShutterState.ShutterOpen) {
-                    Logger.Error($"Attempt to unpark unpark while the dome shutter or roof status is {shutterState}");
+                var domeInfo = domeMediator.GetInfo();
+                if (!domeInfo.Connected || domeInfo.ShutterStatus != ShutterState.ShutterOpen) {
+                    Logger.Error($"Attempt to unpark the mount while the dome shutter or roof status is {domeInfo.ShutterStatus} or is not connected");
                     Notification.ShowError(Loc.Instance["LblRefuseUnparkWithoutShutterOpenError"]);
                     return false;
                 }

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -36,6 +36,7 @@ using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Equipment.Equipment;
 using NINA.Core.Utility.Extensions;
 using CommunityToolkit.Mvvm.Input;
+using System.Xml.Serialization;
 
 namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
 
@@ -233,6 +234,15 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             if (!TelescopeInfo.Connected) {
                 Logger.Error("Mount is not connected");
                 return false;
+            }
+
+            if (profileService.ActiveProfile.DomeSettings.RefuseUnparkWithoutShutterOpen) {
+                var shutterState = domeMediator.GetInfo().ShutterStatus;
+                if (shutterState != ShutterState.ShutterOpen) {
+                    Logger.Error($"Attempt to unpark unpark while the dome shutter or roof status is {shutterState}");
+                    Notification.ShowError(Loc.Instance["LblRefuseUnparkWithoutShutterOpenError"]);
+                    return false;
+                }
             }
 
             await Task.Run(async () => {

--- a/NINA/View/Options/DomeView.xaml
+++ b/NINA/View/Options/DomeView.xaml
@@ -408,6 +408,17 @@
                         <TextBlock
                             MinWidth="200"
                             VerticalAlignment="Center"
+                            Text="{ns:Loc LblRefuseUnparkWithoutShutterOpen}"
+                            ToolTip="{ns:Loc LblRefuseUnparkWithoutShutterOpenTooltip}" />
+                        <CheckBox HorizontalAlignment="Left" IsChecked="{Binding RefuseUnparkWithoutShutterOpen}" />
+                    </UniformGrid>
+                    <UniformGrid
+                        Margin="0,5,0,0"
+                        VerticalAlignment="Center"
+                        Columns="2">
+                        <TextBlock
+                            MinWidth="200"
+                            VerticalAlignment="Center"
                             Text="{ns:Loc LblRefuseUnsafeShutterMoveIfMountUnparked}"
                             ToolTip="{ns:Loc LblRefuseUnsafeShutterMoveIfMountUnparkedTooltip}" />
                         <CheckBox HorizontalAlignment="Left" IsChecked="{Binding RefuseUnsafeShutterMove}" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
   - N.I.N.A. now queries the ASCOM device name after connecting to the driver.  
 - **ASCOM Device State**
     - For drivers that implement the new ASCOM 7 Device State the application will now use the state when possible instead of polling individual fields
+- ** Dome/Roof safety **
+    - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 
 ### **User Interface & Usability**
 - **Framing Assistant Improvements**  


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

User request for an option to prevent the mount from unparking (and thus slewing) if the dome/roof controller reports a shutter state other than Open. This is to prevent accidental unparks and slews into the underside of a low roof. This option was added to the existing set of safety options present in the Options -> Dome screen.

## 🧪 How Was It Tested?

Use the ASCOM Omni sims for mount and dome to test various combinations of shutter state while attempting to unpark the mount with the option active.

## ✅ PR Checklist

- [x ] All unit tests pass
- [x ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [x ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
