### PR TITLE
Rotator v2

### DIFF
--- a/NINA.Equipment/Equipment/MyRotator/AscomRotator.cs
+++ b/NINA.Equipment/Equipment/MyRotator/AscomRotator.cs
@@ -65,7 +65,15 @@ namespace NINA.Equipment.Equipment.MyRotator {
 
         public float Position => AstroUtil.EuclidianModulus(MechanicalPosition + offset, 360);
 
-        public float MechanicalPosition => GetProperty(nameof(Rotator.MechanicalPosition), float.NaN);
+        public float MechanicalPosition {
+            get {
+                if (GetProperty(nameof(Rotator.InterfaceVersion), short.MinValue) < 3)
+                    return GetProperty(nameof(Rotator.Position), float.NaN);
+                else
+                return GetProperty(nameof(Rotator.MechanicalPosition), float.NaN);
+            }
+        }
+            
 
         public float StepSize => GetProperty(nameof(Rotator.StepSize), float.NaN);
 

--- a/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeFollower.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Dome/DomeFollower.cs
@@ -250,7 +250,15 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Dome {
             if (targetCoordinates == null) { return null; }
             PierSide targetSideOfPier = PierSide.pierUnknown;
             if (this.profileService.ActiveProfile.MeridianFlipSettings.UseSideOfPier) {
-                targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                try {
+                    // If the telescope mediator is available, use it to determine the target side of pier
+                    targetSideOfPier = telescopeMediator?.DestinationSideOfPier(targetCoordinates) ?? PierSide.pierUnknown;
+                    if (targetSideOfPier == PierSide.pierUnknown) {
+                        targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                    }
+                } catch (Exception ex) {
+                    targetSideOfPier = telescopeInfo.TargetSideOfPier ?? telescopeInfo.SideOfPier;
+                }
             }
             if (targetSideOfPier == PierSide.pierUnknown) {
                 targetSideOfPier = MeridianFlip.ExpectedPierSide(targetCoordinates, Angle.ByHours(telescopeInfo.SiderealTime));


### PR DESCRIPTION

## 🚀 Purpose

As outlined already by Bob in the lengthy discussion about rotators https://discord.com/channels/436650817295089664/1413605096855572532
, the new implementation fails for Rotator ASCOM drivers with Version < 3. 

Tested against OmniDrivers, set them to V2 and they raised an exception.

This change will fallback to the old "Position" for these rotators.

## 🧪 How Was It Tested?

using OmniSim Alpaca Simulator

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)


