### PR TITLE
Handle ASCOM.ValueNotSet in accordance with recent guidance

### DIFF
--- a/NINA.Equipment/Equipment/AscomDevice.cs
+++ b/NINA.Equipment/Equipment/AscomDevice.cs
@@ -497,6 +497,25 @@ namespace NINA.Equipment.Equipment {
                 } catch (Exception ex) {
                     if (rethrow) { throw; }
 
+                    // ValueNotSetException is not fully fatal.
+                    // For read-only properties, It can mean that the property is implemented but the driver cannot provide a value for it at the moment.
+                    // In such cases, the property's default value will be returned.
+                    // Example: ObervingConditions.StarFWHM when no stars are visible during the daytime or due to clouds.
+                    if (ex is ASCOM.ValueNotSetException || ex.InnerException is ASCOM.ValueNotSetException) {
+                        var log = $"Property {type.Name}.{propertyName} GET value is not set by this driver ({Name})";
+
+                        if (!string.IsNullOrEmpty(ex.Message)) {
+                            log += $"; Reason: {ex.Message}";
+                        }
+
+                        if (!string.IsNullOrEmpty(ex.InnerException?.Message)) {
+                            log += $"; Inner Reason: {ex.InnerException.Message}";
+                        }
+
+                        Logger.Trace(log);
+                        return defaultValue;
+                    }
+
                     memory.ConsecutiveErrors++;
                     if (memory.ConsecutiveErrors == memory.ConsecutiveErrorThreshold) {
                         Logger.Warning($"GET of {type.Name}.{propertyName} encountered {memory.ConsecutiveErrorThreshold} consecutive errors. Further logs for this property access are logged on TRACE level until the property access is successful again");

--- a/NINA.Equipment/Equipment/AscomDevice.cs
+++ b/NINA.Equipment/Equipment/AscomDevice.cs
@@ -500,7 +500,7 @@ namespace NINA.Equipment.Equipment {
                     // ValueNotSetException is not fully fatal.
                     // For read-only properties, It can mean that the property is implemented but the driver cannot provide a value for it at the moment.
                     // In such cases, the property's default value will be returned.
-                    // Example: ObervingConditions.StarFWHM when no stars are visible during the daytime or due to clouds.
+                    // Example: ObservingConditions.StarFWHM when no stars are visible during the daytime or due to clouds.
                     if (ex is ASCOM.ValueNotSetException || ex.InnerException is ASCOM.ValueNotSetException) {
                         var log = $"Property {type.Name}.{propertyName} GET value is not set by this driver ({Name})";
 


### PR DESCRIPTION
## 🚀 Purpose

At HCRO, we are implementing a consolidated Alpaca service for the ObservingConditions class. This brings together at least 3 separate sensor data providers under a single OC endpoint, which greatly simplifies user setup as it eliminates the need for the users to set up 3 separate dynamic ASCOM drivers for each of the individual sources of OC data and glue those together under ASCOM Observing Conditions Hub (OCH). 

One of the sensors is an Alcor Cyclope which provides data for ObservingConditions' `StarFWHM`  property.  All of the ObservingConditions weather-related properties are able to return data at any time of day with the exception of  `StarFWHM`. This is because it can perform its star measurements only when it is dark enough or if there is no cloud obscuring the star being measured. Throwing `PropertyNotImplemented` would be inappropriate as it the property technically is implemented, it just cannot provide any data _at that moment_. I queried the ASCOM Developers list about this and [Peter responded](https://ascomtalk.groups.io/g/Developer/message/9540) affirming my suspicion that `ValueNotSetException` would be best in for those cases where the `StarFWHM` property is available, but data for it is not.

I understand that you may have some reservations about this situation using an exception to signal that no data is available, but it seems that the preferred way to communicate unavailable data in the generic sense is through exceptions, as they can also convey a reason for unavailability of data ("it's daytime" or "star cannot be detected"). 

Currently, without specific handling for `ASCOM.ValueNotSetException`, `GetProperty()` will return the last-known value which is usually `0`. This erroneously tricks the downstream consumers - Star FWHM display in the weather-related areas, FITS/XISF header content, etc. that there is real data when there isn't.

This PR adds  `ASCOM.ValueNotSetException` handing in the `GetProperty(...)` method. If it is encountered while getting a property, the result will be logged at the TRACE level with any provided  reason and the default value of the property will be returned. The logging is done at the TRACE level in accordance with other "normal" property gets. The default value is not cached as the driver may resume reporting data for the property at any moment, so we should keep asking it.

## 🧪 How Was It Tested?

Pointed at the consolidated ObservingConditions setup, where it is returning ValueNotSet for StarFHWM. NINA presents a value of 0.00 for StarFWHM without this patch. With this patch, `double.NaN` is returned instead and thus the Star FWHM display is kept out of the Weather screens and out of the file metadata.

## ✅ PR Checklist

- [x ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x ] Plugin API compatibility reviewed  
  - [x ] No breaking changes to interfaces  
  - [x ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)
