### PR TITLE
ToupTekAlike LED "always on" fix

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/ToupTekAlikeCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/ToupTekAlikeCamera.cs
@@ -654,11 +654,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
                         HasHighFullwell = false;
                     }
 
-                    if(CanSetLEDLights) {
-                        SupportedActions.Add(ToupTekActions.LEDLights);
-                        LEDLights = profile.TouptekAlikeLEDLights;
-                    }                    
-
                     ReadoutModes = new List<string> { "Low Conversion Gain" };
 
                     if ((this.flags & ToupTekAlikeFlag.FLAG_CG) != 0) {
@@ -685,6 +680,11 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
                     if (!sdk.StartPullModeWithCallback(new ToupTekAlikeCallback(OnEventCallback))) {
                         throw new Exception($"{Category} - Could not start pull mode");
+                    }
+
+                    if (CanSetLEDLights) {
+                        SupportedActions.Add(ToupTekActions.LEDLights);
+                        LEDLights = profile.TouptekAlikeLEDLights;
                     }
 
                     if (!sdk.put_Option(ToupTekAlikeOption.OPTION_FLUSH, 3)) {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - Sequencer conditions and instructions now better handle transitions near the horizon, preventing sudden jumps in sun and moon altitude caused by atmospheric refraction effects breaking down below horizon.
 - Direct guider will now wait for "IsPulseGuiding" flag to become false before continuing.
 - In Legacy Sequencer, when interrupting the start or end actions, the sequence will now properly re-run these when starting again
+- Fixed an issue causing ToupTek camera LEDs to remain on after connection, regardless of the profile setting.
  
 ### **Device Management**
 - **Device Chooser Enhancements**  


### PR DESCRIPTION
## 🚀 Purpose
Fixes an issue with ToupTekAlike cameras where the LED taillight settings were ignored if configured before the image callback was initialized. This appears to be a bug in the ToupTek SDK — the camera reports that the LED lights are turned off, but they remain physically on when the setting is applied prior to callback initialization.

## 🧪 How Was It Tested?
Tested with ATR2600 and SkyEye62AM.

## ✅ PR Checklist

- ✅ All unit tests pass
- ✅ UI changes tested across Light, Dark, and Night themes (if applicable)
- ✅ Plugin API compatibility reviewed  
  - ✅ No breaking changes to interfaces  
  - ✅ No changes to method/class signatures (especially optional parameters)
- ✅ `Changelog.md` updated (if applicable)
- ✅ [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues
## 📸 Screenshots
## 📝 Additional Notes