### PR TITLE
[3.3] Framing Assistant: Save catalogue visibility to profile settings & add show all catalogues toggle

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -6966,6 +6966,9 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblToggleCatalogueDisplay" xml:space="preserve">
     <value>Toggle Catalogue Display</value>
   </data>
+  <data name="LblToggleShowAllCatalogues" xml:space="preserve">
+    <value>Show all catalogues</value>
+  </data>
   <data name="LblTargetAlt" xml:space="preserve">
     <value>Target Alt</value>
   </data>

--- a/NINA.Profile/FramingAssistantSettings.cs
+++ b/NINA.Profile/FramingAssistantSettings.cs
@@ -13,8 +13,10 @@
 #endregion "copyright"
 
 using NINA.Core.Enum;
+using NINA.Core.Utility;
 using NINA.Profile.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace NINA.Profile {
@@ -184,5 +186,17 @@ namespace NINA.Profile {
                 }
             }
         }
+
+        private List<string> disabledCatalogues;
+
+        [DataMember]
+        public List<string> DisabledCatalogues {
+            get => disabledCatalogues ?? (disabledCatalogues = new List<string>());
+            set {
+                disabledCatalogues = value;
+                RaisePropertyChanged();
+            }
+        }
+
     }
 }

--- a/NINA.Profile/FramingAssistantSettings.cs
+++ b/NINA.Profile/FramingAssistantSettings.cs
@@ -13,7 +13,6 @@
 #endregion "copyright"
 
 using NINA.Core.Enum;
-using NINA.Core.Utility;
 using NINA.Profile.Interfaces;
 using System;
 using System.Collections.Generic;

--- a/NINA.Profile/Interfaces/IFramingAssistantSettings.cs
+++ b/NINA.Profile/Interfaces/IFramingAssistantSettings.cs
@@ -13,9 +13,7 @@
 #endregion "copyright"
 
 using NINA.Core.Enum;
-using NINA.Core.Utility;
 using System.Collections.Generic;
