### PR TITLE
Add Wait Until Telescope Parked sequencer instruction

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -4390,6 +4390,15 @@ In case a longer duration is needed, a duration can be specified and the applica
   <data name="Lbl_SequenceItem_Telescope_ParkScope_Name" xml:space="preserve">
     <value>Park Scope</value>
   </data>
+  <data name="Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Description" xml:space="preserve">
+    <value>Waits until the telescope is confirmed to be in park position before continuing</value>
+  </data>
+  <data name="Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Name" xml:space="preserve">
+    <value>Wait Until Telescope Parked</value>
+  </data>
+  <data name="Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Waiting" xml:space="preserve">
+    <value>Waiting for telescope to park...</value>
+  </data>
   <data name="Lbl_SequenceItem_Telescope_SlewScopeToAltAz_Description" xml:space="preserve">
     <value>Slews the telescope to the given altitude and azimuth coordinates</value>
   </data>

--- a/NINA.Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParked.cs
+++ b/NINA.Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParked.cs
@@ -1,0 +1,97 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using NINA.Core.Model;
+using NINA.Sequencer.Validations;
+using NINA.Equipment.Interfaces.Mediator;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using NINA.Core.Locale;
+
+namespace NINA.Sequencer.SequenceItem.Telescope {
+
+    [ExportMetadata("Name", "Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Name")]
+    [ExportMetadata("Description", "Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Description")]
+    [ExportMetadata("Icon", "ParkSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_Telescope")]
+    [Export(typeof(ISequenceItem))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public class WaitUntilTelescopeParked : SequenceItem, IValidatable {
+
+        [ImportingConstructor]
+        public WaitUntilTelescopeParked(ITelescopeMediator telescopeMediator) {
+            this.telescopeMediator = telescopeMediator;
+        }
+
+        private WaitUntilTelescopeParked(WaitUntilTelescopeParked cloneMe) : this(cloneMe.telescopeMediator) {
+            CopyMetaData(cloneMe);
+        }
+
+        public override object Clone() {
+            return new WaitUntilTelescopeParked(this);
+        }
+
+        private ITelescopeMediator telescopeMediator;
+        private IList<string> issues = new List<string>();
+
+        public IList<string> Issues {
+            get => issues;
+            set {
+                issues = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public override async Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+            // Poll until telescope is parked
+            while (true) {
+                token.ThrowIfCancellationRequested();
+
+                var info = telescopeMediator.GetInfo();
+
+                if (info.AtPark) {
+                    // Telescope is parked, we can continue
+                    return;
+                }
+
+                // Report status while waiting
+                progress?.Report(new ApplicationStatus { Status = Loc.Instance["Lbl_SequenceItem_Telescope_WaitUntilTelescopeParked_Waiting"] });
+
+                // Wait 1 second before checking again
+                await Task.Delay(1000, token);
+            }
+        }
+
+        public bool Validate() {
+            var i = new List<string>();
+            if (!telescopeMediator.GetInfo().Connected) {
+                i.Add(Loc.Instance["LblTelescopeNotConnected"]);
+            }
+            Issues = i;
+            return i.Count == 0;
+        }
+
+        public override void AfterParentChanged() {
+            Validate();
+        }
+
+        public override string ToString() {
+            return $"Category: {Category}, Item: {nameof(WaitUntilTelescopeParked)}";
+        }
+    }
+}

--- a/NINA.Test/Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParkedTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParkedTest.cs
@@ -1,0 +1,130 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2024 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Sequencer;
+using NINA.Core.Model;
+using NINA.Sequencer.SequenceItem.Telescope;
+using NINA.Equipment.Interfaces.Mediator;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Test.Sequencer.SequenceItem.Telescope {
+
+    [TestFixture]
+    internal class WaitUntilTelescopeParkedTest {
+        public Mock<ITelescopeMediator> telescopeMediatorMock;
+
+        [SetUp]
+        public void Setup() {
+            telescopeMediatorMock = new Mock<ITelescopeMediator>();
+        }
+
+        [Test]
+        public void Clone_ItemClonedProperly() {
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+            sut.Name = "SomeName";
+            sut.Description = "SomeDescription";
+            sut.Icon = new System.Windows.Media.GeometryGroup();
+            var item2 = (WaitUntilTelescopeParked)sut.Clone();
+
+            item2.Should().NotBeSameAs(sut);
+            item2.Name.Should().BeSameAs(sut.Name);
+            item2.Description.Should().BeSameAs(sut.Description);
+            item2.Icon.Should().BeSameAs(sut.Icon);
+        }
+
+        [Test]
+        public void Validate_NoIssues() {
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true });
+
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+            var valid = sut.Validate();
+
+            valid.Should().BeTrue();
+
+            sut.Issues.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Validate_NotConnected_OneIssue() {
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = false });
+
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+            var valid = sut.Validate();
+
+            valid.Should().BeFalse();
+
+            sut.Issues.Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task Execute_AlreadyParked_ReturnsImmediately() {
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, AtPark = true });
+
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+            await sut.Execute(default, default);
+
+            // Should only call GetInfo once since telescope is already parked
+            telescopeMediatorMock.Verify(x => x.GetInfo(), Times.Once);
+        }
+
+        [Test]
+        public async Task Execute_NotParked_WaitsUntilParked() {
+            var callCount = 0;
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(() => {
+                callCount++;
+                // Return not parked for first 2 calls, then parked
+                return new TelescopeInfo() { Connected = true, AtPark = callCount >= 3 };
+            });
+
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await sut.Execute(default, cts.Token);
+
+            // Should have polled multiple times before telescope was parked
+            callCount.Should().BeGreaterOrEqualTo(3);
+        }
+
+        [Test]
+        public async Task Execute_Cancelled_ThrowsOperationCancelled() {
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, AtPark = false });
+
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Func<Task> act = async () => await sut.Execute(default, cts.Token);
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Test]
+        public void GetEstimatedDuration_ReturnsZero() {
+            var sut = new WaitUntilTelescopeParked(telescopeMediatorMock.Object);
+
+            var duration = sut.GetEstimatedDuration();
+
+            duration.Should().Be(TimeSpan.Zero);
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,12 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 
 ## Features
 
+### **Sequencer**
+- **Wait Until Telescope Parked Instruction**
+  - New sequencer instruction that blocks execution until the telescope confirms it is in the park position.
+  - Useful in end-of-session sequences to ensure the mount is fully parked before closing a roll-off roof or dome shutter.
+  - Prevents potential equipment damage from closing the roof while the telescope is still moving to park.
+
 ### **Device Management**
 - **ASCOM Alpaca Direct Drivers**
     - In case your ASCOM Alpaca specific device has a static IP or doesn't offer Alpaca Discovery a new static entry is available for each device type to pick from where you can specify the address to connect to instead of having to rely on discovery


### PR DESCRIPTION
## Summary

- New sequencer instruction that blocks execution until the telescope confirms it is in the park position
- Useful in end-of-session sequences to ensure the mount is fully parked before closing a roll-off roof or dome shutter
- Prevents potential equipment damage from closing the roof while the telescope is still moving to park

## Changes

- `NINA.Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParked.cs` - New instruction that polls `TelescopeInfo.AtPark` until true
- `NINA.Core/Locale/Locale.resx` - Added localization strings for name, description, and status message
- `NINA.Test/Sequencer/SequenceItem/Telescope/WaitUntilTelescopeParkedTest.cs` - Unit tests (7 tests covering clone, validation, execution, and cancellation)
- `RELEASE_NOTES.md` - Added feature description under Sequencer section

## Test plan

- [x] All 7 new unit tests pass
- [x] All 3314 existing tests still pass (3 skipped as expected)
- [ ] Manual testing with actual telescope hardware (to be done at observatory)

## Use Case

When using a roll-off roof observatory, the default NINA end-of-session template runs `Park Scope` and `Close Dome Shutter` in parallel. This can be dangerous if the roof closes before the mount finishes parking. 

This new instruction can be placed between `Park Scope` and `Close Dome Shutter` to ensure the telescope is confirmed parked before proceeding with roof closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)