### PR TITLE
Hide optional focuser and rotator controls if they are not available

### DIFF
--- a/NINA/View/Equipment/Focuser/FocuserView.xaml
+++ b/NINA/View/Equipment/Focuser/FocuserView.xaml
@@ -182,7 +182,7 @@
                     <Border
                         BorderBrush="{StaticResource BorderBrush}"
                         BorderThickness="0"
-                        IsEnabled="{Binding Focuser.TempCompAvailable, FallbackValue=False}">
+                        Visibility="{Binding FocuserInfo.TempCompAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <UniformGrid Columns="2">
                             <UniformGrid
                                 Margin="0,6,0,6"

--- a/NINA/View/Equipment/Rotator/RotatorView.xaml
+++ b/NINA/View/Equipment/Rotator/RotatorView.xaml
@@ -123,7 +123,7 @@
                     <Border
                         BorderBrush="{StaticResource BorderBrush}"
                         BorderThickness="0"
-                        IsEnabled="{Binding RotatorInfo.CanReverse}">
+                        Visibility="{Binding RotatorInfo.CanReverse, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                         <UniformGrid
                             Margin="0,6,0,6"
                             VerticalAlignment="Center"

--- a/NINA/View/Imaging/AnchorableFocuserView.xaml
+++ b/NINA/View/Imaging/AnchorableFocuserView.xaml
@@ -126,9 +126,13 @@
                             <Border
                                 Margin="0,5,0,0"
                                 BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="0"
-                                IsEnabled="{Binding Focuser.TempCompAvailable, FallbackValue=False}"
-                                Visibility="{Binding ActiveProfile.DockPanelSettings.FocuserInfoOnly, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                BorderThickness="0">
+                                <Border.Visibility>
+                                    <MultiBinding Converter="{StaticResource BooleanToVisibilityCollapsedMultiConverter}">
+                                        <Binding Path="FocuserInfo.TempCompAvailable" />
+                                        <Binding Path="ActiveProfile.DockPanelSettings.FocuserInfoOnly" />
+                                    </MultiBinding>
+                                </Border.Visibility>
                                 <UniformGrid VerticalAlignment="Center" Columns="2">
                                     <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblTempComp}" />
                                     <CheckBox
@@ -146,9 +150,11 @@
                                 Margin="0,5,0,0"
                                 BorderBrush="{StaticResource BorderBrush}"
                                 BorderThickness="0"
-                                IsEnabled="{Binding Focuser.TempCompAvailable, FallbackValue=False}"
                                 Visibility="{Binding ActiveProfile.DockPanelSettings.FocuserInfoOnly, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
-                                <UniformGrid VerticalAlignment="Center" Columns="2">
+                                <UniformGrid
+                                    VerticalAlignment="Center"
+                                    Columns="2"
+                                    Visibility="{Binding FocuserInfo.TempCompAvailable, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
                                     <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblTempComp}" />
                                     <CheckBox
                                         Height="25"


### PR DESCRIPTION
## 🚀 Purpose

This PR changes display logic in the **Equipment > Focuser** and **Equipment > Rotator** views to hide, rather than disable, the Temperature Compensation and (rotator) Reverse toggles if the connected driver does not offer these optional features. This is to reduce user confusion when using drivers that do not provide these functions.

## 🧪 How Was It Tested?

ASCOM OmniSims for focuser and rotator with temperature compensation and reverse features enabled and disabled.

## ✅ PR Checklist

- [x ] All unit tests pass
- [x ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x ] Plugin API compatibility reviewed  
  - [x ] No breaking changes to interfaces  
  - [x ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)
