### PR TITLE
Added support for ZStandard compression in XISF files

### DIFF
--- a/NINA.Core/Enum/XISFFeaturesEnum.cs
+++ b/NINA.Core/Enum/XISFFeaturesEnum.cs
@@ -30,7 +30,10 @@ namespace NINA.Core.Enum {
         LZ4HC,
 
         [Description("LblCompressionZLib")]
-        ZLIB
+        ZLIB,
+
+        [Description("LblCompressionZStandard")]
+        ZSTD
     }
 
     [TypeConverter(typeof(EnumDescriptionTypeConverter))]

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7453,4 +7453,7 @@ If exposure count is not important to you, enable this option to avoid having to
   <data name="LblNotificationApplication" xml:space="preserve">
     <value>Application</value>
   </data>
+  <data name="LblCompressionZStandard" xml:space="preserve">
+    <value>ZStandard</value>
+  </data>
 </root>

--- a/NINA.Image/FileFormat/XISF/XISF.cs
+++ b/NINA.Image/FileFormat/XISF/XISF.cs
@@ -331,6 +331,16 @@ namespace NINA.Image.FileFormat.XISF {
                     info.IsShuffled = true;
                     break;
 
+                case "zstd":
+                    info.CompressionType = XISFCompressionTypeEnum.ZSTD;
+                    break;
+
+                case "zstd+sh":
+                    info.CompressionType = XISFCompressionTypeEnum.ZSTD;
+                    info.ItemSize = int.Parse(compression[2]);
+                    info.IsShuffled = true;
+                    break;
+
                 default:
                     throw new InvalidDataException();
             }
@@ -431,6 +441,11 @@ namespace NINA.Image.FileFormat.XISF {
                         case XISFCompressionTypeEnum.ZLIB:
                             outArray = ZlibStream.UncompressBuffer(raw);
                             break;
+                        case XISFCompressionTypeEnum.ZSTD: {
+                            using var decompressor = new ZstdSharp.Decompressor();
+                            outArray = decompressor.Unwrap(raw).ToArray();
+                            break;
+                        }
                     }
                 }
             }

--- a/NINA.Image/FileFormat/XISF/XISFData.cs
+++ b/NINA.Image/FileFormat/XISF/XISFData.cs
@@ -173,6 +173,16 @@ namespace NINA.Image.FileFormat.XISF {
                     }
 
                     outArray = ZlibStream.CompressBuffer(byteArray);
