### PR TITLE
Add update sub sample area option and roi option to simulator directory

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/ASICamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/ASICamera.cs
@@ -832,6 +832,30 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
         public int DroppedFrames { get; private set; }
 
+        public void UpdateSubSampleArea() {
+            // This is not fully working yet, still needs testing, might not be possible or needs some other approach
+            // I did see it working when taking images 0.5s images, but not consistently
+            if (EnableSubSample) {
+                CaptureAreaInfo = new CaptureAreaInfo(
+                    new Point(SubSampleX / BinX, SubSampleY / BinY),
+                    new Size(SubSampleWidth / BinX - (SubSampleWidth / BinX % 8),
+                             SubSampleHeight / BinY - (SubSampleHeight / BinY % 2)
+                    ),
+                    BinX,
+                    ASICameraDll.ASI_IMG_TYPE.ASI_IMG_RAW16
+                );
+            } else {
+                CaptureAreaInfo = new CaptureAreaInfo(
+                    new Point(0, 0),
+                    new Size((Resolution.Width / BinX) - (Resolution.Width / BinX % 8),
+                              Resolution.Height / BinY - (Resolution.Height / BinY % 2)
+                    ),
+                    BinX,
+                    ASICameraDll.ASI_IMG_TYPE.ASI_IMG_RAW16
+                );
+            }
+        }
+
         public bool HasBattery => false;
 
         public string Action(string actionName, string actionParameters) {

--- a/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
@@ -823,6 +823,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
             throw new System.NotImplementedException();
         }
 
+        public void UpdateSubSampleArea() {
+            throw new System.NotImplementedException();
+        }
+
         protected override async Task PostConnect() {
             if(device.SensorType == ASCOM.Common.DeviceInterfaces.SensorType.Color) {
                 Disconnect();

--- a/NINA.Equipment/Equipment/MyCamera/AtikCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AtikCamera.cs
@@ -954,6 +954,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
             throw new NotImplementedException();
         }
 
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
+
         private readonly IProfileService profileService;
         private readonly IExposureDataFactory exposureDataFactory;
         public bool LiveViewEnabled { get => false; set => throw new NotImplementedException(); }

--- a/NINA.Equipment/Equipment/MyCamera/EDCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/EDCamera.cs
@@ -1154,5 +1154,9 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public void SendCommandBlind(string command, bool raw) {
             throw new NotImplementedException();
         }
+
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/NINA.Equipment/Equipment/MyCamera/FLICamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/FLICamera.cs
@@ -1044,5 +1044,8 @@ namespace NINA.Equipment.Equipment.MyCamera {
             throw new NotImplementedException();
         }
 
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/NINA.Equipment/Equipment/MyCamera/FileCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/FileCamera.cs
@@ -592,6 +592,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public void SendCommandBlind(string command, bool raw) {
             throw new NotImplementedException();
         }
+
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
     }
 
     public class FileCameraFolderWatcher : IDisposable {

--- a/NINA.Equipment/Equipment/MyCamera/GenericCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/GenericCamera.cs
@@ -571,6 +571,9 @@ namespace NINA.Equipment.Equipment.MyCamera {
             throw new NotImplementedException();
         }
 
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
         #endregion "Unsupported Features"
     }
 }

--- a/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
@@ -860,6 +860,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public void SendCommandBlind(string command, bool raw) {
             throw new NotImplementedException();
         }
+
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
     }
 
     internal class NikonLogger : Nikon.ILogger {

--- a/NINA.Equipment/Equipment/MyCamera/PersistSettingsCameraDecorator.cs
+++ b/NINA.Equipment/Equipment/MyCamera/PersistSettingsCameraDecorator.cs
@@ -372,5 +372,9 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public void SendCommandBlind(string command, bool raw) {
             this.Camera.SendCommandBlind(command, raw);
         }
+
+        public void UpdateSubSampleArea() {
+            this.Camera.UpdateSubSampleArea();
+        }
     }
 }

--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -12,28 +12,29 @@
 
 #endregion "copyright"
 
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Equipment.Exceptions;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Model;
+using NINA.Equipment.Utility;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
 using NINA.Profile.Interfaces;
 using QHYCCD;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.Image.ImageData;
