### PR TITLE
Add TrendPerFilter option to HFR autofocus trigger

### DIFF
--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
@@ -156,6 +156,16 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             }
         }
 
+        private bool trendPerFilter = true; // default true to keep the original behaviour to create a trend per filter 
+        public bool TrendPerFilter {
+            get => trendPerFilter;
+            private set {
+                trendPerFilter = value;
+                RaisePropertyChanged();
+                
+            }
+        }
+
         public override async Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
             await TriggerRunner.Run(progress, token);
         }
@@ -177,7 +187,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
                 imageHistory = imageHistory.Where(point => point.Id > lastAF.Id).ToList();
             }
 
-            if (fwInfo != null && fwInfo.Connected && fwInfo.SelectedFilter != null) {
+            if (fwInfo != null && fwInfo.Connected && fwInfo.SelectedFilter != null && TrendPerFilter == true) {
                 //Further filter the history to only considere items by the current filter
                 Filter = fwInfo.SelectedFilter.Name;
 

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
@@ -116,6 +116,18 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             }
         }
 
+        private bool trendPerFilter = true; // default true to keep the original behaviour creating a trend per filter 
+
+        [JsonProperty]
+        public bool TrendPerFilter {
+            get => trendPerFilter;
+            private set {
+                trendPerFilter = value;
+                RaisePropertyChanged();
+
+            }
+        }
+
         private double originalHFR;
 
         public double OriginalHFR {
@@ -153,16 +165,6 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             private set {
                 filter = value;
                 RaisePropertyChanged();
-            }
-        }
-
-        private bool trendPerFilter = true; // default true to keep the original behaviour to create a trend per filter 
-        public bool TrendPerFilter {
-            get => trendPerFilter;
-            private set {
-                trendPerFilter = value;
-                RaisePropertyChanged();
-                
             }
         }
 
@@ -250,7 +252,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
         }
 
         public override string ToString() {
-            return $"Trigger: {nameof(AutofocusAfterHFRIncreaseTrigger)}, Amount: {Amount}";
+            return $"Trigger: {nameof(AutofocusAfterHFRIncreaseTrigger)}, Amount: {Amount}, TrendPerFilter: {TrendPerFilter}";
         }
 
         public bool Validate() {

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml
@@ -139,6 +139,14 @@
                         Text="{Binding Amount}"
                         TextAlignment="Right"
                         Unit="%" />
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="{ns:Loc LblHFRTrendPerFilter}" />
+                    <CheckBox
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        IsChecked="{Binding TrendPerFilter}" />
                 </StackPanel>
             </view:SequenceBlockView.SequenceItemContent>
             <view:SequenceBlockView.SequenceItemProgressContent>


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

adds a TrendPerFilter checkbox to the AutofocusAfterHFRIncreaseTrigger.  
When enabled (default) HFR trend per filter is evaluated (original behaviour) 
When disabled, the trigger evaluates the HFR trend across all filters combined, which can help initiate autofocus runs earlier if HFR variations between filters are small. Useful when imaging for example in L-L-R-G-B loops.

## 🧪 How Was It Tested?

It was tested first as a plugin.

## ✅ PR Checklist

- [X] All unit tests pass
- [X] UI changes tested across Light, Dark, and Night themes (if applicable) 
- [not applicable ] Plugin API compatibility reviewed  
- [X] No breaking changes to interfaces  
- [X] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