-using System.Windows.Documents;
 
 namespace NINA.Profile.Interfaces {
 

--- a/NINA.Profile/Interfaces/IFramingAssistantSettings.cs
+++ b/NINA.Profile/Interfaces/IFramingAssistantSettings.cs
@@ -13,6 +13,9 @@
 #endregion "copyright"
 
 using NINA.Core.Enum;
+using NINA.Core.Utility;
+using System.Collections.Generic;
+using System.Windows.Documents;
 
 namespace NINA.Profile.Interfaces {
 
@@ -28,5 +31,6 @@ namespace NINA.Profile.Interfaces {
         bool AnnotateConstellations { get; set; }
         bool AnnotateDSO { get; set; }
         bool AnnotateGrid { get; set; }
+        List<string> DisabledCatalogues { get; set; }
     }
 }

--- a/NINA.WPF.Base/Interfaces/ViewModel/ISkyMapAnnotator.cs
+++ b/NINA.WPF.Base/Interfaces/ViewModel/ISkyMapAnnotator.cs
@@ -33,6 +33,7 @@ namespace NINA.WPF.Base.Interfaces.ViewModel {
         bool AnnotateDSO { get; set; }
         bool AnnotateGrid { get; set; }
         bool UseCachedImages { get; set; }
+        bool ShowAllCatalogues { get; set; }
         IList<ActiveCatalogue> ActiveCatalogues { get; set; }
         List<FramingConstellationBoundary> ConstellationBoundariesInViewPort { get; }
         List<FramingConstellation> ConstellationsInViewport { get; }

--- a/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
+++ b/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
@@ -102,6 +102,16 @@ namespace NINA.WPF.Base.SkySurvey {
                 }
             }
 
+            if(ActiveCatalogues != null) { 
+                if (ActiveCatalogues.All(c => c.Active)) {
+                    ShowAllCatalogues = true;
+                    OnPropertyChanged(nameof(ShowAllCatalogues));
+                } else if (ActiveCatalogues.All(c => !c.Active)) {
+                    ShowAllCatalogues = false;
+                    OnPropertyChanged(nameof(ShowAllCatalogues));
+                }
+            }
+
             ConstellationsInViewport.Clear();
             ClearFrameLineMatrix();
 
@@ -176,6 +186,9 @@ namespace NINA.WPF.Base.SkySurvey {
         [ObservableProperty]
         private BitmapSource skyMapOverlay;
 
+        [ObservableProperty]
+        private bool showAllCatalogues = true;
+
         partial void OnAnnotateConstellationBoundariesChanged(bool oldValue, bool newValue) {
             if (profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellationBoundaries != newValue)
                 profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellationBoundaries = newValue;
@@ -194,6 +207,15 @@ namespace NINA.WPF.Base.SkySurvey {
         partial void OnAnnotateGridChanged(bool oldValue, bool newValue) {
             if (profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid != newValue)
                 profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid = newValue;
+        }
+        
+        partial void OnShowAllCataloguesChanged(bool oldValue, bool newValue) {
+
+            if (ActiveCatalogues is null) return;
+
+            foreach (var c in ActiveCatalogues)
+                c.Active = newValue;
+
         }
 
         private void LoadSettings() {

--- a/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
+++ b/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
@@ -92,24 +92,25 @@ namespace NINA.WPF.Base.SkySurvey {
             }
 
             if (ActiveCatalogues == null) {
-                ActiveCatalogues = (await dbInstance.GetCatalogues(50, ct))?.Select(x => new ActiveCatalogue(x, true)).ToList() ?? new List<ActiveCatalogue>();
-                foreach (var item in ActiveCatalogues) {
-                    item.PropertyChanged += (sender, e) => {
+                var catalogues = await dbInstance.GetCatalogues(50, ct);
+                var settings = profileService.ActiveProfile.FramingAssistantSettings;
+
+                ActiveCatalogues = catalogues?.Select(x => {
+
+                    bool isActive = !settings.DisabledCatalogues.Contains(x);
+                    var activeCat = new ActiveCatalogue(x, isActive);
+
+                    activeCat.PropertyChanged += (s, e) => {
                         if (e.PropertyName == nameof(ActiveCatalogue.Active)) {
+                            SaveDisabledCatalogues();
                             UpdateSkyMap();
                         }
                     };
-                }
-            }
 
-            if(ActiveCatalogues != null) { 
-                if (ActiveCatalogues.All(c => c.Active)) {
-                    ShowAllCatalogues = true;
-                    OnPropertyChanged(nameof(ShowAllCatalogues));
-                } else if (ActiveCatalogues.All(c => !c.Active)) {
-                    ShowAllCatalogues = false;
-                    OnPropertyChanged(nameof(ShowAllCatalogues));
-                }
+                    return activeCat;
+                }).ToList() ?? new List<ActiveCatalogue>();
+
+                UpdateShowAllCataloguesState();
             }
 
             ConstellationsInViewport.Clear();
@@ -188,6 +189,8 @@ namespace NINA.WPF.Base.SkySurvey {
 
         [ObservableProperty]
         private bool showAllCatalogues = true;
+        private List<string> DisabledCatalogues =>
+               profileService.ActiveProfile.FramingAssistantSettings?.DisabledCatalogues ?? new List<string>();
 
         partial void OnAnnotateConstellationBoundariesChanged(bool oldValue, bool newValue) {
             if (profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellationBoundaries != newValue)
@@ -208,14 +211,43 @@ namespace NINA.WPF.Base.SkySurvey {
             if (profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid != newValue)
                 profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid = newValue;
         }
-        
+
         partial void OnShowAllCataloguesChanged(bool oldValue, bool newValue) {
+            if (ActiveCatalogues == null) return;
 
-            if (ActiveCatalogues is null) return;
+            foreach (var catalogue in ActiveCatalogues) {
+                catalogue.Active = newValue;
+            }
 
-            foreach (var c in ActiveCatalogues)
-                c.Active = newValue;
+            SaveDisabledCatalogues();
+            UpdateSkyMap();
+        }
+        private void SaveDisabledCatalogues() {
 
+            if (ActiveCatalogues == null) return;
+
+            var settings = profileService.ActiveProfile.FramingAssistantSettings;
+            settings.DisabledCatalogues = ActiveCatalogues
+                .Where(x => !x.Active)
+                .Select(x => x.Name)
+                .ToList();
+        }
+        private void UpdateShowAllCataloguesState() {
+
+            if (ActiveCatalogues == null || !ActiveCatalogues.Any()) return;
+
+            bool newState;
+            if (ActiveCatalogues.All(c => c.Active)) {
+                newState = true;
+            } else if (ActiveCatalogues.All(c => !c.Active)) {
+                newState = false;
+            } else {
+                return;
+            }
+
+            if (ShowAllCatalogues != newState) {
+                ShowAllCatalogues = newState;
+            }
         }
 
         private void LoadSettings() {
@@ -223,7 +255,7 @@ namespace NINA.WPF.Base.SkySurvey {
                 profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellationBoundaries;
             AnnotateConstellations = profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellations;
             AnnotateDSO = profileService.ActiveProfile.FramingAssistantSettings.AnnotateDSO;
-            AnnotateGrid = profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid;
+            AnnotateGrid = profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid;    
         }
 
         /// <summary>

--- a/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
+++ b/NINA.WPF.Base/SkySurvey/SkyMapAnnotator.cs
@@ -255,7 +255,7 @@ namespace NINA.WPF.Base.SkySurvey {
                 profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellationBoundaries;
             AnnotateConstellations = profileService.ActiveProfile.FramingAssistantSettings.AnnotateConstellations;
             AnnotateDSO = profileService.ActiveProfile.FramingAssistantSettings.AnnotateDSO;
-            AnnotateGrid = profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid;    
+            AnnotateGrid = profileService.ActiveProfile.FramingAssistantSettings.AnnotateGrid;
         }
 
         /// <summary>

--- a/NINA/View/FramingAssistantView.xaml
+++ b/NINA/View/FramingAssistantView.xaml
@@ -1228,30 +1228,53 @@
                         Margin="5"
                         Header="{ns:Loc LblToggleCatalogueDisplay}"
                         Visibility="{Binding SkyMapAnnotator.Initialized, Converter={StaticResource VisibilityConverter}}">
-                        <ItemsControl Margin="15,5,5,5" ItemsSource="{Binding SkyMapAnnotator.ActiveCatalogues}">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <WrapPanel />
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" SharedSizeGroup="Catalogue" />
-                                            <ColumnDefinition />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="{Binding Name}" />
-                                        <CheckBox
-                                            Grid.Column="1"
-                                            Margin="0,0,5,0"
-                                            HorizontalAlignment="Left"
-                                            IsChecked="{Binding Active, Mode=TwoWay}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-
+                        <StackPanel Orientation="Vertical">
+                            <!--  Show/Hide All Checkbox  -->
+                            <StackPanel Margin="15,5,5,0" Orientation="Horizontal">
+                                <TextBlock
+                                    Margin="0,0,10,0"
+                                    VerticalAlignment="Center"
+                                    Text="{ns:Loc LblToggleShowAllCatalogues}" />
+                                <CheckBox HorizontalAlignment="Left" IsChecked="{Binding SkyMapAnnotator.ShowAllCatalogues, Mode=TwoWay}" />
+                            </StackPanel>
+                            <!--
+                            <Grid Margin="15,5,5,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Catalogue" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock VerticalAlignment="Center" Text="Show/hide all" />
+                                <CheckBox
+                                    Grid.Column="1"
+                                    Margin="2,0,10,0"
+                                    HorizontalAlignment="Left"
+                                    IsChecked="{Binding SkyMapAnnotator.ShowAllCatalogues, Mode=TwoWay}" />
+                            </Grid>
+                            -->
+                            <ItemsControl Margin="15,5,5,5" ItemsSource="{Binding SkyMapAnnotator.ActiveCatalogues}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="Catalogue" />
+                                                <ColumnDefinition />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
+                                            <CheckBox
+                                                Grid.Column="1"
+                                                Margin="2,0,10,0"
+                                                HorizontalAlignment="Left"
+                                                IsChecked="{Binding Active, Mode=TwoWay}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
                     </Expander>
                 </Grid>
 

--- a/NINA/View/FramingAssistantView.xaml
+++ b/NINA/View/FramingAssistantView.xaml
@@ -1237,20 +1237,6 @@
                                     Text="{ns:Loc LblToggleShowAllCatalogues}" />
                                 <CheckBox HorizontalAlignment="Left" IsChecked="{Binding SkyMapAnnotator.ShowAllCatalogues, Mode=TwoWay}" />
                             </StackPanel>
-                            <!--
-                            <Grid Margin="15,5,5,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Catalogue" />
-                                    <ColumnDefinition />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock VerticalAlignment="Center" Text="Show/hide all" />
-                                <CheckBox
-                                    Grid.Column="1"
-                                    Margin="2,0,10,0"
-                                    HorizontalAlignment="Left"
-                                    IsChecked="{Binding SkyMapAnnotator.ShowAllCatalogues, Mode=TwoWay}" />
-                            </Grid>
-                            -->
                             <ItemsControl Margin="15,5,5,5" ItemsSource="{Binding SkyMapAnnotator.ActiveCatalogues}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,7 +40,8 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
 - **Sky Atlas Improvements**  
   - Deep sky objects can now be filtered and sorted by their upper transit time
 - **Framing Assistant Improvements** 
-  - In HiPS 2 FITS Sky Survey different HiPS sky maps can now be selected like CTA-FRAM, Mellinger, Northern Sky Narrowband Survey and more for better target planning. 
+  - In HiPS 2 FITS Sky Survey different HiPS sky maps can now be selected like CTA-FRAM, Mellinger, Northern Sky Narrowband Survey and more for better target planning.
+  - Toogle Catalogue Display: visibility of individual catalogues is no stored in settings and a new "show all catalogues" toogle been added   
 - **New Toast Notification System**
   - Replaced the external ToastNotifications package with a fully native WPF implementation.
   - Improved reliability, lifetime handling, and positioning across multiple monitors.


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose
Currently, catalogue visibility is always initialized as enabled as the list is dynamically generated from the catalogue database. As a result, users must manually disable each catalogue individually on every start-up, and the visibility changes are not stored.

There have been multiple requests to make the visibility state of individual catalogues persistent and to provide a global “Show all” toggle.

This PR introduces persistence for individual catalogue visibility and adds a global toggle to quickly enable or disable all catalogues at once.

## 🧪 How Was It Tested?

manually tested with different catalogue visibility settings as well as with newly created profile.

## ✅ PR Checklist

- [X] All unit tests pass (3.277 passed, 3 ignored)
- [X] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [X] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots
<img width="420" height="288" alt="show all catalogues off" src="https://github.com/user-attachments/assets/bc56f47d-446d-4496-a9f5-f1dbe12a7b27" />

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
