### PR TITLE
feat: Add ASP.NET Core framework reference to NINA project

### DIFF
--- a/NINA/NINA.csproj
+++ b/NINA/NINA.csproj
@@ -396,6 +396,9 @@
     <PackageReference Include="ToastNotifications.Messages" Version="2.5.1" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <Page Remove="Resources\Camera.xaml" />
     <Page Remove="Resources\SVG\camera-shutter.xaml" />
     <Page Remove="Resources\SVG\CameraSVG.xaml" />
@@ -432,9 +435,11 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='SignedRelease|AnyCPU'">
     <Optimize>True</Optimize>
   </PropertyGroup>
+	
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec IgnoreExitCode="true" Command="&#xD;&#xA;   if exist &quot;$(ProjectDir)External\x64\Canon&quot; xcopy &quot;$(ProjectDir)External\x64\Canon&quot; &quot;$(TargetDir)\External\x64\Canon&quot; /h/i/c/k/e/r/y&#xD;&#xA;   if exist &quot;$(ProjectDir)External\x64\Nikon&quot; xcopy &quot;$(ProjectDir)External\x64\Nikon&quot; &quot;$(TargetDir)\External\x64\Nikon&quot; /h/i/c/k/e/r/y&#xD;&#xA;&#xD;&#xA;   if $(Configuration) == SignedRelease signtool sign /t http://timestamp.sectigo.com /i Sectigo /v /a /fd SHA256 $(TargetPath)&#xD;&#xA;   if $(Configuration) == SignedRelease signtool sign /t http://timestamp.sectigo.com /i Sectigo /v /a /fd SHA256 $(TargetDir)NINA.exe&#xD;&#xA;&#xD;&#xA;set SOLUTION_DIR=$(SolutionDir)&#xD;&#xA;if not &quot;%25SOLUTION_DIR%25&quot;==&quot;&quot; (&#xD;&#xA;  if exist &quot;$(SolutionDir)NINA.Docs&quot; (&#xA;    SET OFFLINE=true&#xA;&#xA;    mkdocs --version &gt; nul 2&gt;&amp;1&#xA;    if errorlevel 1 (&#xA;        echo mkdocs is not installed. Skipping documentation build.&#xA;    ) else (&#xA;        mkdocs build -f &quot;$(SolutionDir)NINA.Docs\mkdocs.yml&quot; -c&#xA;        xcopy &quot;$(SolutionDir)NINA.Docs\site&quot; &quot;$(TargetDir)\docs&quot; /h/i/c/k/e/r/y&#xA;    )&#xA;  )&#xD;&#xA;) else (&#xA;        echo SolutionDir is not set. Skipping documentation build.&#xA;    )" />
   </Target>


### PR DESCRIPTION
Added FrameworkReference for Microsoft.AspNetCore.App to NINA.csproj

Enables access to ASP.NET Core APIs and services in the main NINA application

Supports potential future web-based features or embedded web server functionality

Build verified successful with no compilation errors

## 🚀 Purpose

Added so Plugins can resolve dependencies to the  AspNetCore framework references.  this allows using these AspNetCore assemblies in PlugIns.

## 🧪 How Was It Tested?

Compiled locally and then tested a local PlugIn to make sure it loaded properly while referencing the needed assemblies.

## ✅ PR Checklist

- [ NONE ] All unit tests pass
- [ N/A ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ X ] Plugin API compatibility reviewed  
  - [ X ] No breaking changes to interfaces  
  - [ X ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues
NONE

## 📸 Screenshots
NONE

## 📝 Additional Notes
NONE