+                } else if (CompressionType == XISFCompressionTypeEnum.ZSTD) {
+                    if (ByteShuffling) {
+                        CompressionName = "zstd+sh";
+                        byteArray = Shuffle(byteArray, ShuffleItemSize);
+                    } else {
+                        CompressionName = "zstd";
+                    }
+
+                    using var compressor = new ZstdSharp.Compressor(1);
+                    outArray = compressor.Wrap(byteArray).ToArray();
                 } else {
                     outArray = new byte[byteArray.Length];
                     Array.Copy(byteArray, outArray, outArray.Length);

--- a/NINA.Image/NINA.Image.csproj
+++ b/NINA.Image/NINA.Image.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.7" />
   </ItemGroup>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/NINA.Setup/Product.wxs
+++ b/NINA.Setup/Product.wxs
@@ -1446,6 +1446,9 @@
       <Component Id="wpfgfx_cor3.dll" Guid="0472e370-5dd8-4ee9-ba87-10fae5e3f89a">
         <File Id="wpfgfx_cor3.dll" Name="wpfgfx_cor3.dll" Source="$(var.NINA_TargetDir)wpfgfx_cor3.dll" />
       </Component>
+      <Component Id="ZstdSharp.dll" Guid="1b50b5b3-72f9-4a62-99e3-be76b50ad9fa">
+        <File Id="ZstdSharp.dll" Name="ZstdSharp.dll" Source="$(var.NINA_TargetDir)ZstdSharp.dll" />
+      </Component>
     </ComponentGroup>
   </Fragment>
   <Fragment>

--- a/NINA.Test/XISFTest.cs
+++ b/NINA.Test/XISFTest.cs
@@ -310,6 +310,63 @@ namespace NINA.Test {
         }
 
         [Test]
+        public void XISFCompressZStdTest() {
+            const int imgSize = 128;
+            var props = new ImageProperties(width: imgSize, height: imgSize, bitDepth: 16, isBayered: false, gain: 0, offset: 0);
+            const string imageType = "LIGHT";
+            var data = new ushort[imgSize * imgSize];
+            var length = data.Length * sizeof(ushort);
+
+            var fileSaveInfo = new FileSaveInfo {
+                FilePath = string.Empty,
+                FilePattern = string.Empty,
+                FileType = NINA.Core.Enum.FileTypeEnum.XISF,
+                XISFCompressionType = NINA.Core.Enum.XISFCompressionTypeEnum.ZSTD
+            };
+
+            for (ushort i = 0; i < data.Length; i++) {
+                data[i] = ushort.MaxValue;
+            }
+
+            var header = new XISFHeader();
+            header.AddImageMetaData(props, imageType);
+            var sut = new XISF(header);
+            sut.AddAttachedImage(data, fileSaveInfo);
+
+            sut.Header.Image.Should().HaveAttribute("compression", $"zstd:{length}");
+            sut.Header.Image.Should().HaveAttribute("location", $"attachment:{sut.PaddedBlockSize}:{sut.Data.Data.Length}");
+        }
+
+        [Test]
+        public void XISFCompressZStdShuffledTest() {
+            const int imgSize = 128;
+            var props = new ImageProperties(width: imgSize, height: imgSize, bitDepth: 16, isBayered: false, gain: 0, offset: 0);
+            const string imageType = "LIGHT";
+            var data = new ushort[imgSize * imgSize];
+            var length = data.Length * sizeof(ushort);
+
+            var fileSaveInfo = new FileSaveInfo {
+                FilePath = string.Empty,
+                FilePattern = string.Empty,
+                FileType = NINA.Core.Enum.FileTypeEnum.XISF,
+                XISFCompressionType = NINA.Core.Enum.XISFCompressionTypeEnum.ZSTD,
+                XISFByteShuffling = true
+            };
+
+            for (ushort i = 0; i < data.Length; i++) {
+                data[i] = ushort.MaxValue;
+            }
+
+            var header = new XISFHeader();
+            header.AddImageMetaData(props, imageType);
+            var sut = new XISF(header);
+            sut.AddAttachedImage(data, fileSaveInfo);
+
+            sut.Header.Image.Should().HaveAttribute("compression", $"zstd+sh:{length}:{sizeof(ushort)}");
+            sut.Header.Image.Should().HaveAttribute("location", $"attachment:{sut.PaddedBlockSize}:{sut.Data.Data.Length}");
+        }
+
+        [Test]
         public void XISFChecksumSHA1Test() {
             const int imgSize = 128;
             var props = new ImageProperties(width: imgSize, height: imgSize, bitDepth: 16, isBayered: false, gain: 0, offset: 0);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,10 @@ More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">n
   - Added configurable notification placement: primary screen, same screen as the app, or application window, as well as adjustable corner positioning via Options > General > Advanced.
   - Notifications now reposition automatically on window moves, DPI changes, and display configuration changes.
 
+### File formats
+- **XISF ZStandard Compression**
+  - Added support for ZStandard compression in XISF files.
+
 
 # Version 3.2
 


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->
Saved and opened images compressed with ZStandard selected and verified in PixInsight that they load properly.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
Compression Level 1 already yields a significant compression ratio while being blazing fast. 
On my test image increasing the level did not yield any further benefit while taking significantly longer.
Uncompressed image is around 50Mb while the compressed image results in 19.50Mb (byte shuffle on)
