### PR TITLE
Fix yappy filter event

### DIFF
--- a/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelVM.cs
@@ -172,8 +172,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FilterWheel {
                 } else {
                     await Disconnect();
                 }
-            } catch(OperationCanceledException) {
-                if(token.IsCancellationRequested == true) {
+            } catch (OperationCanceledException) {
+                if (token.IsCancellationRequested == true) {
                     throw;
                 } else {
                     Logger.Error("Switching filter timed out after 5 Minutes");
@@ -343,6 +343,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FilterWheel {
         private FilterWheelInfo filterWheelInfo;
 
         public event Func<object, EventArgs, Task> Connected;
+
         public event Func<object, EventArgs, Task> Disconnected;
 
         public FilterWheelInfo FilterWheelInfo {
@@ -395,6 +396,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FilterWheel {
                 FW.SendCommandBlind(command, raw);
             }
         }
+
         public IDevice GetDevice() {
             return FW;
         }

--- a/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelVM.cs
@@ -165,9 +165,10 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FilterWheel {
                             Notification.ShowError(string.Format(Loc.Instance["LblFilterChangeFailed"], filter.Name, filter.Position + 1));
                             throw new Exception(string.Format(Loc.Instance["LblFilterChangeFailed"], filter.Name, filter.Position + 1));
                         }
+
+                        FilterWheelInfo.SelectedFilter = filter;
+                        await (FilterChanged?.InvokeAsync(this, new FilterChangedEventArgs(from: prevFilter, to: filter)) ?? Task.CompletedTask);
                     }
-                    FilterWheelInfo.SelectedFilter = filter;
-                    await (FilterChanged?.InvokeAsync(this, new FilterChangedEventArgs(from: prevFilter, to: filter)) ?? Task.CompletedTask);
                 } else {
                     await Disconnect();
                 }


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

The `FilterChanged` event fires even when no filter change occurs,  when the filter wheel is already at the filter position being requested. This event should fire only if the filter position actually changed. This pulls the event invocation and `SelectedFilter` assignment inside the `if` statement that runs if the filter position needs to be changed.

## 🧪 How Was It Tested?

Plugin that registered a `FilterChanged` handler and logged its occurrence, comparing before and after log entries.

## ✅ PR Checklist

- [x ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x ] Plugin API compatibility reviewed  
  - [x ] No breaking changes to interfaces  
  - [x ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
