### PR TITLE
[3.3] Skip imaging related triggers when safety monitor reports unsafe

### DIFF
--- a/NINA.Sequencer/SequenceItem/Imaging/SmartExposure.cs
+++ b/NINA.Sequencer/SequenceItem/Imaging/SmartExposure.cs
@@ -63,12 +63,13 @@ namespace NINA.Sequencer.SequenceItem.Imaging {
                 IImageSaveMediator imageSaveMediator,
                 IImageHistoryVM imageHistoryVM,
                 IFilterWheelMediator filterWheelMediator,
-                IGuiderMediator guiderMediator) : this(
+                IGuiderMediator guiderMediator,
+                ISafetyMonitorMediator safetyMonitorMediator) : this(
                     null,
                     new SwitchFilter(profileService, filterWheelMediator),
                     new TakeExposure(profileService, cameraMediator, imagingMediator, imageSaveMediator, imageHistoryVM),
                     new LoopCondition(),
-                    new DitherAfterExposures(guiderMediator, imageHistoryVM, profileService)
+                    new DitherAfterExposures(guiderMediator, imageHistoryVM, profileService, safetyMonitorMediator)
                 ) {
         }
 

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterExposures.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterExposures.cs
@@ -111,8 +111,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             var lastAFId = history.AutoFocusPoints?.LastOrDefault()?.Id ?? 0;
             var lightImageHistory = history.ImageHistory.Where(x => x.Type == "LIGHT" && x.Id > lastAFId).ToList();

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterExposures.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterExposures.cs
@@ -13,14 +13,23 @@
 #endregion "copyright"
 
 using Newtonsoft.Json;
+using NINA.Core.Locale;
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.Utility;
 using NINA.Sequencer.Validations;
