### PR TITLE
Add Annotation instruction metadata copy

### DIFF
--- a/NINA.Sequencer/SequenceItem/Utility/Annotation.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/Annotation.cs
@@ -36,6 +36,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         public Annotation() { }
 
         private Annotation(Annotation cloneMe) : base(cloneMe) {
+            CopyMetaData(cloneMe);
         }
 
         [JsonProperty]


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

The Annotation instruction was missing its `CopyMetaData()` call, causing it to lose its contents if moved around. Reported in issue #115  

## 🧪 How Was It Tested?

Added an Annotation instruction to a sequence and moved it to a new position in it

## ✅ PR Checklist

- [x ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

Closes #115 
