### PR TITLE
Update DomeFollower.cs

### DIFF
--- a/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeFollower.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeFollower.cs
@@ -250,7 +250,15 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
             if (targetCoordinates == null) { return null; }
             PierSide targetSideOfPier = PierSide.pierUnknown;
             if (this.profileService.ActiveProfile.MeridianFlipSettings.UseSideOfPier) {
-                targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                try {
+                    // If the telescope mediator is available, use it to determine the target side of pier
+                    targetSideOfPier = telescopeMediator?.DestinationSideOfPier(targetCoordinates) ?? PierSide.pierUnknown;
+                    if (targetSideOfPier == PierSide.pierUnknown) {
+                        targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                    }
+                } catch (Exception ex) {
+                    targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                }
             }
             if (targetSideOfPier == PierSide.pierUnknown) {
                 targetSideOfPier = MeridianFlip.ExpectedPierSide(targetCoordinates, Angle.ByHours(telescopeInfo.SiderealTime));


### PR DESCRIPTION
## 🚀 Purpose

The current Dome Follower implementation calculates the target PierSide using an assumption that all mounts flip at 12h HA. This simplification leads to incorrect dome positioning for:

- Mounts that can track beyond the meridian
- Observatories with angled piers

This PR introduces more accurate pier side determination by:

1. Primarily using the ASCOM DestinationSideOfPier method when available
2. Falling back to the existing calculation method when precise data isn't available

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues


## 📸 Screenshots


## 📝 Additional Notes

- Added proper exception handling for telescope mediator communication
- Implemented graceful fallback to legacy calculation when:
  - DestinationSideOfPier isn't available
  - The method returns pierUnknown
  - Communication errors occur
- Maintained backward compatibility with existing configurations

