### PR TITLE
[3.3] Sync timer

### DIFF
--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -778,15 +778,18 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
                     Logger.Info($"{(result ? string.Empty : "FAILED - ")}Syncing scope from {position} to {transform}");
                     var waitForUpdate = updateTimer.WaitForNextUpdate(default);
                     await waitForUpdate;
+                    position = GetCurrentPosition();
                     var timeoutEnds = DateTime.UtcNow + TimeSpan.FromSeconds(profileService.ActiveProfile.TelescopeSettings.SettleTime);
-                    while (telescopeInfo.Coordinates.RADegrees != transform.RADegrees || telescopeInfo.Coordinates.Dec != transform.Dec) {
-                        Logger.Info("Waiting for telescope to update its position after a sync command");
+                    while (position.ToString() != transform.ToString()) {
+                        //using string comparison to avoid issues with very small differences in the coordinates
+                        Logger.Info($"Waiting for telescope to update its position from {position} to {transform} after a sync command");
                         if (DateTime.UtcNow > timeoutEnds) {
-                            Logger.Warning("Timed out waiting for telescope to update its position after a sync command");
+                            Logger.Warning($"Timed out waiting for telescope to update its position from {position} to {transform} after a sync command");
                             break;
                         }
                         var waitForSyncCompletetion = updateTimer.WaitForNextUpdate(default);
                         await waitForSyncCompletetion;
+                        position = GetCurrentPosition();
                     }
                     return result;
                 } else {

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -793,7 +793,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
 
                     while (Math.Abs((position - transform).Distance.ArcSeconds) > (1.0)) {
                         Logger.Debug($"Waiting for telescope to update its position from {position} to {transform} after a sync command. " +
-                            $"Error: {(position - transform).Distance.ArcSeconds}, Sync Threshold: {1.0 + (DateTime.UtcNow - syncStartTime).TotalSeconds}");
+                            $"Error: {(position - transform).Distance.ArcSeconds}");
                         if (DateTime.UtcNow > timeoutEnds) {
                             Logger.Warning($"Timed out waiting for telescope to update its position from {position} to {transform} after a sync command");
                             break;

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -774,13 +774,14 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
                         transform.RA = mod24Ra;
                     }
                     var position = GetCurrentPosition();
+                    var syncSent = DateTime.UtcNow;
                     bool result = Telescope.Sync(transform);
+                    position = GetCurrentPosition();
                     Logger.Info($"{(result ? string.Empty : "FAILED - ")}Syncing scope from {position} to {transform}");
                     var waitForUpdate = updateTimer.WaitForNextUpdate(default);
                     await waitForUpdate;
-                    position = GetCurrentPosition();
                     var timeoutEnds = DateTime.UtcNow + TimeSpan.FromSeconds(profileService.ActiveProfile.TelescopeSettings.SettleTime);
-                    while (position.ToString() != transform.ToString()) {
+                    while (position.Transform(Epoch.JNOW).ToString() != transform.Transform(Epoch.JNOW).ToString()) {
                         //using string comparison to avoid issues with very small differences in the coordinates
                         Logger.Info($"Waiting for telescope to update its position from {position} to {transform} after a sync command");
                         if (DateTime.UtcNow > timeoutEnds) {

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -780,6 +780,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
                     await waitForUpdate;
                     var timeoutEnds = DateTime.UtcNow + TimeSpan.FromSeconds(profileService.ActiveProfile.TelescopeSettings.SettleTime);
                     while (telescopeInfo.Coordinates.RADegrees != transform.RADegrees || telescopeInfo.Coordinates.Dec != transform.Dec) {
+                        Logger.Info("Waiting for telescope to update its position after a sync command");
                         if (DateTime.UtcNow > timeoutEnds) {
                             Logger.Warning("Timed out waiting for telescope to update its position after a sync command");
                             break;


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose
To remove long delays due to sync function waiting for slew settle time although no slew had taken place.
(https://github.com/isbeorn/nina/issues/73)

## 🧪 How Was It Tested?

Have tested using ASCOM camera simulator and mount. Also tested with connection to CPWI but with ASCOM camera simulator (due to weather)

## ✅ PR Checklist

- [Y ] All unit tests pass
- [ NA ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [NA] `Changelog.md` updated (if applicable)
- [NA] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

Closes #73

## 📸 Screenshots

N/A

## 📝 Additional Notes

Tests included instantaneous sync completion and (by trying to slew out side the mount limits) cases where the original time out kicks in. 
