### PR TITLE
[3.3] Framing Assistant: Add multi-source cache support

### DIFF
--- a/NINA.WPF.Base/SkySurvey/CacheSkySurvey.cs
+++ b/NINA.WPF.Base/SkySurvey/CacheSkySurvey.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright ï¿½ 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 
@@ -15,6 +15,7 @@
 using NINA.Astrometry;
 using NINA.Core.Utility;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -27,12 +28,22 @@ using System.Xml.Linq;
 namespace NINA.WPF.Base.SkySurvey {
 
     public class CacheSkySurvey {
+        public const string Default = "Default";
+        
         public readonly string framingAssistantCachePath;
         private string framingAssistantCachInfo;
+        private Dictionary<string, XElement> cachesBySource;
+        private Dictionary<string, string> cachePathsBySource;
+        private string activeSource = Default;
+        private string activeCachePath;
+
+        public string ActiveCachePath => string.IsNullOrEmpty(activeCachePath) ? framingAssistantCachePath : activeCachePath;
 
         public CacheSkySurvey(string framingAssistantCachePath) {
             this.framingAssistantCachePath = framingAssistantCachePath;
             this.framingAssistantCachInfo = Path.Combine(framingAssistantCachePath, "CacheInfo.xml");
+            this.cachesBySource = new Dictionary<string, XElement>();
+            this.cachePathsBySource = new Dictionary<string, string>();
             Initialize();
         }
 
@@ -79,12 +90,18 @@ namespace NINA.WPF.Base.SkySurvey {
 
 
         public void DeleteFromCache(XElement element) {
-            if(Cache != null && element != null) {
+            if(element != null) {
+                // Determine active cache document and paths
+                var doc = GetActiveCacheElement();
+                var basePath = ActiveCachePath;
+                var infoPath = (activeSource == Default || string.IsNullOrEmpty(activeSource))
+                    ? framingAssistantCachInfo
+                    : Path.Combine(ActiveCachePath, "CacheInfo.xml");
 
                 var fileNameAttribute = element.Attribute("FileName");
 
                 if(fileNameAttribute != null) {
-                    var fullFileName = Path.Combine(framingAssistantCachePath, fileNameAttribute.Value);                 
+                    var fullFileName = Path.Combine(basePath, fileNameAttribute.Value);
                     var thumbnailBig = CacheImage.GetImagePathForThumbnail(fullFileName, CacheImage.BigThumbnailSize);
                     var thumbnailMedium = CacheImage.GetImagePathForThumbnail(fullFileName, CacheImage.MediumThumbnailSize);
                     var thumbnailSmall = CacheImage.GetImagePathForThumbnail(fullFileName, CacheImage.SmallThumbnailSize);
@@ -101,11 +118,10 @@ namespace NINA.WPF.Base.SkySurvey {
                     if (File.Exists(thumbnailSmall)) {
                         try { File.Delete(thumbnailSmall); } catch { }
                     }
-
                 }
 
                 element.Remove();
-                Cache.Save(framingAssistantCachInfo);
+                doc?.Save(infoPath);
             }
         }
 
@@ -219,6 +235,7 @@ namespace NINA.WPF.Base.SkySurvey {
         /// <returns></returns>
         public Task<SkySurveyImage> GetImage(string source, double ra, double dec, double rotation, double fov) {
             return Task.Run(() => {
+                // Online sources and file cache are stored in the default cache (root)
                 var element =
                     Cache
                     .Elements("Image")
@@ -230,7 +247,7 @@ namespace NINA.WPF.Base.SkySurvey {
                     .FirstOrDefault();
 
                 if (element != null) {
-                    return Load(element);
+                    return Load(element, framingAssistantCachePath);
                 }
 
                 return null;
@@ -246,7 +263,7 @@ namespace NINA.WPF.Base.SkySurvey {
                         x => x.Attribute("Id").Value == id.ToString()
                     ).FirstOrDefault();
                 if (element != null) {
-                    return Load(element);
+                    return Load(element, framingAssistantCachePath);
                 } else {
                     return null;
                 }
@@ -254,7 +271,11 @@ namespace NINA.WPF.Base.SkySurvey {
         }
 
         private SkySurveyImage Load(XElement element) {
-            var img = LoadJpg(element.Attribute("FileName").Value);
+            return Load(element, framingAssistantCachePath);
+        }
+
+        private SkySurveyImage Load(XElement element, string cachePath) {
+            var img = LoadJpg(element.Attribute("FileName").Value, cachePath);
             Guid id = Guid.Parse(element.Attribute("Id").Value);
             var fovW = double.Parse(element.Attribute("FoVW").Value, CultureInfo.InvariantCulture);
             var fovH = double.Parse(element.Attribute("FoVH").Value, CultureInfo.InvariantCulture);
@@ -277,8 +298,12 @@ namespace NINA.WPF.Base.SkySurvey {
         }
 
         private BitmapSource LoadJpg(string filename) {
+            return LoadJpg(filename, framingAssistantCachePath);
+        }
+
+        private BitmapSource LoadJpg(string filename, string cachePath) {
             if (!Path.IsPathRooted(filename)) {
-                filename = Path.Combine(framingAssistantCachePath, filename);
+                filename = Path.Combine(cachePath, filename);
             }
 
             JpegBitmapDecoder JpgDec = new JpegBitmapDecoder(new Uri(filename), BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
@@ -296,6 +321,92 @@ namespace NINA.WPF.Base.SkySurvey {
             }
 
             return image;
+        }
+
+        /// <summary>
+        /// Scans subdirectories for cache sources and returns list of available sources
+        /// </summary>
+        public List<string> GetAvailableCacheSources() {
+            var sources = new List<string> { Default };
+            
+            try {
+                if (Directory.Exists(framingAssistantCachePath)) {
+                    var subdirs = Directory.GetDirectories(framingAssistantCachePath);
+                    foreach (var subdir in subdirs) {
+                        var dirName = Path.GetFileName(subdir);
+                        var cacheInfoPath = Path.Combine(subdir, "CacheInfo.xml");
+                        
+                        // Only add if it has a CacheInfo.xml file
+                        if (File.Exists(cacheInfoPath)) {
+                            sources.Add(dirName);
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                Logger.Error("Error scanning cache sources", ex);
+            }
+
+            return sources;
+        }
+
+        /// <summary>
+        /// Loads cache from a specific source (subdirectory or default)
+        /// </summary>
+        public void LoadCacheSource(string source) {
+            try {
+                string cachePath;
+                string cacheInfoPath;
+
+                if (source == Default || string.IsNullOrEmpty(source)) {
+                    cachePath = framingAssistantCachePath;
+                    cacheInfoPath = framingAssistantCachInfo;
+                } else {
+                    cachePath = Path.Combine(framingAssistantCachePath, source);
+                    cacheInfoPath = Path.Combine(cachePath, "CacheInfo.xml");
+                }
+
+                if (!Directory.Exists(cachePath)) {
+                    Directory.CreateDirectory(cachePath);
+                }
+
+                XElement cacheElement;
+                if (!File.Exists(cacheInfoPath)) {
+                    cacheElement = new XElement("ImageCacheInfo");
+                    cacheElement.Save(cacheInfoPath);
+                } else {
+                    cacheElement = XElement.Load(cacheInfoPath);
+
+                    // Ensure Backwards compatibility
+                    var elements = cacheElement.Elements("Image").Where(x => x.Attribute("Id") == null);
+                    foreach (var element in elements) {
+                        element.Add(new XAttribute("Id", Guid.NewGuid()));
+                    }
+                    elements = cacheElement.Elements("Image").Where(x => x.Attribute("Source") == null);
+                    foreach (var element in elements) {
+                        if (element.Attribute("Rotation").Value != "0") {
+                            element.Add(new XAttribute("Source", nameof(FileSkySurvey)));
+                        } else {
+                            element.Add(new XAttribute("Source", nameof(NASASkySurvey)));
+                        }
+                    }
+                }
+
+                cachesBySource[source] = cacheElement;
+                cachePathsBySource[source] = cachePath;
+
+                // set active source context
+                activeSource = string.IsNullOrEmpty(source) ? Default : source;
+                activeCachePath = cachePath;
+            } catch (Exception ex) {
+                Logger.Error($"Error loading cache source {source}", ex);
+            }
+        }
+
+        public XElement GetActiveCacheElement() {
+            if (activeSource == Default || !cachesBySource.ContainsKey(activeSource)) {
+                return Cache;
+            }
+            return cachesBySource[activeSource];
         }
     }
 }

--- a/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
+++ b/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright ï¿½ 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 
@@ -300,7 +300,8 @@ namespace NINA.WPF.Base.SkySurvey {
                 double maxSize = 600;
 
                 var l = new List<CacheImage>();
-                foreach (var entry in cache.Cache.Elements("Image")) {
+                var cacheDoc = cache?.GetActiveCacheElement();
+                foreach (var entry in cacheDoc?.Elements("Image") ?? Enumerable.Empty<System.Xml.Linq.XElement>()) {
                     double fovW = double.Parse(entry.Attribute("FoVW").Value, CultureInfo.InvariantCulture);
                     double fovH = double.Parse(entry.Attribute("FoVH").Value, CultureInfo.InvariantCulture);
 
@@ -311,7 +312,7 @@ namespace NINA.WPF.Base.SkySurvey {
                     double ra = double.Parse(entry.Attribute("RA").Value, CultureInfo.InvariantCulture);
                     double dec = double.Parse(entry.Attribute("Dec").Value, CultureInfo.InvariantCulture);
                     double rotation = double.Parse(entry.Attribute("Rotation").Value, CultureInfo.InvariantCulture);
-                    string path = Path.Combine(cache.framingAssistantCachePath, entry.Attribute("FileName").Value);
+                    string path = Path.Combine(cache.ActiveCachePath, entry.Attribute("FileName").Value);
 
                     if (AstroUtil.ArcminToArcsec(fovW) > minSize && AstroUtil.ArcminToArcsec(fovH) > minSize) {
                         var existing = cacheImages.FirstOrDefault(x => x.Coordinates.RA == ra && x.Coordinates.Dec == dec);

--- a/NINA/View/FramingAssistantView.xaml
+++ b/NINA/View/FramingAssistantView.xaml
@@ -334,6 +334,35 @@
                             </Grid>
 
                             <Grid>
+                                <!--  SKYATLAS (Offline Sky Map) Specific UI  -->
+                                <Grid.Style>
+                                    <Style TargetType="{x:Type Grid}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ElementName=PART_FramingAssistantSource, Path=SelectedItem}" Value="{x:Static enum:SkySurveySource.SKYATLAS}">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+    
+                                <Grid Margin="0,5,0,0" 
+                                      VerticalAlignment="Center"
+                                      Visibility="{Binding AvailableCacheSources, Converter={StaticResource CollectionContainsItemsToVisibilityConverter}}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock VerticalAlignment="Center" Text="Cache source" />
+                                    <ComboBox
+                                        Grid.Column="1"
+                                        Margin="5,0,0,0"
+                                        ItemsSource="{Binding AvailableCacheSources}"
+                                        SelectedItem="{Binding SelectedCacheSource}" />
+                                </Grid>
+                            </Grid>
+
+                            <Grid>
                                 <!--  Cache Specific UI  -->
                                 <Grid.Style>
                                     <Style TargetType="{x:Type Grid}">

--- a/NINA/View/FramingAssistantView.xaml
+++ b/NINA/View/FramingAssistantView.xaml
@@ -350,13 +350,13 @@
                                       VerticalAlignment="Center"
                                       Visibility="{Binding AvailableCacheSources, Converter={StaticResource CollectionContainsItemsToVisibilityConverter}}">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="FramingLabel"/>
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <TextBlock VerticalAlignment="Center" Text="Cache source" />
                                     <ComboBox
                                         Grid.Column="1"
-                                        Margin="5,0,0,0"
+                                        Margin="10,0,0,0"
                                         ItemsSource="{Binding AvailableCacheSources}"
                                         SelectedItem="{Binding SelectedCacheSource}" />
                                 </Grid>

--- a/NINA/ViewModel/FramingAssistant/FramingAssistantVM.cs
+++ b/NINA/ViewModel/FramingAssistant/FramingAssistantVM.cs
@@ -935,6 +935,8 @@ namespace NINA.ViewModel.FramingAssistant {
                             SkyMapAnnotator?.ClearImagesForViewport();
                             SkyMapAnnotator?.UpdateSkyMap();
                         } catch { }
+
+                        LoadImage();
                     }
                     RaisePropertyChanged();
                 }

--- a/NINA/ViewModel/FramingAssistant/FramingAssistantVM.cs
+++ b/NINA/ViewModel/FramingAssistant/FramingAssistantVM.cs
@@ -447,6 +447,15 @@ namespace NINA.ViewModel.FramingAssistant {
                 Cache = new CacheSkySurvey(profileService.ActiveProfile.ApplicationSettings.SkySurveyCacheDirectory);
                 ImageCacheInfo = Cache.Cache;
                 _selectedImageCacheInfo = (XElement)ImageCacheInfo?.FirstNode ?? null;
+
+                // Load available cache sources
+                var sources = Cache.GetAvailableCacheSources();
+                if (!sources.SequenceEqual(new[] { CacheSkySurvey.Default }))
+                    AvailableCacheSources = sources;
+                else
+                    AvailableCacheSources = null;
+                SelectedCacheSource = CacheSkySurvey.Default;
+
                 RaisePropertyChanged(nameof(ImageCacheInfo));
             } catch (Exception ex) {
                 Logger.Error(ex);
@@ -624,8 +633,7 @@ namespace NINA.ViewModel.FramingAssistant {
                     SkyMapAnnotator.ClearImagesForViewport();
 
                     Cache.Clear();
-                    ImageCacheInfo = Cache.Cache;
-                    RaisePropertyChanged(nameof(ImageCacheInfo));
+                    InitializeCache();
                 }
             }
         }
@@ -902,6 +910,37 @@ namespace NINA.ViewModel.FramingAssistant {
             }
         }
 
+        private List<string> _availableCacheSources;
+
+        public List<string> AvailableCacheSources {
+            get => _availableCacheSources;
+            set {
+                _availableCacheSources = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private string _selectedCacheSource = CacheSkySurvey.Default;
+
+        public string SelectedCacheSource {
+            get => _selectedCacheSource;
+            set {
+                if (_selectedCacheSource != value) {
+                    _selectedCacheSource = value;
+                    if (Cache != null) {
+                        Cache.LoadCacheSource(value);
+                        ImageCacheInfo = Cache.GetActiveCacheElement();
+                        RaisePropertyChanged(nameof(ImageCacheInfo));
+                        try {
+                            SkyMapAnnotator?.ClearImagesForViewport();
+                            SkyMapAnnotator?.UpdateSkyMap();
+                        } catch { }
+                    }
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         private double _cameraPixelSize;
 
         public double CameraPixelSize {
@@ -1102,6 +1141,11 @@ namespace NINA.ViewModel.FramingAssistant {
                         SkyMapAnnotator.UseCachedImages = IsX64;
                     } else {
                         SkyMapAnnotator.UseCachedImages = false;
+                    }
+
+                    // Load cache from selected source if SKYATLAS is selected
+                    if (FramingAssistantSource == SkySurveySource.SKYATLAS && Cache != null) {
+                        Cache.LoadCacheSource(SelectedCacheSource);
                     }
 
                     if (Cache != null && DSO != null) {


### PR DESCRIPTION
Framing Assistant: Add multi-source cache support for SKYATLAS. New caches should be placed inside framingAssistantCachePath as subdirectores. Selecting cache UI is added to skyatlas mode of Framing Assistant

<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

Since we have new excellent sky survey by [sigm.de](https://www.simg.de/nebulae3/index.html) that would be great to have ability to use Framing Assistant in different surveys. A user can add existing caches as subdirectories of `framingAssistantCachePath` and switch them in runtime when sky atlas is selected. Clearing cache clears all caches including subdirectories. If no subdirectores were found, no combobox is shown (same as previous ui behavior)

## 🧪 How Was It Tested?

Manual tests. Adding, removing subdirs, empty subdirs, invalid cacheinfo in subdirs

## ✅ PR Checklist

- [ x] All unit tests pass
- [ x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ x] Plugin API compatibility reviewed  
  - [x ] No breaking changes to interfaces  
  - [x ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<img width="1992" height="1498" alt="image" src="https://github.com/user-attachments/assets/9b8be6b0-739d-4de6-9c0a-b94b41d42682" />

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
