### PR TITLE
Remove the telescope info auto-update for Nikon Camera

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
@@ -396,44 +396,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
 
-        public string LensName {
-            get {
-                if (Connected) {
-                    return _camera.GetString(Nikon.eNkMAIDCapability.kNkMAIDCapability_LensInfo).Trim();
-                } else {
-                    return string.Empty;
-                }
-            }
-        }
-
-        public double LensFocalLength {
-            get {
-                if (Connected) {
-                    return _camera.GetFloat(Nikon.eNkMAIDCapability.kNkMAIDCapability_FocalLength);
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public double LensFocalRatio {
-            get {
-                if(Connected) {
-                    try {
-                        return Convert.ToDouble(_camera.GetEnum(Nikon.eNkMAIDCapability.kNkMAIDCapability_Aperture).ToString());
-                    } catch (FormatException ex) {
-                        Logger.Error($"Unexpected format for lens aperture value : {ex.Message}");
-                        return double.NaN;
-                    }
-                } else {
-                    return double.NaN;
-                }
-            }
-        }
-
-        public event EventHandler LensStateChanged;
-
-
         public bool CanSetTemperature => false;
 
         public bool CoolerOn {
@@ -649,17 +611,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
         public bool HasBattery => true;
-
-        private void ScanDeviceCapabilitiyValue (NikonDevice sender, eNkMAIDCapability capability) {
-            switch (capability) {
-                case eNkMAIDCapability.kNkMAIDCapability_LensInfo:
-                case eNkMAIDCapability.kNkMAIDCapability_Aperture:
-                case eNkMAIDCapability.kNkMAIDCapability_FocalLength:
-                    Logger.Debug($"Lens info changed: {capability}");
-                    LensStateChanged?.Invoke(this, EventArgs.Empty);
-                    break;
-            }
-        }
 
         public void AbortExposure() {
             if (Connected) {
@@ -934,8 +885,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     using (token.Register(() => _cameraConnected.TrySetCanceled())) {
                         await _cameraConnected.Task;
                     }
-
-                    _camera.CapabilityValueChanged += new CapabilityChangedDelegate(ScanDeviceCapabilitiyValue);
 
                     Logger.Debug($"Camera connection task returned successfully with result {_cameraConnected.Task.Result}");
                     connected = _cameraConnected.Task.Result;

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -443,36 +443,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                                 profileService.ActiveProfile.CameraSettings.PixelSize = Cam.PixelSizeX;
                             }
 
-                            if (Cam is PersistSettingsCameraDecorator p) {
-                                if (p.Camera is NikonCamera nikonCamera) {
-                                    if (nikonCamera.LensName.Length > 0) {
-                                        profileService.ActiveProfile.TelescopeSettings.Name = nikonCamera.LensName;
-                                    }
-
-                                    if (nikonCamera.LensFocalLength > 0) {
-                                        profileService.ActiveProfile.TelescopeSettings.FocalLength = nikonCamera.LensFocalLength;
-                                    }
-
-                                    if (nikonCamera.LensFocalRatio > 0) {
-                                        profileService.ActiveProfile.TelescopeSettings.FocalRatio = nikonCamera.LensFocalRatio;
-                                    }
-
-                                    nikonCamera.LensStateChanged += (object sender, EventArgs e) => {
-                                        if (nikonCamera.LensName.Length > 0) {
-                                            profileService.ActiveProfile.TelescopeSettings.Name = nikonCamera.LensName;
-                                        }
-
-                                        if (nikonCamera.LensFocalLength > 0) {
-                                            profileService.ActiveProfile.TelescopeSettings.FocalLength = nikonCamera.LensFocalLength;
-                                        }
-
-                                        if (nikonCamera.LensFocalRatio > 0) {
-                                            profileService.ActiveProfile.TelescopeSettings.FocalRatio = nikonCamera.LensFocalRatio;
-                                        }
-                                    };
-                                }
-                            }
-
                             BroadcastCameraInfo();
 
                             if (Cam.CanSetTemperature) {


### PR DESCRIPTION
Remove the partially working Nikon Focal Length auto-update.
Also, remove auto-update for Lens Name and Focal Ratio to prevent confusion on what to manually input.

Tested on Z6 II.