### PR TITLE
[3.3] Native driver for ToupTek based Filterwheels.

### DIFF
--- a/NINA.Equipment/Equipment/MyFilterWheel/ToupTekAlikeFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/ToupTekAlikeFilterWheel.cs
@@ -1,7 +1,7 @@
 ﻿#region "copyright"
 
 /*
-    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright © 2016 - 2025 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 

--- a/NINA.Equipment/Equipment/MyFilterWheel/ToupTekAlikeFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/ToupTekAlikeFilterWheel.cs
@@ -1,0 +1,240 @@
+﻿#region "copyright"
+
+/*
+    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Model.Equipment;
+using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Utility;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Equipment.Equipment.MyFilterWheel {
+
+    public partial class ToupTekAlikeFilterWheel : BaseINPC, IFilterWheel {
+        private readonly ToupTekAlikeFlag flags;
+        private readonly string internalId;
+        private IToupTekAlikeCameraSDK sdk;
+
+        public ToupTekAlikeFilterWheel(ToupTekAlikeDeviceInfo deviceInfo, IToupTekAlikeCameraSDK sdk, IProfileService profileService) {
+            Category = sdk.Category;
+
+            this.profileService = profileService;
+            this.sdk = sdk;
+            this.internalId = deviceInfo.id;
+            this.Id = Category + "_" + deviceInfo.id;
+
+            this.Name = deviceInfo.displayname;
+
+            var match = IdExtractorRegex().Match(deviceInfo.id);
+
+            this.Description = $"{Category} filterwheel.";
+            if (match.Success) {
+                var vid = match.Groups[1].Value;
+                var pid = match.Groups[2].Value;
+                var tail = match.Groups[3].Value;
+                this.Description += $" Vendor ID: {vid}, Product ID: {pid}, Filterwheel ID: {tail}";
+            }
+
+            this.flags = (ToupTekAlikeFlag)deviceInfo.model.flag;
+
+            CalibrateAfwCommand = new AsyncCommand<bool>(CalibrateAfw);
+        }
+
+        [GeneratedRegex(@"vid_([0-9a-fA-F]+)&pid_([0-9a-fA-F]+)#([^\\]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        private static partial Regex IdExtractorRegex();
+
+        private IProfileService profileService;
+
+        public string Category { get; }
+
+        public int[] FocusOffsets => Filters.Select((x) => x.FocusOffset).ToArray();
+
+        public string[] Names => Filters.Select((x) => x.Name).ToArray();
+
+        private bool unidirectional;
+        public bool Unidirectional {
+            get => unidirectional;
+            set {
+                unidirectional = value;
+                profileService.ActiveProfile.FilterWheelSettings.Unidirectional = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public IList<string> SupportedActions => new List<string>();
+
+        private object lockObj = new object();
+        public AsyncObservableCollection<FilterInfo> Filters {
+            get {
+                lock (lockObj) {
+                    var filtersList = profileService.ActiveProfile.FilterWheelSettings.FilterWheelFilters;
+                    sdk.get_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_SLOT, out var positions);
+                    return new FilterManager().SyncFiltersWithPositions(filtersList, positions);
+                }
+            }
+        }
+
+        public bool HasSetupDialog => false;
+
+        private string id;
+        public string Id {
+            get => id;
+            set {
+                id = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private string name;
+        public string Name {
+            get => name;
+            set {
+                name = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string DisplayName => $"{Name} ({(Id.Length > 8 ? Id[^8..] : Id)})";
+
+        private bool _connected;
+        public bool Connected {
+            get => _connected;
+            private set {
+                _connected = value;
+                RaisePropertyChanged();
+                RaisePropertyChanged(nameof(HasSetupDialog));
+            }
+        }
+
+        private string description;
+        public string Description {
+            get => description;
+            set {
+                description = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string DriverInfo => $"{Category} SDK";
+
+        public string DriverVersion => sdk?.Version() ?? string.Empty;
+
+        public short Position {
+            get {
+                sdk.get_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, out var position);
+                return (short)position;
+            }
+            set {
+                var position = (Unidirectional ? 0 : 0x100) | (ushort)value;
+                sdk.put_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, position);
+            }
+        }
+
+        public Task<bool> Connect(CancellationToken ct) {
+            return Task<bool>.Run(async () => {
+                var success = false;
+                try {
+                    SupportedActions.Clear();
+
+                    sdk = sdk.Open(this.internalId);
+
+                    // Read number of positions
+                    sdk.get_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_SLOT, out var slotNum);
+
+                    // Initialize filter wheel with number of positions
+                    sdk.put_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_SLOT, slotNum);
+
+                    // Connected flag
+                    Connected = true;
+
+                    // Initial calibration
+                    await CalibrateAfw(null);
+
+                    success = true;
+                    var profile = profileService.ActiveProfile.FilterWheelSettings;
+                    Unidirectional = profile.Unidirectional;
+
+                    RaiseAllPropertiesChanged();
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                    Notification.ShowError(ex.Message);
+                }
+                return success;
+            });
+        }
+
+        private async Task<bool> CalibrateAfw(object arg) {
+            return await Task.Run(async () => {
+                if (Connected) {
+                    var currentPostion = Position;
+
+                    sdk.put_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, -1);
+
+                    // Wait for calibration to finish
+                    int position = -1;
+                    while (position == -1) {
+                        sdk.get_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, out position);
+                        await Task.Delay(TimeSpan.FromSeconds(2));
+                    }
+
+                    // Set initial position
+                    sdk.put_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, currentPostion);
+
+                    position = -1;
+                    while (position == -1) {
+                        sdk.get_Option(ToupTekAlikeOption.OPTION_FILTERWHEEL_POSITION, out position);
+                        await Task.Delay(TimeSpan.FromSeconds(2));
+                    }
+
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+        }
+
+        public void Disconnect() {
+            this.Connected = false;
+            sdk.Close();
+        }
+
+        public IAsyncCommand CalibrateAfwCommand { get; }
+
+        public void SetupDialog() {
+        }
+
+        public string Action(string actionName, string actionParameters) {
+            throw new NotImplementedException();
+        }
+
+        public string SendCommandString(string command, bool raw) {
+            throw new NotImplementedException();
+        }
+
+        public bool SendCommandBool(string command, bool raw) {
+            throw new NotImplementedException();
+        }
+
+        public void SendCommandBlind(string command, bool raw) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraChooserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraChooserVM.cs
@@ -83,6 +83,9 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                     var altairCameras = Altair.Altaircam.EnumV2();
                     Logger.Info($"Found {altairCameras?.Length} Altair Cameras");
                     foreach (var instance in altairCameras) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) { continue; }
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_AUTOFOCUSER) > 0) { continue; }
                         var cam = new ToupTekAlikeCamera(instance.ToDeviceInfo(), new AltairSDKWrapper(), profileService, exposureDataFactory);
                         devices.Add(cam);
                     }

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraChooserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraChooserVM.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright © 2016 - 2025 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 

--- a/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelChooserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelChooserVM.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright © 2016 - 2025 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 

--- a/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelChooserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/FilterWheel/FilterWheelChooserVM.cs
@@ -26,6 +26,7 @@ using NINA.Core.Locale;
 using NINA.Equipment.Interfaces;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyCamera.ToupTekAlike;
 using NINA.Equipment.SDK.CameraSDKs.SBIGSDK;
 using System.Threading.Tasks;
 using NINA.Equipment.Interfaces.ViewModel;
@@ -147,6 +148,111 @@ namespace NINA.WPF.Base.ViewModel.Equipment.FilterWheel {
                         var fw = new PlayerOneFilterWheel(i, profileService);
                         Logger.Debug($"Adding PlayerOne Filter Wheel {i})");
                         devices.Add(fw);
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* Altair */
+                try {
+                    var altairDevices = Altair.Altaircam.EnumV2();
+                    Logger.Info($"Found {altairDevices?.Length} Altair Devices");
+                    foreach (var instance in altairDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new AltairSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* ToupTek */
+                try {
+                    var toupTekDevices = ToupTek.ToupCam.EnumV2();
+                    Logger.Info($"Found {toupTekDevices?.Length} ToupTek Devices");
+                    foreach (var instance in toupTekDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new ToupTekSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* Ogma */
+                try {
+                    var ogmaDevices = Ogmacam.EnumV2();
+                    Logger.Info($"Found {ogmaDevices?.Length} Ogma Devices");
+                    foreach (var instance in ogmaDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new OgmaSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* Omegon */
+                try {
+                    var omegonDevices = Omegon.Omegonprocam.EnumV2();
+                    Logger.Info($"Found {omegonDevices?.Length} Omegon Devices");
+                    foreach (var instance in omegonDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new OmegonSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* Risingcam */
+                try {
+                    var risingCamDevices = Nncam.EnumV2();
+                    Logger.Info($"Found {risingCamDevices?.Length} RisingCam Devices");
+                    foreach (var instance in risingCamDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new RisingcamSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* MallinCam */
+                try {
+                    var mallinCamDevices = MallinCam.Mallincam.EnumV2();
+                    Logger.Info($"Found {mallinCamDevices?.Length} MallinCam Devices");
+                    foreach (var instance in mallinCamDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new MallinCamSDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
+                    }
+                } catch (Exception ex) {
+                    Logger.Error(ex);
+                }
+
+                /* SVBony */
+                try {
+                    var svBonyDevices = Svbonycam.EnumV2();
+                    Logger.Info($"Found {svBonyDevices?.Length} SVBony Devices");
+                    foreach (var instance in svBonyDevices) {
+                        var info = instance.ToDeviceInfo();
+                        if (((ToupTekAlikeFlag)info.model.flag & ToupTekAlikeFlag.FLAG_FILTERWHEEL) > 0) {
+                            var wheel = new ToupTekAlikeFilterWheel(info, new SVBonySDKWrapper(), profileService);
+                            devices.Add(wheel);
+                        }
                     }
                 } catch (Exception ex) {
                     Logger.Error(ex);

--- a/NINA/View/Equipment/FilterWheel/FilterWheelTemplateSelector.cs
+++ b/NINA/View/Equipment/FilterWheel/FilterWheelTemplateSelector.cs
@@ -23,6 +23,7 @@ namespace NINA.View.Equipment {
     internal class FilterWheelTemplateSelector : DataTemplateSelector {
         public DataTemplate Default { get; set; }
         public DataTemplate Zwo { get; set; }
+        public DataTemplate ToupTekAlike { get; set; }
         public DataTemplate FailedToLoadTemplate { get; set; }
 
         public string Postfix { get; set; }
@@ -30,6 +31,8 @@ namespace NINA.View.Equipment {
         public override DataTemplate SelectTemplate(object item, DependencyObject container) {
             if (item is ASIFilterWheel) {
                 return Zwo;
+            } else if (item is ToupTekAlikeFilterWheel) {
+                return ToupTekAlike;
             } else {
                 var templateKey = item?.GetType().FullName + Postfix;
                 if (item != null && Application.Current.Resources.Contains(templateKey)) {

--- a/NINA/View/Equipment/FilterWheel/FilterWheelTemplateSelector.cs
+++ b/NINA/View/Equipment/FilterWheel/FilterWheelTemplateSelector.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright © 2016 - 2025 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 

--- a/NINA/View/Equipment/FilterWheel/FilterWheelView.xaml
+++ b/NINA/View/Equipment/FilterWheel/FilterWheelView.xaml
@@ -191,11 +191,33 @@
                         </StackPanel>
                     </DataTemplate>
 
+                    <DataTemplate x:Key="ToupTekAlike">
+                        <StackPanel Orientation="Vertical">
+                            <DockPanel Margin="0,0,0,6">
+                                <TextBlock
+                                    MinWidth="100"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblUnidirectional}" />
+                                <CheckBox HorizontalAlignment="Right" IsChecked="{Binding Unidirectional}" />
+                            </DockPanel>
+                            <DockPanel Margin="0,0,0,6">
+                                <ninactrl:AsyncProcessButton
+                                    Width="150"
+                                    Height="25"
+                                    Margin="0,0,0,5"
+                                    HorizontalAlignment="Right"
+                                    ButtonText="{ns:Loc LblCalibrate}"
+                                    Command="{Binding CalibrateAfwCommand}" />
+                            </DockPanel>
+                        </StackPanel>
+                    </DataTemplate>
+
                     <local:FilterWheelTemplateSelector
                         x:Key="ContentSelector"
                         Default="{StaticResource Default}"
                         FailedToLoadTemplate="{StaticResource Failed}"
                         Postfix="{x:Static wpfutil:DataTemplatePostfix.FilterWheelSettings}"
+                        ToupTekAlike="{StaticResource ToupTekAlike}"
                         Zwo="{StaticResource Zwo}" />
                 </Grid.Resources>
                 <ContentControl

--- a/NINA/View/Equipment/FilterWheel/FilterWheelView.xaml
+++ b/NINA/View/Equipment/FilterWheel/FilterWheelView.xaml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright (c) 2016 - 2025 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - Sequencer conditions and instructions now better handle transitions near the horizon, preventing sudden jumps in sun and moon altitude caused by atmospheric refraction effects breaking down below horizon.
 - Direct guider will now wait for "IsPulseGuiding" flag to become false before continuing.
 - In Legacy Sequencer, when interrupting the start or end actions, the sequence will now properly re-run these when starting again
+- ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
  
 ### **Device Management**
 - **Device Chooser Enhancements**  
@@ -36,6 +37,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
     - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 - ** Switch Polling**
     - Switches are now polled sequentially instead of in parallel for their status update, to accommodate drivers that do not handle concurrent access properly.
+- **Altair, Mallincam, Ogma, Omegon, Risingcam, SvBony and ToupTek Filterwheel Native Driver**
+  - The ToupTek based filter wheels are now available as a native driver.
 
 ### **User Interface & Usability**
 - **Framing Assistant Improvements**  

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@
 If N.I.N.A. helps you in your journey for amazing deep sky images, please consider a donation. Each backer will help keeping the project alive and active.  
 More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">nighttime-imaging.eu/donate/</a>
 
+# Version 3.3
+
+## Bugfixes
+- ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
+
+### **Device Management**
+- **Altair, Mallincam, Ogma, Omegon, Risingcam, SvBony and ToupTek Filterwheel Native Driver**
+  - The ToupTek based filter wheels are now available as a native driver.
+
 # Version 3.2
 
 ## Bugfixes
@@ -19,7 +28,6 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - Sequencer conditions and instructions now better handle transitions near the horizon, preventing sudden jumps in sun and moon altitude caused by atmospheric refraction effects breaking down below horizon.
 - Direct guider will now wait for "IsPulseGuiding" flag to become false before continuing.
 - In Legacy Sequencer, when interrupting the start or end actions, the sequence will now properly re-run these when starting again
-- ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
  
 ### **Device Management**
 - **Device Chooser Enhancements**  
@@ -37,8 +45,6 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
     - Optionally disallow the mount to be unparked if the dome or roof controller reports a shutter state other than Open.
 - ** Switch Polling**
     - Switches are now polled sequentially instead of in parallel for their status update, to accommodate drivers that do not handle concurrent access properly.
-- **Altair, Mallincam, Ogma, Omegon, Risingcam, SvBony and ToupTek Filterwheel Native Driver**
-  - The ToupTek based filter wheels are now available as a native driver.
 
 ### **User Interface & Usability**
 - **Framing Assistant Improvements**  


### PR DESCRIPTION
## 🚀 Purpose
- ToupTek based filter wheels and focusers will no longer pop up in the Camera connector.
- Added native driver for ToupTek based filter wheels.

## 🧪 How Was It Tested?
Functionality was tested with ToupTek AFW-L filter wheel.

## ✅ PR Checklist

- ✅ All unit tests pass
- ✅ UI changes tested across Light, Dark, and Night themes (if applicable)
- [not applicable] Plugin API compatibility reviewed  
  - ✅ No breaking changes to interfaces  
  - ✅ No changes to method/class signatures (especially optional parameters)
- ✅ `Changelog.md` updated (if applicable)
- [not applicable] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues
## 📸 Screenshots
Screenshot showing Filterwheel as camera issue.
![fw_as_cam](https://github.com/user-attachments/assets/2b5c0c6c-cc8f-4ea0-bb89-685119704fcf)
Screenshot showing native filterwheel drivers.
![fw](https://github.com/user-attachments/assets/cabc8ffe-8cda-403a-8d0c-c4c08019f7e9)
![fw2](https://github.com/user-attachments/assets/7c04423f-320d-496a-b28f-de86292dcc47)

## 📝 Additional Notes