-using NINA.Equipment.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -29,13 +38,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Locale;
-using NINA.Core.Utility;
-using NINA.Sequencer.Utility;
-using NINA.Image.ImageAnalysis;
-using NINA.Sequencer.Interfaces;
-using NINA.WPF.Base.Interfaces;
 
 namespace NINA.Sequencer.Trigger.Autofocus {
 
@@ -53,22 +55,23 @@ namespace NINA.Sequencer.Trigger.Autofocus {
         private IFilterWheelMediator filterWheelMediator;
         private IFocuserMediator focuserMediator;
         private IAutoFocusVMFactory autoFocusVMFactory;
-
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
         private int afterExposures;
 
         [ImportingConstructor]
-        public AutofocusAfterExposures(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory) : base() {
+        public AutofocusAfterExposures(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory, ISafetyMonitorMediator safetyMonitorMediator) : base() {
             this.history = history;
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
             this.filterWheelMediator = filterWheelMediator;
             this.focuserMediator = focuserMediator;
             this.autoFocusVMFactory = autoFocusVMFactory;
+            this.safetyMonitorMediator = safetyMonitorMediator;
             AfterExposures = 5;
             TriggerRunner.Add(new RunAutofocus(profileService, history, cameraMediator, filterWheelMediator, focuserMediator, autoFocusVMFactory));
         }
 
-        private AutofocusAfterExposures(AutofocusAfterExposures cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory) {
+        private AutofocusAfterExposures(AutofocusAfterExposures cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory, cloneMe.safetyMonitorMediator) {
             CopyMetaData(cloneMe);
         }
 
@@ -108,7 +111,8 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-
+            var safety = safetyMonitorMediator.GetInfo();
+            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
 
             var lastAFId = history.AutoFocusPoints?.LastOrDefault()?.Id ?? 0;
             var lightImageHistory = history.ImageHistory.Where(x => x.Type == "LIGHT" && x.Id > lastAFId).ToList();

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterFilterChange.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterFilterChange.cs
@@ -12,17 +12,27 @@
 
 #endregion "copyright"
 
+using ASCOM.Com.DriverAccess;
 using Newtonsoft.Json;
+using NINA.Core.Locale;
 using NINA.Core.Model;
+using NINA.Core.Model.Equipment;
+using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.Utility;
 using NINA.Sequencer.Validations;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.Core.Utility.WindowService;
 using NINA.ViewModel;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -31,14 +41,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Model.Equipment;
-using NINA.Core.Locale;
-using NINA.Sequencer.Utility;
-using NINA.Core.Utility;
-using NINA.Sequencer.Interfaces;
-using NINA.Image.ImageAnalysis;
-using NINA.WPF.Base.Interfaces;
 
 namespace NINA.Sequencer.Trigger.Autofocus {
 
@@ -54,20 +56,22 @@ namespace NINA.Sequencer.Trigger.Autofocus {
         private IFilterWheelMediator filterWheelMediator;
         private IFocuserMediator focuserMediator;
         private IAutoFocusVMFactory autoFocusVMFactory;
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
 
         [ImportingConstructor]
-        public AutofocusAfterFilterChange(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory) : base() {
+        public AutofocusAfterFilterChange(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory, ISafetyMonitorMediator safetyMonitorMediator) : base() {
             this.history = history;
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
             this.filterWheelMediator = filterWheelMediator;
             this.focuserMediator = focuserMediator;
             this.autoFocusVMFactory = autoFocusVMFactory;
+            this.safetyMonitorMediator = safetyMonitorMediator;
             LastAutoFocusFilter = null;
             TriggerRunner.Add(new RunAutofocus(profileService, history, cameraMediator, filterWheelMediator, focuserMediator, autoFocusVMFactory));
         }
 
-        private AutofocusAfterFilterChange(AutofocusAfterFilterChange cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory) {
+        private AutofocusAfterFilterChange(AutofocusAfterFilterChange cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory, cloneMe.safetyMonitorMediator) {
             CopyMetaData(cloneMe);
         }
 
@@ -110,6 +114,8 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
+            var safety = safetyMonitorMediator.GetInfo();
+            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
 
             var hasAutofocusFilter = profileService.ActiveProfile?.FilterWheelSettings?.FilterWheelFilters?.Where(f => f.AutoFocusFilter == true).FirstOrDefault() != null;
             if (!hasAutofocusFilter) {

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterFilterChange.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterFilterChange.cs
@@ -114,8 +114,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             var hasAutofocusFilter = profileService.ActiveProfile?.FilterWheelSettings?.FilterWheelFilters?.Where(f => f.AutoFocusFilter == true).FirstOrDefault() != null;
             if (!hasAutofocusFilter) {

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
@@ -168,8 +168,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             bool shouldTrigger = false;
             var fwInfo = this.filterWheelMediator.GetInfo();

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTrigger.cs
@@ -14,18 +14,26 @@
 
 using Accord.Math;
 using Accord.Statistics.Models.Regression.Linear;
+using ASCOM.Com.DriverAccess;
 using Newtonsoft.Json;
+using NINA.Core.Locale;
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.Utility;
 using NINA.Sequencer.Validations;
-using NINA.Core.Utility;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.Core.Utility.WindowService;
-using NINA.WPF.Base.Interfaces.ViewModel;
 using NINA.ViewModel.Interfaces;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -34,12 +42,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Locale;
-using NINA.Sequencer.Utility;
-using NINA.Image.ImageAnalysis;
-using NINA.Sequencer.Interfaces;
-using NINA.WPF.Base.Interfaces;
 
 namespace NINA.Sequencer.Trigger.Autofocus {
 
@@ -56,21 +58,23 @@ namespace NINA.Sequencer.Trigger.Autofocus {
         private IFilterWheelMediator filterWheelMediator;
         private IFocuserMediator focuserMediator;
         private IAutoFocusVMFactory autoFocusVMFactory;
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
 
         [ImportingConstructor]
-        public AutofocusAfterHFRIncreaseTrigger(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory) : base() {
+        public AutofocusAfterHFRIncreaseTrigger(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory, ISafetyMonitorMediator safetyMonitorMediator) : base() {
             this.history = history;
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
             this.filterWheelMediator = filterWheelMediator;
             this.focuserMediator = focuserMediator;
             this.autoFocusVMFactory = autoFocusVMFactory;
+            this.safetyMonitorMediator = safetyMonitorMediator;
             Amount = 5;
             SampleSize = 10;
             TriggerRunner.Add(new RunAutofocus(profileService, history, cameraMediator, filterWheelMediator, focuserMediator, autoFocusVMFactory));
         }
 
-        private AutofocusAfterHFRIncreaseTrigger(AutofocusAfterHFRIncreaseTrigger cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory) {
+        private AutofocusAfterHFRIncreaseTrigger(AutofocusAfterHFRIncreaseTrigger cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory, cloneMe.safetyMonitorMediator) {
             CopyMetaData(cloneMe);
         }
 
@@ -164,6 +168,8 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
+            var safety = safetyMonitorMediator.GetInfo();
+            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
 
             bool shouldTrigger = false;
             var fwInfo = this.filterWheelMediator.GetInfo();

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTrigger.cs
@@ -125,8 +125,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             if (history.ImageHistory == null) { return false; }
             if (history.ImageHistory.Count == 0) { return false; }

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTrigger.cs
@@ -12,16 +12,25 @@
 
 #endregion "copyright"
 
+using ASCOM.Com.DriverAccess;
 using Newtonsoft.Json;
+using NINA.Core.Locale;
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageAnalysis;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.Utility;
 using NINA.Sequencer.Validations;
-using NINA.Equipment.Interfaces.Mediator;
-using NINA.WPF.Base.Interfaces.ViewModel;
 using NINA.ViewModel.Interfaces;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -30,13 +39,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.WPF.Base.Interfaces.Mediator;
-using NINA.Core.Locale;
-using NINA.Sequencer.Utility;
-using NINA.Core.Utility;
-using NINA.Sequencer.Interfaces;
-using NINA.Image.ImageAnalysis;
-using NINA.WPF.Base.Interfaces;
 
 namespace NINA.Sequencer.Trigger.Autofocus {
 
@@ -53,21 +55,23 @@ namespace NINA.Sequencer.Trigger.Autofocus {
         private IFilterWheelMediator filterWheelMediator;
         private IFocuserMediator focuserMediator;
         private IAutoFocusVMFactory autoFocusVMFactory;
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
         private double initialTemperature;
 
         [ImportingConstructor]
-        public AutofocusAfterTemperatureChangeTrigger(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory) : base() {
+        public AutofocusAfterTemperatureChangeTrigger(IProfileService profileService, IImageHistoryVM history, ICameraMediator cameraMediator, IFilterWheelMediator filterWheelMediator, IFocuserMediator focuserMediator, IAutoFocusVMFactory autoFocusVMFactory, ISafetyMonitorMediator safetyMonitorMediator) : base() {
             this.history = history;
             this.profileService = profileService;
             this.cameraMediator = cameraMediator;
             this.filterWheelMediator = filterWheelMediator;
             this.focuserMediator = focuserMediator;
             this.autoFocusVMFactory = autoFocusVMFactory;
+            this.safetyMonitorMediator = safetyMonitorMediator;
             Amount = 5;
             TriggerRunner.Add(new RunAutofocus(profileService, history, cameraMediator, filterWheelMediator, focuserMediator, autoFocusVMFactory));
         }
 
-        private AutofocusAfterTemperatureChangeTrigger(AutofocusAfterTemperatureChangeTrigger cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory) {
+        private AutofocusAfterTemperatureChangeTrigger(AutofocusAfterTemperatureChangeTrigger cloneMe) : this(cloneMe.profileService, cloneMe.history, cloneMe.cameraMediator, cloneMe.filterWheelMediator, cloneMe.focuserMediator, cloneMe.autoFocusVMFactory, cloneMe.safetyMonitorMediator) {
             CopyMetaData(cloneMe);
         }
 
@@ -121,6 +125,8 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
+            var safety = safetyMonitorMediator.GetInfo();
+            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
 
             if (history.ImageHistory == null) { return false; }
             if (history.ImageHistory.Count == 0) { return false; }

--- a/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTimeTrigger.cs
+++ b/NINA.Sequencer/Trigger/Autofocus/AutofocusAfterTimeTrigger.cs
@@ -129,8 +129,7 @@ namespace NINA.Sequencer.Trigger.Autofocus {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             bool shouldTrigger = false;
             var lastAF = history.AutoFocusPoints.LastOrDefault();

--- a/NINA.Sequencer/Trigger/Guider/DitherAfterExposures.cs
+++ b/NINA.Sequencer/Trigger/Guider/DitherAfterExposures.cs
@@ -109,8 +109,7 @@ namespace NINA.Sequencer.Trigger.Guider {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             RaisePropertyChanged(nameof(ProgressExposures));
             if(lastTriggerId > history.ImageHistory.Count) { 

--- a/NINA.Sequencer/Trigger/Guider/DitherAfterExposures.cs
+++ b/NINA.Sequencer/Trigger/Guider/DitherAfterExposures.cs
@@ -12,15 +12,22 @@
 
 #endregion "copyright"
 
+using ASCOM.Com.DriverAccess;
 using Newtonsoft.Json;
-using NINA.Equipment.Interfaces.Mediator;
+using NINA.Core.Locale;
 using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Profile.Interfaces;
 using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.SequenceItem.Guider;
+using NINA.Sequencer.Utility;
 using NINA.Sequencer.Validations;
-using NINA.WPF.Base.Interfaces.ViewModel;
 using NINA.ViewModel.Interfaces;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -29,11 +36,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.Core.Locale;
-using NINA.Profile.Interfaces;
-using NINA.Sequencer.Utility;
-using NINA.Core.Utility;
-using NINA.Sequencer.Interfaces;
 
 namespace NINA.Sequencer.Trigger.Guider {
 
@@ -47,17 +49,19 @@ namespace NINA.Sequencer.Trigger.Guider {
         private IGuiderMediator guiderMediator;
         private IImageHistoryVM history;
         private IProfileService profileService;
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
 
         [ImportingConstructor]
-        public DitherAfterExposures(IGuiderMediator guiderMediator, IImageHistoryVM history, IProfileService profileService) : base() {
+        public DitherAfterExposures(IGuiderMediator guiderMediator, IImageHistoryVM history, IProfileService profileService, ISafetyMonitorMediator safetyMonitorMediator) : base() {
             this.guiderMediator = guiderMediator;
             this.history = history;
             this.profileService = profileService;
+            this.safetyMonitorMediator = safetyMonitorMediator;
             AfterExposures = 1;
             TriggerRunner.Add(new Dither(guiderMediator, profileService));
         }
 
-        private DitherAfterExposures(DitherAfterExposures cloneMe) : this(cloneMe.guiderMediator, cloneMe.history, cloneMe.profileService) {
+        private DitherAfterExposures(DitherAfterExposures cloneMe) : this(cloneMe.guiderMediator, cloneMe.history, cloneMe.profileService, cloneMe.safetyMonitorMediator) {
             CopyMetaData(cloneMe);
         }
 
@@ -105,6 +109,8 @@ namespace NINA.Sequencer.Trigger.Guider {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
+            var safety = safetyMonitorMediator.GetInfo();
+            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
 
             RaisePropertyChanged(nameof(ProgressExposures));
             if(lastTriggerId > history.ImageHistory.Count) { 

--- a/NINA.Sequencer/Trigger/Guider/RestoreGuiding.cs
+++ b/NINA.Sequencer/Trigger/Guider/RestoreGuiding.cs
@@ -76,8 +76,7 @@ namespace NINA.Sequencer.Trigger.Guider {
         }
 
         public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             if (nextItem is IExposureItem) {
                 var takeExposure = (IExposureItem)nextItem;

--- a/NINA.Sequencer/Trigger/MeridianFlip/MeridianFlipTrigger.cs
+++ b/NINA.Sequencer/Trigger/MeridianFlip/MeridianFlipTrigger.cs
@@ -208,8 +208,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 return false;
             }
 
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) {
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) {
             Logger.Info("Meridian Flip - Safety Monitor connected and reports unsafe conditions. Skip flip evaluation.");
                 return false;
             }

--- a/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
+++ b/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
@@ -213,8 +213,7 @@ namespace NINA.Sequencer.Trigger.Platesolving {
             if (nextItem == null) { return false; }
             if (!(nextItem is IExposureItem exposureItem)) { return false; }
             if (exposureItem.ImageType != "LIGHT") { return false; }
-            var safety = safetyMonitorMediator.GetInfo();
-            if (safety != null && safety.Connected && !safety.IsSafe) { return false; }
+            if (safetyMonitorMediator.GetInfo() is { Connected: true, IsSafe: false }) { return false; }
 
             if (LastDistanceArcMinutes >= DistanceArcMinutes) {
                 Logger.Info($"Drift exceeded threshold: {LastDistanceArcMinutes} / {DistanceArcMinutes} arc minutes");

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AuftofocusAfterExposuresTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AuftofocusAfterExposuresTriggerTest.cs
@@ -35,6 +35,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
         private Mock<IImageSaveMediator> imageSaveMediatorMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
         private ImageHistoryVM imagehistory;
 
         [SetUp]
@@ -47,6 +48,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = true });
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = true });
             imageSaveMediatorMock = new Mock<IImageSaveMediator>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
 
             var autoFocusVM = new Mock<IAutoFocusVM>();
             autoFocusVM.Setup(x => x.StartAutoFocus(It.IsAny<FilterInfo>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>())).ReturnsAsync(new AutoFocusReport() { Timestamp = DateTime.Now });
@@ -64,7 +66,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void CloneTest() {
-            var initial = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var initial = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
 
             var sut = (AutofocusAfterExposures)initial.Clone();
@@ -89,7 +91,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var report = new AutoFocusReport() { Timestamp = DateTime.Now - TimeSpan.FromMinutes(10) };
             imagehistory.AppendAutoFocusPoint(report);
 
-            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.AfterExposures = afterExposures;
 
             afTrigger.SequenceBlockInitialize();
@@ -128,7 +130,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var report = new AutoFocusReport() { Timestamp = DateTime.Now - TimeSpan.FromMinutes(10) };
             imagehistory.AppendAutoFocusPoint(report);
 
-            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.AfterExposures = afterExposures;
 
             afTrigger.SequenceBlockInitialize();
@@ -167,7 +169,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var report = new AutoFocusReport() { Timestamp = DateTime.Now - TimeSpan.FromMinutes(10) };
             imagehistory.AppendAutoFocusPoint(report);
 
-            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             var windowServiceFactory = new Mock<IWindowServiceFactory>();
             var windowService = new Mock<IWindowService>();
             windowService.Setup(x => x.Show(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<ResizeMode>(), It.IsAny<WindowStyle>()));
@@ -207,7 +209,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         [TestCase(13, 13, true)]
         [TestCase(100, 205, false)]
         public async Task ShouldTrigger_NoLastAFRun(int afterExposures, double exposuresToAdd, bool shouldTrigger) {
-            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.AfterExposures = afterExposures;
 
             afTrigger.SequenceBlockInitialize();
@@ -238,7 +240,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         [TestCase(13, 13, false)]
         [TestCase(100, 205, false)]
         public async Task NextItemNoLightExposure_ShouldNotTrigger_NoLastAFRun(int afterExposures, double exposuresToAdd, bool shouldTrigger) {
-            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.AfterExposures = afterExposures;
 
             afTrigger.SequenceBlockInitialize();
@@ -264,7 +266,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var filter = new FilterInfo() { Position = 0 };
             filterWheelMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = filter });
 
-            var sut = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
 
             await sut.Execute(default, default, default);
 
@@ -274,7 +276,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void ToString_FilledProperly() {
-            var sut = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterExposures(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             var tostring = sut.ToString();
             tostring.Should().Be("Trigger: AutofocusAfterExposures, AfterExposures: 5");
         }

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterFilterChangeTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterFilterChangeTest.cs
@@ -39,6 +39,7 @@ using NINA.Core.Utility;
 using NINA.WPF.Base.Model;
 using NINA.Core.Model;
 using static NINA.Equipment.Equipment.MyGPS.PegasusAstro.UnityApi.DriverUranusReport;
+using NINA.Equipment.Equipment.MySafetyMonitor;
 
 namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
@@ -136,6 +137,66 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
             var itemMock = new Mock<IExposureItem>();
             itemMock.SetupGet(x => x.ImageType).Returns("LIGHT");
+            var result = sut.ShouldTrigger(null, itemMock.Object);
+
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Test_ShouldTrigger_WhenChangeButUnsafe_NoTrigger() {
+            var filterWheelInfo = new FilterWheelInfo();
+            var filterInfo = new FilterInfo() {
+                Name = "Test1"
+            };
+            filterWheelInfo.SelectedFilter = filterInfo;
+
+            var nextFilterWheelInfo = new FilterWheelInfo();
+            var nextFilterInfo = new FilterInfo() {
+                Name = "Test2"
+            };
+            nextFilterWheelInfo.SelectedFilter = nextFilterInfo;
+
+            filterWheelMediatorMock.SetupSequence(m => m.GetInfo())
+                .Returns(filterWheelInfo)
+                .Returns(nextFilterWheelInfo);
+
+            sut.Initialize();
+
+            var itemMock = new Mock<IExposureItem>();
+            itemMock.SetupGet(x => x.ImageType).Returns("LIGHT");
+
+            safetyMonitorMediatorMock.Setup(m => m.GetInfo()).Returns(new SafetyMonitorInfo() { Connected = true, IsSafe = false });
+
+            var result = sut.ShouldTrigger(null, itemMock.Object);
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Test_ShouldTrigger_WhenChangeAndSafe_Triggers() {
+            var filterWheelInfo = new FilterWheelInfo();
+            var filterInfo = new FilterInfo() {
+                Name = "Test1"
+            };
+            filterWheelInfo.SelectedFilter = filterInfo;
+
+            var nextFilterWheelInfo = new FilterWheelInfo();
+            var nextFilterInfo = new FilterInfo() {
+                Name = "Test2"
+            };
+            nextFilterWheelInfo.SelectedFilter = nextFilterInfo;
+
+            filterWheelMediatorMock.SetupSequence(m => m.GetInfo())
+                .Returns(filterWheelInfo)
+                .Returns(nextFilterWheelInfo);
+
+            sut.Initialize();
+
+            var itemMock = new Mock<IExposureItem>();
+            itemMock.SetupGet(x => x.ImageType).Returns("LIGHT");
+
+            safetyMonitorMediatorMock.Setup(m => m.GetInfo()).Returns(new SafetyMonitorInfo() { Connected = true, IsSafe = true });
+
             var result = sut.ShouldTrigger(null, itemMock.Object);
 
             result.Should().BeTrue();

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterFilterChangeTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterFilterChangeTest.cs
@@ -51,6 +51,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         private Mock<IFilterWheelMediator> filterWheelMediatorMock;
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
         private AutofocusAfterFilterChange sut;
 
         [SetUp]
@@ -62,6 +63,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             filterWheelMediatorMock = new Mock<IFilterWheelMediator>();
             focuserMediatorMock = new Mock<IFocuserMediator>();
             autoFocusVMFactoryMock = new Mock<IAutoFocusVMFactory>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
 
             profileServiceMock.SetupGet(x => x.ActiveProfile.FocuserSettings.AutoFocusExposureTime).Returns(2);
             profileServiceMock.SetupGet(x => x.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps).Returns(4);
@@ -70,7 +72,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
             cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = true });
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = true });
-            sut = new AutofocusAfterFilterChange(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            sut = new AutofocusAfterFilterChange(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTriggerTest.cs
@@ -54,6 +54,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
         private Mock<IImageSaveMediator> imageSaveMediatorMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         private ImageHistoryVM imagehistory;
 
@@ -67,6 +68,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = true });
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = true });
             imageSaveMediatorMock = new Mock<IImageSaveMediator>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
 
             profileServiceMock.SetupGet(x => x.ActiveProfile.FocuserSettings.AutoFocusExposureTime).Returns(2);
             profileServiceMock.SetupGet(x => x.ActiveProfile.FocuserSettings.AutoFocusInitialOffsetSteps).Returns(4);
@@ -82,7 +84,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void CloneTest() {
-            var initial = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var initial = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
             initial.SampleSize = 15;
             initial.Amount = 33;
@@ -105,7 +107,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 imagehistory.Add(imagehistory.GetNextImageId(), null, "LIGHT");
             }
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Amount = 1;
 
             var trigger = sut.ShouldTrigger(null, null);
@@ -130,7 +132,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 imagehistory.AppendImageProperties(new ImageSavedEventArgs() { StarDetectionAnalysis = new StarDetectionAnalysis() { DetectedStars = 1, HFR = hfrs[i] }, MetaData = new ImageMetaData() { Image = new ImageParameter() { Id = id } } });
             }
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Amount = changeAmount;
 
             var itemMock = new Mock<IExposureItem>();
@@ -155,7 +157,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 imagehistory.AppendImageProperties(new ImageSavedEventArgs() { StarDetectionAnalysis = new StarDetectionAnalysis() { DetectedStars = 1, HFR = hfrs[i] }, MetaData = new ImageMetaData() { Image = new ImageParameter() { Id = id } } });
             }
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.SampleSize = 4;
             sut.Amount = changeAmount;
 
@@ -193,7 +195,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 imagehistory.AppendImageProperties(new ImageSavedEventArgs() { StarDetectionAnalysis = new StarDetectionAnalysis() { DetectedStars = 1 + 5, HFR = hfrs[i] }, MetaData = new ImageMetaData() { Image = new ImageParameter() { Id = id } } });
             }
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Amount = changeAmount;
 
             var itemMock = new Mock<IExposureItem>();
@@ -210,7 +212,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var filter = new FilterInfo() { Position = 0 };
             filterWheelMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = filter });
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
 
             await sut.Execute(default, default, default);
 
@@ -220,7 +222,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void ToString_FilledProperly() {
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             var tostring = sut.ToString();
             tostring.Should().Be("Trigger: AutofocusAfterHFRIncreaseTrigger, Amount: 5");
         }
@@ -251,7 +253,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
             filterWheelMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { Connected = true, SelectedFilter = new FilterInfo() { Name = "TestFilter" } });
 
-            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterHFRIncreaseTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Amount = changeAmount;
 
             var itemMock = new Mock<IExposureItem>();

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterHFRIncreaseTriggerTest.cs
@@ -313,7 +313,8 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 cameraMediatorMock.Object,
                 filterWheelMediatorMock.Object,
                 focuserMediatorMock.Object,
-                autoFocusVMFactoryMock.Object) {
+                autoFocusVMFactoryMock.Object,
+                safetyMonitorMediatorMock.Object) {
                 SampleSize = sampleSize,
                 Amount = 0.0
             };

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterTemperatureChangeTriggerTest.cs
@@ -54,6 +54,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         private Mock<IFilterWheelMediator> filterWheelMediatorMock;
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
@@ -63,6 +64,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             filterWheelMediatorMock = new Mock<IFilterWheelMediator>();
             focuserMediatorMock = new Mock<IFocuserMediator>();
             autoFocusVMFactoryMock = new Mock<IAutoFocusVMFactory>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
             cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = true });
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = true });
 
@@ -74,7 +76,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void CloneTest() {
-            var initial = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var initial = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
 
             var sut = (AutofocusAfterTemperatureChangeTrigger)initial.Clone();
@@ -101,7 +103,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo() { Temperature = changedTemp });
 
-            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Amount = tempAmount;
 
             var itemMock = new Mock<IExposureItem>();
@@ -127,7 +129,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 .Returns(new FocuserInfo() { Temperature = initialTemp })
                 .Returns(new FocuserInfo() { Temperature = changedTemp });
 
-            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Initialize();
             sut.Amount = tempAmount;
 
@@ -154,7 +156,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
                 .Returns(new FocuserInfo() { Temperature = initialTemp })
                 .Returns(new FocuserInfo() { Temperature = changedTemp });
 
-            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             sut.Initialize();
             sut.Amount = tempAmount;
 
@@ -172,7 +174,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var filter = new FilterInfo() { Position = 0 };
             filterWheelMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = filter });
 
-            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
 
             await sut.Execute(default, default, default);
 
@@ -182,7 +184,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void ToString_FilledProperly() {
-            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTemperatureChangeTrigger(profileServiceMock.Object, historyMock.Object, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             var tostring = sut.ToString();
             tostring.Should().Be("Trigger: AutofocusAfterTemperatureChangeTrigger, Amount: 5°");
         }

--- a/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterTimeTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Autofocus/AutofocusAfterTimeTriggerTest.cs
@@ -55,6 +55,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
         private Mock<IImageSaveMediator> imageSaveMediatorMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
         private ImageHistoryVM imagehistory;
 
         [SetUp]
@@ -64,6 +65,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             filterWheelMediatorMock = new Mock<IFilterWheelMediator>();
             focuserMediatorMock = new Mock<IFocuserMediator>();
             autoFocusVMFactoryMock = new Mock<IAutoFocusVMFactory>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
             cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = true });
             focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = true });
             imageSaveMediatorMock = new Mock<IImageSaveMediator>();
@@ -80,7 +82,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void CloneTest() {
-            var initial = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var initial = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
 
             var sut = (AutofocusAfterTimeTrigger)initial.Clone();
@@ -101,7 +103,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             imagehistory.AppendAutoFocusPoint(report);
             
 
-            var afTrigger = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.Amount = TimeSpan.FromMinutes(afterAFTime).TotalMinutes;
             
             var itemMock = new Mock<IExposureItem>();
@@ -117,7 +119,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
         [TestCase(100, 5, false)]
         [TestCase(10, 10, true)]
         public async Task ShouldTrigger_NoLastAFRun(double milliseconds, double initDelay, bool shouldTrigger) {
-            var afTrigger = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var afTrigger = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             afTrigger.Amount = TimeSpan.FromMilliseconds(milliseconds).TotalMinutes;
 
             afTrigger.SequenceBlockInitialize();
@@ -138,7 +140,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
             var filter = new FilterInfo() { Position = 0 };
             filterWheelMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = filter });
 
-            var sut = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
 
             await sut.Execute(default, default, default);
 
@@ -148,7 +150,7 @@ namespace NINA.Test.Sequencer.Trigger.Autofocus {
 
         [Test]
         public void ToString_FilledProperly() {
-            var sut = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object);
+            var sut = new AutofocusAfterTimeTrigger(profileServiceMock.Object, imagehistory, cameraMediatorMock.Object, filterWheelMediatorMock.Object, focuserMediatorMock.Object, autoFocusVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
             var tostring = sut.ToString();
             tostring.Should().Be("Trigger: AutofocusAfterTimeTrigger, Amount: 30m");
         }

--- a/NINA.Test/Sequencer/Trigger/Guider/DitherAfterExposuresTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Guider/DitherAfterExposuresTest.cs
@@ -40,19 +40,21 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
         private Mock<IImageHistoryVM> historyMock;
         private Mock<IGuiderMediator> guiderMediatorMock;
         private Mock<IProfileService> profileServiceMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
             historyMock = new Mock<IImageHistoryVM>();
             guiderMediatorMock = new Mock<IGuiderMediator>();
             profileServiceMock = new Mock<IProfileService>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
             profileServiceMock.Setup(x => x.ActiveProfile.GuiderSettings.SettleTimeout).Returns(0);
             guiderMediatorMock.Setup(x => x.GetInfo()).Returns(new GuiderInfo() { Connected = true });
         }
 
         [Test]
         public void CloneTest() {
-            var initial = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var initial = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
 
             var sut = (DitherAfterExposures)initial.Clone();
@@ -65,7 +67,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
         public async Task ExecuteTest() {
             historyMock.SetupGet(x => x.ImageHistory).Returns(new List<ImageHistoryPoint>());
 
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             await sut.Execute(default, default, default);
 
             guiderMediatorMock.Verify(x => x.Dither(It.IsAny<CancellationToken>()), Times.Once);
@@ -73,7 +75,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
 
         [Test]
         public void InitializeTest() {
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             sut.SequenceBlockStarted();
 
             Assert.Pass();
@@ -106,7 +108,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
             }
             historyMock.SetupGet(x => x.ImageHistory).Returns(history);
 
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             sut.AfterExposures = afterExpsoures;
 
             var nextItem = new Mock<IExposureItem>();
@@ -143,7 +145,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
             }
             historyMock.SetupGet(x => x.ImageHistory).Returns(history);
 
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             sut.AfterExposures = afterExpsoures;
 
             var nextItem = new Mock<ISequenceItem>();            
@@ -160,7 +162,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
             }
             historyMock.SetupGet(x => x.ImageHistory).Returns(history);
 
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             sut.AfterExposures = 1;
 
             var nextItem = new Mock<IExposureItem>();
@@ -187,7 +189,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
             var nextItem = new Mock<IExposureItem>();
             nextItem.SetupGet(x => x.ImageType).Returns("LIGHT");
 
-            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object);
+            var sut = new DitherAfterExposures(guiderMediatorMock.Object, historyMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object);
             sut.AfterExposures = 1;
 
             var test1 = sut.ShouldTrigger(null, nextItem.Object);

--- a/NINA.Test/Sequencer/Trigger/Guider/RestoreGuidingTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Guider/RestoreGuidingTest.cs
@@ -34,16 +34,18 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
     [TestFixture]
     public class RestoreGuidingTest {
         private Mock<IGuiderMediator> guiderMediatorMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
             guiderMediatorMock = new Mock<IGuiderMediator>();
+            safetyMonitorMediatorMock= new Mock<ISafetyMonitorMediator>();
             guiderMediatorMock.Setup(x => x.GetInfo()).Returns(new GuiderInfo() { Connected = true });
         }
 
         [Test]
         public void CloneTest() {
-            var initial = new RestoreGuiding(guiderMediatorMock.Object);
+            var initial = new RestoreGuiding(guiderMediatorMock.Object, safetyMonitorMediatorMock.Object);
             initial.Icon = new System.Windows.Media.GeometryGroup();
 
             var sut = (RestoreGuiding)initial.Clone();
@@ -54,7 +56,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
 
         [Test]
         public async Task ExecuteTest() {
-            var sut = new RestoreGuiding(guiderMediatorMock.Object);
+            var sut = new RestoreGuiding(guiderMediatorMock.Object, safetyMonitorMediatorMock.Object);
             await sut.Execute(default, default, default);
 
             guiderMediatorMock.Verify(x => x.StartGuiding(false, It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -62,7 +64,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
 
         [Test]
         public void InitializeTest() {
-            var sut = new RestoreGuiding(guiderMediatorMock.Object);
+            var sut = new RestoreGuiding(guiderMediatorMock.Object, safetyMonitorMediatorMock.Object);
             sut.SequenceBlockStarted();
 
             Assert.Pass();
@@ -70,7 +72,7 @@ namespace NINA.Test.Sequencer.Trigger.Guider {
 
         [Test]
         public void ShouldTrigger_NextItemLightExposure() {
-            var sut = new RestoreGuiding(guiderMediatorMock.Object);
+            var sut = new RestoreGuiding(guiderMediatorMock.Object, safetyMonitorMediatorMock.Object);
 
             var profileServiceMock = new Mock<IProfileService>();
             var cameraMediatorMock = new Mock<ICameraMediator>();

--- a/NINA.Test/Sequencer/Trigger/MeridianFlip/MeridianFlipTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/MeridianFlip/MeridianFlipTriggerTest.cs
@@ -44,6 +44,7 @@ namespace NINA.Test.Sequencer.Trigger.MeridianFlip {
         private Mock<IFocuserMediator> focuserMediatorMock;
         private Mock<ICameraMediator> cameraMediatorMock;
         private Mock<IMeridianFlipVMFactory> meridianFlipVMFactoryMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
@@ -53,10 +54,11 @@ namespace NINA.Test.Sequencer.Trigger.MeridianFlip {
             cameraMediatorMock = new Mock<ICameraMediator>();
             focuserMediatorMock = new Mock<IFocuserMediator>();
             meridianFlipVMFactoryMock = new Mock<IMeridianFlipVMFactory>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
         }
 
         private MeridianFlipTrigger CreateSUT() {
-            return new MeridianFlipTrigger(profileServiceMock.Object, cameraMediatorMock.Object, telescopeMediatorMock.Object, focuserMediatorMock.Object, applicationStatusMediatorMock.Object, meridianFlipVMFactoryMock.Object);
+            return new MeridianFlipTrigger(profileServiceMock.Object, cameraMediatorMock.Object, telescopeMediatorMock.Object, focuserMediatorMock.Object, applicationStatusMediatorMock.Object, meridianFlipVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/Trigger/Platesolving/CenterAfterDriftTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Platesolving/CenterAfterDriftTriggerTest.cs
@@ -42,6 +42,7 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
         private Mock<IImageSaveMediator> imageSaveMediatorMock;
         private Mock<IDomeMediator> domeMediatorMock;
         private Mock<IDomeFollower> domeFollowerMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
@@ -55,6 +56,7 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
             imageSaveMediatorMock = new Mock<IImageSaveMediator>();
             domeMediatorMock = new Mock<IDomeMediator>();
             domeFollowerMock = new Mock<IDomeFollower>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
         }
 
         [Test]
@@ -75,7 +77,8 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
                 domeMediatorMock.Object,
                 domeFollowerMock.Object,
                 imageSaveMediatorMock.Object,
-                applicationStatusMediatorMock.Object);
+                applicationStatusMediatorMock.Object,
+                safetyMonitorMediatorMock.Object);
 
             sut.DistanceArcMinutes = arcmin;
 

--- a/NINA.Test/Sequencer/Utility/ItemUtilityTest.cs
+++ b/NINA.Test/Sequencer/Utility/ItemUtilityTest.cs
@@ -207,6 +207,7 @@ namespace NINA.Test.Sequencer.Utility {
             var cameraMediatorMock = new Mock<ICameraMediator>();
             var focuserMediatorMock = new Mock<IFocuserMediator>();
             var meridianFlipVMFactoryMock = new Mock<IMeridianFlipVMFactory>();
+            var safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
 
             telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() {
                 Connected = true,
@@ -215,7 +216,7 @@ namespace NINA.Test.Sequencer.Utility {
             });
             profileServiceMock.SetupGet(x => x.ActiveProfile.MeridianFlipSettings.UseSideOfPier).Returns(false);
 
-            var flip = new MeridianFlipTrigger(profileServiceMock.Object, cameraMediatorMock.Object, telescopeMediatorMock.Object, focuserMediatorMock.Object, applicationStatusMediatorMock.Object, meridianFlipVMFactoryMock.Object);
+            var flip = new MeridianFlipTrigger(profileServiceMock.Object, cameraMediatorMock.Object, telescopeMediatorMock.Object, focuserMediatorMock.Object, applicationStatusMediatorMock.Object, meridianFlipVMFactoryMock.Object, safetyMonitorMediatorMock.Object);
 
             flip.ShouldTrigger(null, null);
 

--- a/NINA.Test/SimpleSequencer/SimpleDSOContainerTest.cs
+++ b/NINA.Test/SimpleSequencer/SimpleDSOContainerTest.cs
@@ -35,6 +35,7 @@ namespace NINA.Test.SimpleSequencer {
         private Mock<IImagingMediator> imagingMediatorMock;
         private Mock<IImageHistoryVM> imageHistoryVMMock;
         private Mock<IGuiderMediator> guiderMediatorMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
 
         [SetUp]
         public void Setup() {
@@ -50,6 +51,7 @@ namespace NINA.Test.SimpleSequencer {
             imagingMediatorMock = new Mock<IImagingMediator>();
             imageHistoryVMMock = new Mock<IImageHistoryVM>();
             guiderMediatorMock = new Mock<IGuiderMediator>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
 
             profileServiceMock.Setup(m => m.ActiveProfile.AstrometrySettings.Latitude).Returns(33.005699);
             profileServiceMock.Setup(m => m.ActiveProfile.AstrometrySettings.Longitude).Returns(-117.103254);
@@ -62,7 +64,7 @@ namespace NINA.Test.SimpleSequencer {
             factoryMock.Setup(x => x.GetCondition<LoopCondition>()).Returns(() => new LoopCondition());
             factoryMock.Setup(x => x.GetItem<SwitchFilter>()).Returns(() => new SwitchFilter(profileServiceMock.Object, filterWheelMediatorMock.Object));
             factoryMock.Setup(x => x.GetItem<TakeExposure>()).Returns(() => new TakeExposure(profileServiceMock.Object, cameraMediatorMock.Object, imagingMediatorMock.Object, imageSaveMediatorMock.Object, imageHistoryVMMock.Object));
-            factoryMock.Setup(x => x.GetTrigger<DitherAfterExposures>()).Returns(() =>   new DitherAfterExposures(guiderMediatorMock.Object, imageHistoryVMMock.Object, profileServiceMock.Object));
+            factoryMock.Setup(x => x.GetTrigger<DitherAfterExposures>()).Returns(() =>   new DitherAfterExposures(guiderMediatorMock.Object, imageHistoryVMMock.Object, profileServiceMock.Object, safetyMonitorMediatorMock.Object));
         }
 
         [Test]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 ## Bugfixes
 
 ## Improvements
+- When a safety monitor is connected and is reporting unsafe conditions, the imaging related core triggers will no longer fire as the conditions aren't safe anyways to execute them.
+    - In case the meridian should trigger in this scenario, it will stop mount tracking instead to ensure there will be no pier collision. Safety related logic in a sequence needs to handle resuming tracking once it's safe again.
 
 ## Features
 


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
When a safety monitor is connected and reports unsafe it makes no sense for most of the imaging related triggers to fire. This PR adds an early exit for these triggers to report `false` on ShouldTrigger when safety monitor is connected and reporting unsafe.

Special care is done in MeridianFlipTrigger - When the trigger should return true here but the safety monitor reports unsafe conditions it will stop tracking instead and not trigger.

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
