### PR TITLE
Fix Liveview header size value for Nikon Z8 & Z9

### DIFF
--- a/nikoncswrapper/Database/NikonCameraList.cs
+++ b/nikoncswrapper/Database/NikonCameraList.cs
@@ -491,7 +491,7 @@ namespace Nikon {
                 },
                 LiveView = new NikonCameraModel.LiveViewConfig {
                     OnStatus = 3U,
-                    ImageHeaderSize = 512
+                    ImageHeaderSize = 1024
                 }
             },
 
@@ -503,7 +503,7 @@ namespace Nikon {
                 },
                 LiveView = new NikonCameraModel.LiveViewConfig {
                     OnStatus = 3U,
-                    ImageHeaderSize = 512
+                    ImageHeaderSize = 1024
                 }
             },
 


### PR DESCRIPTION
Fix live view issue on the Nikon Z8 (and also the Z9: untested), where the image would not show up.
Origin: incorrect header size for liveview image for Z8 and Z9.
https://discord.com/channels/436650817295089664/1414361498850955326

Tested on a Z8