-using NINA.Core.Enum;
-using NINA.Core.Model.Equipment;
-using NINA.Core.Locale;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
-using NINA.Equipment.Interfaces;
-using NINA.Equipment.Exceptions;
-using System.Collections;
-using NINA.Astrometry;
-using NINA.Equipment.Utility;
+using static NINA.Image.ImageAnalysis.StarDetection;
 
 namespace NINA.Equipment.Equipment.MyCamera {
 
@@ -1202,6 +1203,9 @@ namespace NINA.Equipment.Equipment.MyCamera {
             return true;
         }
 
+        public void UpdateSubSampleArea() {
+            SetResolution(out var startx, out var starty, out var sizex, out var sizey);
+        }
 
         public void StartExposure(CaptureSequence sequence) {
             RaiseIfNotConnected();

--- a/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
@@ -851,6 +851,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
             throw new NotImplementedException();
         }
 
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
+
         public void SetupDialog() {
             throw new NotImplementedException();
         }

--- a/NINA.Equipment/Equipment/MyCamera/ToupTekAlikeCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/ToupTekAlikeCamera.cs
@@ -1099,6 +1099,22 @@ namespace NINA.Equipment.Equipment.MyCamera {
             });
         }
 
+        public void UpdateSubSampleArea() {
+            if (EnableSubSample) {
+                var rect = GetROI();
+                roiInfo = rect;
+                if (!sdk.put_ROI((uint)rect.X, (uint)rect.Y, (uint)rect.Width, (uint)rect.Height)) {
+                    throw new Exception($"{Category} - Failed to set ROI to {rect.X}x{rect.Y}x{rect.Width}x{rect.Height}");
+                }
+            } else {
+                roiInfo = null;
+                // 0,0,0,0 resets the ROI to original size
+                if (!sdk.put_ROI(0, 0, 0, 0)) {
+                    throw new Exception($"{Category} - Failed to reset ROI");
+                }
+            }
+        }
+
         public int USBLimitStep => 1;
 
         public string Action(string actionName, string actionParameters) {

--- a/NINA.Equipment/Equipment/OfflineDevice.cs
+++ b/NINA.Equipment/Equipment/OfflineDevice.cs
@@ -522,5 +522,9 @@ namespace NINA.Equipment.Equipment {
         public Task<bool> SlewToAltAz(TopocentricCoordinates coordinates, CancellationToken token) {
             throw new NotImplementedException();
         }
+
+        public void UpdateSubSampleArea() {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/NINA.Equipment/Interfaces/ICamera.cs
+++ b/NINA.Equipment/Interfaces/ICamera.cs
@@ -100,5 +100,7 @@ namespace NINA.Equipment.Interfaces {
         Task<IExposureData> DownloadLiveView(CancellationToken token);
 
         void StopLiveView();
+
+        void UpdateSubSampleArea();
     }
 }

--- a/NINA.Equipment/Interfaces/Mediator/ICameraMediator.cs
+++ b/NINA.Equipment/Interfaces/Mediator/ICameraMediator.cs
@@ -13,14 +13,15 @@
 #endregion "copyright"
 
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.ViewModel;
 using NINA.Equipment.Model;
 using NINA.Image.Interfaces;
-using NINA.Equipment.Equipment.MyCamera;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.Equipment.Interfaces.ViewModel;
 
 namespace NINA.Equipment.Interfaces.Mediator {
 
@@ -65,6 +66,9 @@ namespace NINA.Equipment.Interfaces.Mediator {
 
         bool IsFreeToCapture(object cameraConsumer);
         void SetUSBLimit(int usbLimit);
+
+        void SetSubSambleRectangle(ObservableRectangle observableRectangle);
+
         event Func<object, EventArgs, Task> DownloadTimeout;
     }
 }

--- a/NINA.Equipment/Interfaces/Mediator/IImagingMediator.cs
+++ b/NINA.Equipment/Interfaces/Mediator/IImagingMediator.cs
@@ -15,15 +15,13 @@
 using NINA.Core.Interfaces;
 using NINA.Core.Model;
 using NINA.Core.Utility;
-using NINA.Image.ImageData;
-using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
-using NINA.Equipment.Interfaces.ViewModel;
 
 namespace NINA.Equipment.Interfaces.Mediator {
 
@@ -57,7 +55,9 @@ namespace NINA.Equipment.Interfaces.Mediator {
 
         void SetImage(BitmapSource img);
         int GetImageRotation();
-        void SetImageRotation(int rotation);        
+        void SetImageRotation(int rotation);
+
+        void SetSubSambleRectangle(ObservableRectangle observableRectangle);
 
         event EventHandler<ImagePreparedEventArgs> ImagePrepared;        
     }

--- a/NINA.Equipment/Interfaces/ViewModel/ICameraVM.cs
+++ b/NINA.Equipment/Interfaces/ViewModel/ICameraVM.cs
@@ -13,9 +13,10 @@
 #endregion "copyright"
 
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MyCamera;
 using NINA.Equipment.Model;
 using NINA.Image.Interfaces;
-using NINA.Equipment.Equipment.MyCamera;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -56,6 +57,9 @@ namespace NINA.Equipment.Interfaces.ViewModel {
 
         IDeviceChooserVM DeviceChooserVM { get; set; }
         void SetUSBLimit(int usbLimit);
+
+        void SetSubSambleRectangle(ObservableRectangle observableRectangle);
+
         event Func<object, EventArgs, Task> DownloadTimeout;
     }
 }

--- a/NINA.Equipment/Interfaces/ViewModel/IImagingVM.cs
+++ b/NINA.Equipment/Interfaces/ViewModel/IImagingVM.cs
@@ -15,14 +15,12 @@
 using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Equipment.Interfaces.Mediator;
-using NINA.Image.ImageData;
-using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
 
 namespace NINA.Equipment.Interfaces.ViewModel {
 
@@ -34,6 +32,7 @@ namespace NINA.Equipment.Interfaces.ViewModel {
         void SetImage(BitmapSource img);
         int GetImageRotation();
         void SetImageRotation(int rotation);
+        void SetSubSambleRectangle(ObservableRectangle observableRectangle);
 
         Task<IExposureData> CaptureImage(
             CaptureSequence sequence,

--- a/NINA.WPF.Base/Mediator/CameraMediator.cs
+++ b/NINA.WPF.Base/Mediator/CameraMediator.cs
@@ -12,17 +12,17 @@
 
 #endregion "copyright"
 
+using NINA.Core.Model;
+using NINA.Core.Utility;
 using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.Core.Model;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
-using NINA.Equipment.Interfaces.ViewModel;
-using NINA.Core.Utility.Extensions;
 
 namespace NINA.WPF.Base.Mediator {
 
@@ -115,6 +115,10 @@ namespace NINA.WPF.Base.Mediator {
 
         public void SetUSBLimit(int usbLimit) {
             handler.SetUSBLimit(usbLimit);
+        }
+
+        public void SetSubSambleRectangle(ObservableRectangle observableRectangle) {
+            handler.SetSubSambleRectangle(observableRectangle);
         }
     }
 }

--- a/NINA.WPF.Base/Mediator/ImagingMediator.cs
+++ b/NINA.WPF.Base/Mediator/ImagingMediator.cs
@@ -12,18 +12,16 @@
 
 #endregion "copyright"
 
-using NINA.Image.ImageData;
-using NINA.Equipment.Equipment.MyCamera;
+using NINA.Core.Model;
+using NINA.Core.Utility;
 using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
-using NINA.Core.Model;
-using NINA.Core.Utility;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
-using NINA.Equipment.Interfaces.ViewModel;
 
 namespace NINA.WPF.Base.Mediator {
 
@@ -86,6 +84,10 @@ namespace NINA.WPF.Base.Mediator {
 
         public void SetImageRotation(int rotation) {
             handler.SetImageRotation(rotation);
+        }
+
+        public void SetSubSambleRectangle(ObservableRectangle observableRectangle) {
+            handler.SetSubSambleRectangle(observableRectangle);
         }
     }
 }

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -12,11 +12,27 @@
 
 #endregion "copyright"
 
-using NINA.Equipment.Equipment.MyCamera;
+using Accord.Statistics.Models.Regression.Linear;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Dasync.Collections;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.MyMessageBox;
 using NINA.Core.Utility;
-using NINA.Equipment.Interfaces.Mediator;
+using NINA.Core.Utility.Extensions;
 using NINA.Core.Utility.Notification;
+using NINA.Equipment.Equipment;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Exceptions;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Image.Interfaces;
 using NINA.Profile.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -24,24 +40,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Accord.Statistics.Models.Regression.Linear;
-using Dasync.Collections;
-using NINA.Equipment.Utility;
-using NINA.Core.Model;
-using NINA.Core.Locale;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.MyMessageBox;
-using NINA.Image.Interfaces;
-using NINA.Equipment.Model;
-using NINA.Equipment.Interfaces.ViewModel;
-using NINA.Equipment.Interfaces;
-using NINA.Equipment.Equipment;
-using Nito.AsyncEx;
-using NINA.Core.Enum;
-using NINA.Equipment.Exceptions;
-using NINA.Core.Utility.Extensions;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 
 namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
 
@@ -921,6 +919,11 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                     Cam.SubSampleHeight = height;
                 }
             }
+        }
+
+        public void SetSubSambleRectangle(ObservableRectangle observableRectangle) {
+            SetSubSampleArea((int)observableRectangle.X, (int)observableRectangle.Y, (int)observableRectangle.Width, (int)observableRectangle.Height);
+            Cam.UpdateSubSampleArea();
         }
 
         public bool AtTargetTemp => Math.Abs(cameraInfo.Temperature - TargetTemp) <= 2;

--- a/NINA/ViewModel/ImagingVM.cs
+++ b/NINA/ViewModel/ImagingVM.cs
@@ -9,34 +9,33 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 #endregion "copyright"
+using Dasync.Collections;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
+using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyFilterWheel;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyRotator;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Equipment.MyWeatherData;
+using NINA.Equipment.Exceptions;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
+using NINA.Equipment.Utility;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
 using NINA.Profile.Interfaces;
-using NINA.ViewModel.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.ViewModel;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
-using NINA.Equipment.Equipment.MyTelescope;
-using NINA.Equipment.Equipment.MyFilterWheel;
-using NINA.Equipment.Equipment.MyFocuser;
-using NINA.Equipment.Equipment.MyRotator;
-using NINA.Equipment.Equipment.MyWeatherData;
-using Dasync.Collections;
-using NINA.Equipment.Utility;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Model;
-using NINA.Image.Interfaces;
-using NINA.Image.ImageData;
-using NINA.Equipment.Model;
-using NINA.Core.Locale;
-using NINA.Core.Utility;
-using NINA.Equipment.Exceptions;
-using NINA.Core.Utility.Notification;
-using NINA.Equipment.Interfaces.ViewModel;
-using NINA.Equipment.Equipment;
-using NINA.WPF.Base.ViewModel;
-using NINA.WPF.Base.Interfaces.ViewModel;
 
 namespace NINA.ViewModel {
 
@@ -418,5 +417,8 @@ namespace NINA.ViewModel {
             _imageControl.ImageRotation = rotation;
         }
 
+        public void SetSubSambleRectangle(ObservableRectangle observableRectangle) {
+            cameraMediator.SetSubSambleRectangle(observableRectangle);
+        }
     }
 }


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose
I wanted to update the roi settings during imaging. This seems to work for QHY and Touptek camera's, still some issues while testing ZWO cameras.
Also updated the simulator camera to get an roi from directory images.
<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->

## 🧪 How Was It Tested?
Tested a couple of different cameras (qhy polemaster, Altair Astro GPcam, ZWO553) including the simulator camera.
<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
I still want to do some more testing of ZWO cameras, but there's no plugin supporting this yet either. 
I would like to test in the field with qhy cameras though, that's why I'm adding it to Nina already.
And maybe someone else can take a look.