### PR TITLE
Improve date precision, time scale handling, and rise/set robustness

### DIFF
--- a/NINA.Astrometry/AstroUtil.cs
+++ b/NINA.Astrometry/AstroUtil.cs
@@ -630,7 +630,7 @@ namespace NINA.Astrometry {
             var jdTt = GetJulianDateTT(date);
             var error = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
             if (error != 0) {
-                Logger.Error("Error calculating moon position - Novas return code: " + error);
+                Logger.Warning($"Failed to calculate moon position for date {date}, latitude {observerInfo.Latitude}, longitude {observerInfo.Longitude}, elevation {observerInfo.Elevation}, temperature {observerInfo.Temperature}, pressure {observerInfo.Pressure} - Novas return code: " + error);
             }
 
             return skyPosition;
@@ -641,15 +641,15 @@ namespace NINA.Astrometry {
             return GetSunPosition(date, oberverInfo);
         }
 
-        public static NOVAS.SkyPosition GetSunPosition(DateTime date, ObserverInfo oberverInfo) {
+        public static NOVAS.SkyPosition GetSunPosition(DateTime date, ObserverInfo observerInfo) {
             var deltaT = DeltaT(date);
 
             var onSurface = new NOVAS.OnSurface() {
-                Latitude = oberverInfo.Latitude,
-                Longitude = oberverInfo.Longitude,
-                Height = oberverInfo.Elevation,
-                Temperature = oberverInfo.Temperature,
-                Pressure = oberverInfo.Pressure
+                Latitude = observerInfo.Latitude,
+                Longitude = observerInfo.Longitude,
+                Height = observerInfo.Elevation,
+                Temperature = observerInfo.Temperature,
+                Pressure = observerInfo.Pressure
             };
 
             var obs = new NOVAS.Observer() {
@@ -669,7 +669,7 @@ namespace NINA.Astrometry {
             var jdTt = GetJulianDateTT(date);
             var error = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
             if (error != 0) {
-                Logger.Error("Error calculating moon position - Novas return code: " + error);
+                Logger.Warning($"Failed to calculate sun position for date {date}, latitude {observerInfo.Latitude}, longitude {observerInfo.Longitude}, elevation {observerInfo.Elevation}, temperature {observerInfo.Temperature}, pressure {observerInfo.Pressure} - Novas return code: " + error);
             }
 
             return skyPosition;

--- a/NINA.Astrometry/AstroUtil.cs
+++ b/NINA.Astrometry/AstroUtil.cs
@@ -378,7 +378,7 @@ namespace NINA.Astrometry {
 
         public static RiseAndSetEvent GetNightTimes(DateTime date, double latitude, double longitude, double elevation) {
             var riseAndSet = new AstronomicalTwilightRiseAndSet(date, latitude, longitude, elevation);
-            var t = riseAndSet.Calculate().Result;
+            var t = riseAndSet.Calculate();
 
             return riseAndSet;
         }
@@ -390,7 +390,7 @@ namespace NINA.Astrometry {
 
         public static RiseAndSetEvent GetNauticalNightTimes(DateTime date, double latitude, double longitude, double elevation) {
             var riseAndSet = new NauticalTwilightRiseAndSet(date, latitude, longitude, elevation);
-            var t = riseAndSet.Calculate().Result;
+            var t = riseAndSet.Calculate();
 
             return riseAndSet;
         }
@@ -402,7 +402,7 @@ namespace NINA.Astrometry {
 
         public static RiseAndSetEvent GetCivilNightTimes(DateTime date, double latitude, double longitude, double elevation) {
             var riseAndSet = new CivilTwilightRiseAndSet(date, latitude, longitude, elevation);
-            var t = riseAndSet.Calculate().Result;
+            var t = riseAndSet.Calculate();
 
             return riseAndSet;
         }
@@ -415,7 +415,7 @@ namespace NINA.Astrometry {
 
         public static RiseAndSetEvent GetMoonRiseAndSet(DateTime date, double latitude, double longitude, double elevation) {
             var riseAndSet = new MoonRiseAndSet(date, latitude, longitude, elevation);
-            var t = riseAndSet.Calculate().Result;
+            var t = riseAndSet.Calculate();
 
             return riseAndSet;
         }
@@ -428,7 +428,7 @@ namespace NINA.Astrometry {
 
         public static RiseAndSetEvent GetSunRiseAndSet(DateTime date, double latitude, double longitude, double elevation) {
             var riseAndSet = new SunRiseAndSet(date, latitude, longitude, elevation);
-            var t = riseAndSet.Calculate().Result;
+            var t = riseAndSet.Calculate();
 
             return riseAndSet;
         }

--- a/NINA.Astrometry/AstroUtil.cs
+++ b/NINA.Astrometry/AstroUtil.cs
@@ -127,8 +127,48 @@ namespace NINA.Astrometry {
         }
 
         public static double GetJulianDate(DateTime date) {
-            var utcdate = date.ToUniversalTime();
-            return NOVAS.JulianDate((short)utcdate.Year, (short)utcdate.Month, (short)utcdate.Day, utcdate.Hour + utcdate.Minute / 60.0 + utcdate.Second / 60.0 / 60.0 + utcdate.Millisecond / 60.0 / 60.0 / 1000.0);
+            var (utc1, utc2) = GetJulianDateUTCParts(date);
+            return utc1 + utc2;
+        }
+
+        public static double GetSecondOfMinuteWithFraction(DateTime date) {
+            return date.Second + (date.Ticks % TimeSpan.TicksPerSecond) / (double)TimeSpan.TicksPerSecond;
+        }
+
+        public static (double, double) GetJulianDateUTCParts(DateTime date) {
+            var utcDate = date.ToUniversalTime();
+            double utc1 = 0, utc2 = 0;
+            SOFA.Dtf2d(
+                "UTC",
+                utcDate.Year, utcDate.Month, utcDate.Day,
+                utcDate.Hour, utcDate.Minute,
+                GetSecondOfMinuteWithFraction(utcDate),
+                ref utc1, ref utc2);
+            return (utc1, utc2);
+        }
+
+        public static double GetJulianDateTT(DateTime date) {
+            var (tt1, tt2) = GetJulianDateTTParts(date);
+            return tt1 + tt2;
+        }
+
+
+        public static (double, double) GetJulianDateTTParts(DateTime date) {
+            var utcDate = date.ToUniversalTime();
+            double tai1 = 0, tai2 = 0, tt1 = 0, tt2 = 0;
+
+            double utc1 = 0, utc2 = 0;
+            SOFA.Dtf2d(
+                "UTC",
+                utcDate.Year, utcDate.Month, utcDate.Day,
+                utcDate.Hour, utcDate.Minute,
+                GetSecondOfMinuteWithFraction(utcDate),
+                ref utc1, ref utc2);
+
+            SOFA.UtcTai(utc1, utc2, ref tai1, ref tai2);
+            SOFA.TaiTt(tai1, tai2, ref tt1, ref tt2);
+
+            return (tt1, tt2);
         }
 
         public static double MathMod(double a, double b) {
@@ -145,7 +185,8 @@ namespace NINA.Astrometry {
         public static double DeltaT(DateTime date, DatabaseInteraction db = null) {
             var utcDate = date.ToUniversalTime();
             double utc1 = 0, utc2 = 0, tai1 = 0, tai2 = 0;
-            SOFA.Dtf2d("UTC", utcDate.Year, utcDate.Month, utcDate.Day, utcDate.Hour, utcDate.Minute, (double)utcDate.Second + (double)utcDate.Millisecond / 1000.0, ref utc1, ref utc2);
+
+            SOFA.Dtf2d("UTC", utcDate.Year, utcDate.Month, utcDate.Day, utcDate.Hour, utcDate.Minute, GetSecondOfMinuteWithFraction(utcDate), ref utc1, ref utc2);
             SOFA.UtcTai(utc1, utc2, ref tai1, ref tai2);
 
             var utc = utc1 + utc2;
@@ -154,9 +195,9 @@ namespace NINA.Astrometry {
             return deltaT;
         }
 
-        private static double DeltaUTToday = 0.0;
-        private static double DeltaUTYesterday = 0.0;
-        private static double DeltaUTTomorrow = 0.0;
+        private static double? DeltaUTToday;
+        private static double? DeltaUTYesterday;
+        private static double? DeltaUTTomorrow;
         private static ConcurrentDictionary<DateTime, double> DeltaUTCache = new ConcurrentDictionary<DateTime, double>();
         private static DateTime DeltaUTReference;
 
@@ -170,36 +211,34 @@ namespace NINA.Astrometry {
             if (DeltaUTReference != DateTime.UtcNow.Date) {
                 // Clear the cache when a app is open longer than a day
                 DeltaUTReference = DateTime.UtcNow.Date;
-                DeltaUTYesterday = 0d;
-                DeltaUTToday = 0d;
-                DeltaUTTomorrow = 0d;
+                DeltaUTYesterday = null;
+                DeltaUTToday = null;
+                DeltaUTTomorrow = null;
             }
 
             var utcDate = date.ToUniversalTime();
 
             if (utcDate.Date == DateTime.UtcNow.Date) {
-                if (DeltaUTToday != 0) {
-                    return DeltaUTToday;
+                if (DeltaUTToday.HasValue) {
+                    return DeltaUTToday.Value;
                 }
             }
 
             if (utcDate.Date == DateTime.UtcNow.Date - TimeSpan.FromDays(1)) {
-                if (DeltaUTYesterday != 0) {
-                    return DeltaUTYesterday;
+                if (DeltaUTYesterday.HasValue) {
+                    return DeltaUTYesterday.Value;
                 }
             }
 
             if (utcDate.Date == DateTime.UtcNow.Date + TimeSpan.FromDays(1)) {
-                if (DeltaUTTomorrow != 0) {
-                    return DeltaUTTomorrow;
+                if (DeltaUTTomorrow.HasValue) {
+                    return DeltaUTTomorrow.Value;
                 }
             }
 
             var deltaUT = 0d;
-            if (DeltaUTCache.TryGetValue(utcDate.Date, out deltaUT)) {
-                if(deltaUT != 0) {
-                    return deltaUT;
-                }
+            if (DeltaUTCache.TryGetValue(utcDate.Date, out var cached)) {
+                return cached;
             }
 
             db = db ?? new DatabaseInteraction();
@@ -222,9 +261,7 @@ namespace NINA.Astrometry {
             }
 
             try {
-                if (!DeltaUTCache.ContainsKey(utcDate.Date)) {
-                    DeltaUTCache.AddOrUpdate(utcDate.Date, deltaUT, (a, b) => b);
-                }                
+                DeltaUTCache.AddOrUpdate(utcDate.Date, deltaUT, (a, b) => b);
             } catch(Exception) { }
             
 
@@ -237,14 +274,15 @@ namespace NINA.Astrometry {
         /// <param name="longitude"></param>
         /// <returns>Sidereal Time in hours</returns>
         public static double GetLocalSiderealTime(DateTime date, double longitude, DatabaseInteraction db = null) {
-            var jd = GetJulianDate(date);
+            var deltaT = DeltaT(date, db);
+            var (tt1, tt2) = GetJulianDateTTParts(date);
 
-            long jd_high = (long)jd;
-            double jd_low = jd - jd_high;
-
+            var ut_high = (long)tt1;
+            var ut_low = (tt1 - ut_high) + tt2 - SecondsToDays(deltaT);
             double lst = 0;
-            NOVAS.SiderealTime(jd_high, jd_low, DeltaT(date, db), NOVAS.GstType.GreenwichApparentSiderealTime, NOVAS.Method.EquinoxBased, NOVAS.Accuracy.Full, ref lst);
+            NOVAS.SiderealTime(ut_high, ut_low, deltaT, NOVAS.GstType.GreenwichApparentSiderealTime, NOVAS.Method.EquinoxBased, NOVAS.Accuracy.Full, ref lst);
             lst = lst + DegreesToHours(longitude);
+
             return lst;
         }
 
@@ -560,15 +598,19 @@ namespace NINA.Astrometry {
             return Regex.IsMatch(value, pattern);
         }
 
+        [Obsolete("Use function without jd")]
         public static NOVAS.SkyPosition GetMoonPosition(DateTime date, double jd, ObserverInfo oberverInfo) {
+            return GetMoonPosition(date, oberverInfo);
+        }
+        public static NOVAS.SkyPosition GetMoonPosition(DateTime date, ObserverInfo observerInfo) {
             var deltaT = DeltaT(date);
 
             var onSurface = new NOVAS.OnSurface() {
-                Latitude = oberverInfo.Latitude,
-                Longitude = oberverInfo.Longitude,
-                Height = oberverInfo.Elevation,
-                Temperature = oberverInfo.Temperature,
-                Pressure = oberverInfo.Pressure
+                Latitude = observerInfo.Latitude,
+                Longitude = observerInfo.Longitude,
+                Height = observerInfo.Elevation,
+                Temperature = observerInfo.Temperature,
+                Pressure = observerInfo.Pressure
             };
 
             var obs = new NOVAS.Observer() {
@@ -585,13 +627,21 @@ namespace NINA.Astrometry {
 
             var skyPosition = new NOVAS.SkyPosition();
 
-            var jdTt = jd + SecondsToDays(deltaT);
-            _ = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
+            var jdTt = GetJulianDateTT(date);
+            var error = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
+            if (error != 0) {
+                Logger.Error("Error calculating moon position - Novas return code: " + error);
+            }
 
             return skyPosition;
         }
 
+        [Obsolete("Use function without jd")]
         public static NOVAS.SkyPosition GetSunPosition(DateTime date, double jd, ObserverInfo oberverInfo) {
+            return GetSunPosition(date, oberverInfo);
+        }
+
+        public static NOVAS.SkyPosition GetSunPosition(DateTime date, ObserverInfo oberverInfo) {
             var deltaT = DeltaT(date);
 
             var onSurface = new NOVAS.OnSurface() {
@@ -616,15 +666,24 @@ namespace NINA.Astrometry {
 
             var skyPosition = new NOVAS.SkyPosition();
 
-            var jdTt = jd + SecondsToDays(deltaT);
-            _ = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
+            var jdTt = GetJulianDateTT(date);
+            var error = NOVAS.Place(jdTt, celestialObject, obs, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref skyPosition);
+            if (error != 0) {
+                Logger.Error("Error calculating moon position - Novas return code: " + error);
+            }
 
             return skyPosition;
         }
 
+        [Obsolete("Use function without jd")]
         public static Tuple<NOVAS.SkyPosition, NOVAS.SkyPosition> GetMoonAndSunPosition(DateTime date, double jd, ObserverInfo observerInfo = null) {
             if (observerInfo == null) { observerInfo = new ObserverInfo(); }
             return new Tuple<NOVAS.SkyPosition, NOVAS.SkyPosition>(GetMoonPosition(date, jd, observerInfo), GetSunPosition(date, jd, observerInfo));
+        }
+
+        public static Tuple<NOVAS.SkyPosition, NOVAS.SkyPosition> GetMoonAndSunPosition(DateTime date, ObserverInfo observerInfo = null) {
+            if (observerInfo == null) { observerInfo = new ObserverInfo(); }
+            return new Tuple<NOVAS.SkyPosition, NOVAS.SkyPosition>(GetMoonPosition(date, observerInfo), GetSunPosition(date, observerInfo));
         }
 
         [Obsolete("Use function with NINA.Astrometry.ObserverInfo parameter")]
@@ -633,8 +692,7 @@ namespace NINA.Astrometry {
         }
 
         public static double GetMoonPositionAngle(DateTime date, ObserverInfo observerInfo) {
-            var jd = GetJulianDate(date);
-            var tuple = GetMoonAndSunPosition(date, jd, observerInfo);
+            var tuple = GetMoonAndSunPosition(date, observerInfo);
             var moonPosition = tuple.Item1;
             var sunPosition = tuple.Item2;
 
@@ -654,8 +712,7 @@ namespace NINA.Astrometry {
         }
 
         private static double CalculateMoonIllumination(DateTime date, ObserverInfo observerInfo) {
-            var jd = GetJulianDate(date);
-            var tuple = GetMoonAndSunPosition(date, jd, observerInfo);
+            var tuple = GetMoonAndSunPosition(date, observerInfo);
             var moonPosition = tuple.Item1;
             var sunPosition = tuple.Item2;
 
@@ -726,8 +783,7 @@ namespace NINA.Astrometry {
         }
 
         public static double GetMoonAltitude(DateTime date, ObserverInfo observerInfo) {
-            var jd = GetJulianDate(date);
-            var moon = GetMoonPosition(date, jd, observerInfo);
+            var moon = GetMoonPosition(date, observerInfo);
 
             var siderealTime = GetLocalSiderealTime(date, observerInfo.Longitude);
             var hourAngle = HoursToDegrees(GetHourAngle(siderealTime, moon.RA));
@@ -736,8 +792,7 @@ namespace NINA.Astrometry {
         }
 
         public static double GetSunAltitude(DateTime date, ObserverInfo observerInfo) {
-            var jd = GetJulianDate(date);
-            var sun = GetSunPosition(date, jd, observerInfo);
+            var sun = GetSunPosition(date, observerInfo);
 
             var siderealTime = GetLocalSiderealTime(date, observerInfo.Longitude);
             var hourAngle = HoursToDegrees(GetHourAngle(siderealTime, sun.RA));

--- a/NINA.Astrometry/Body/BasicBody.cs
+++ b/NINA.Astrometry/Body/BasicBody.cs
@@ -14,7 +14,6 @@
 
 using NINA.Core.Utility;
 using System;
-using System.Threading.Tasks;
 
 namespace NINA.Astrometry.Body {
 
@@ -39,42 +38,40 @@ namespace NINA.Astrometry.Body {
         protected abstract string Name { get; }
         protected abstract NOVAS.Body BodyNumber { get; }
 
-        public Task Calculate() {
-            return Task.Run(() => {
-                var deltaT = AstroUtil.DeltaT(Date);
+        public void Calculate() {
+            var deltaT = AstroUtil.DeltaT(Date);
 
-                var location = new NOVAS.OnSurface() {
-                    Latitude = Latitude,
-                    Longitude = Longitude,
-                    Height = Elevation
-                };
+            var location = new NOVAS.OnSurface() {
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Height = Elevation
+            };
 
-                var observer = new NOVAS.Observer() {
-                    OnSurf = location,
-                    Where = (short)NOVAS.ObserverLocation.EarthSurface
-                };
+            var observer = new NOVAS.Observer() {
+                OnSurf = location,
+                Where = (short)NOVAS.ObserverLocation.EarthSurface
+            };
 
-                var obj = new NOVAS.CelestialObject() {
-                    Name = Name,
-                    Number = (short)BodyNumber,
-                    Star = new NOVAS.CatalogueEntry(),
-                    Type = (short)NOVAS.ObjectType.MajorPlanetSunOrMoon
-                };
+            var obj = new NOVAS.CelestialObject() {
+                Name = Name,
+                Number = (short)BodyNumber,
+                Star = new NOVAS.CatalogueEntry(),
+                Type = (short)NOVAS.ObjectType.MajorPlanetSunOrMoon
+            };
 
-                var objPosition = new NOVAS.SkyPosition();
+            var objPosition = new NOVAS.SkyPosition();
 
-                var jdTt = AstroUtil.GetJulianDateTT(Date);
-                var error = NOVAS.Place(jdTt, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
-                if (error != 0) {
-                    Logger.Warning($"Failed to calculate {Name} position for date {Date}, latitude {location.Latitude}, longitude {location.Longitude}, elevation {location.Height} - Novas return code: " + error);
-                }
+            var jdTt = AstroUtil.GetJulianDateTT(Date);
+            var error = NOVAS.Place(jdTt, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
+            if (error != 0) {
+                Logger.Warning($"Failed to calculate {Name} position for date {Date}, latitude {location.Latitude}, longitude {location.Longitude}, elevation {location.Height} - Novas return code: " + error);
+            }
 
-                this.Distance = AstroUtil.AUToKilometer(objPosition.Dis);
+            this.Distance = AstroUtil.AUToKilometer(objPosition.Dis);
 
-                var siderealTime = AstroUtil.GetLocalSiderealTime(Date, Longitude);
-                var hourAngle = AstroUtil.HoursToDegrees(AstroUtil.GetHourAngle(siderealTime, objPosition.RA));
-                this.Altitude = AstroUtil.GetAltitude(hourAngle, Latitude, objPosition.Dec);
-            });
+            var siderealTime = AstroUtil.GetLocalSiderealTime(Date, Longitude);
+            var hourAngle = AstroUtil.HoursToDegrees(AstroUtil.GetHourAngle(siderealTime, objPosition.RA));
+            this.Altitude = AstroUtil.GetAltitude(hourAngle, Latitude, objPosition.Dec);
         }
     }
 }

--- a/NINA.Astrometry/Body/BasicBody.cs
+++ b/NINA.Astrometry/Body/BasicBody.cs
@@ -66,7 +66,7 @@ namespace NINA.Astrometry.Body {
                 var jdTt = AstroUtil.GetJulianDateTT(Date);
                 var error = NOVAS.Place(jdTt, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
                 if (error != 0) {
-                    Logger.Error($"Error calculating {Name} position - Novas return code: {error}");
+                    Logger.Warning($"Failed to calculate {Name} position for date {Date}, latitude {location.Latitude}, longitude {location.Longitude}, elevation {location.Height} - Novas return code: " + error);
                 }
 
                 this.Distance = AstroUtil.AUToKilometer(objPosition.Dis);

--- a/NINA.Astrometry/Body/BasicBody.cs
+++ b/NINA.Astrometry/Body/BasicBody.cs
@@ -12,6 +12,7 @@
 
 #endregion "copyright"
 
+using NINA.Core.Utility;
 using System;
 using System.Threading.Tasks;
 
@@ -40,7 +41,6 @@ namespace NINA.Astrometry.Body {
 
         public Task Calculate() {
             return Task.Run(() => {
-                var jd = AstroUtil.GetJulianDate(Date);
                 var deltaT = AstroUtil.DeltaT(Date);
 
                 var location = new NOVAS.OnSurface() {
@@ -63,7 +63,12 @@ namespace NINA.Astrometry.Body {
 
                 var objPosition = new NOVAS.SkyPosition();
 
-                NOVAS.Place(jd, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
+                var jdTt = AstroUtil.GetJulianDateTT(Date);
+                var error = NOVAS.Place(jdTt, obj, observer, deltaT, NOVAS.CoordinateSystem.EquinoxOfDate, NOVAS.Accuracy.Full, ref objPosition);
+                if (error != 0) {
+                    Logger.Error($"Error calculating {Name} position - Novas return code: {error}");
+                }
+
                 this.Distance = AstroUtil.AUToKilometer(objPosition.Dis);
 
                 var siderealTime = AstroUtil.GetLocalSiderealTime(Date, Longitude);

--- a/NINA.Astrometry/Coordinates.cs
+++ b/NINA.Astrometry/Coordinates.cs
@@ -172,7 +172,7 @@ namespace NINA.Astrometry {
         /// <returns></returns>
         private Coordinates TransformToJNOW() {
             var now = DateTime.Now;
-            double jdTT = GetJdTT(now);
+            double jdTT = AstroUtil.GetJulianDateTT(now);
 
             double ri = 0, di = 0, eo = 0;
             SOFA.CelestialToIntermediate(raAngle.Radians, decAngle.Radians, 0.0, 0.0, 0.0, 0.0, jdTT, 0.0, ref ri, ref di, ref eo);
@@ -184,26 +184,16 @@ namespace NINA.Astrometry {
             return jnowCoordinates;
         }
 
-        private double GetJdTT(DateTime date) {
-            var utcDate = date.ToUniversalTime();
-            double tai1 = 0, tai2 = 0, tt1 = 0, tt2 = 0;
-            var utc = AstroUtil.GetJulianDate(utcDate);
-
-            SOFA.UtcTai(utc, 0.0, ref tai1, ref tai2);
-            SOFA.TaiTt(tai1, tai2, ref tt1, ref tt2);
-
-            return tt1 + tt2;
-        }
-
         /// <summary>
         /// Transforms coordinates from JNOW to J2000
         /// </summary>
         /// <returns></returns>
         private Coordinates TransformToJ2000() {
-            var jdTT = GetJdTT(this.creationDate);
-            var jdUTC = AstroUtil.GetJulianDate(this.creationDate);
+            var (jdTt1, jdTt2) = AstroUtil.GetJulianDateTTParts(this.creationDate);
+            var (utc1, utc2) = AstroUtil.GetJulianDateUTCParts(this.creationDate);
+
             double rc = 0, dc = 0, eo = 0;
-            SOFA.IntermediateToCelestial(SOFA.Anp(raAngle.Radians + SOFA.Eo06a(jdUTC, 0.0)), decAngle.Radians, jdTT, 0.0, ref rc, ref dc, ref eo);
+            SOFA.IntermediateToCelestial(SOFA.Anp(raAngle.Radians + SOFA.Eo06a(utc1, utc2)), decAngle.Radians, jdTt1, jdTt2, ref rc, ref dc, ref eo);
 
             var raCelestial = Angle.ByRadians(rc);
             var decCelestial = Angle.ByRadians(dc);
@@ -236,11 +226,10 @@ namespace NINA.Astrometry {
         public TopocentricCoordinates Transform(Angle latitude, Angle longitude, double elevation, double pressurehPa, double tempCelcius, double relativeHumidity, double wavelength, DateTime now) {
             var transform = this.Transform(Epoch.J2000);
 
-            var jdUTC = AstroUtil.GetJulianDate(now);
-
+            var (utc1, utc2) = AstroUtil.GetJulianDateUTCParts(now);
             var deltaUT = AstroUtil.DeltaUT(now);
             double aob = 0d, zob = 0d, hob = 0d, dob = 0d, rob = 0d, eo = 0d;
-            SOFA.CelestialToTopocentric(transform.raAngle.Radians, transform.decAngle.Radians, 0d, 0d, 0d, 0d, jdUTC, 0d, deltaUT, longitude.Radians, latitude.Radians, elevation, 0d, 0d, pressurehPa, tempCelcius, relativeHumidity, wavelength, ref aob, ref zob, ref hob, ref dob, ref rob, ref eo);
+            SOFA.CelestialToTopocentric(transform.raAngle.Radians, transform.decAngle.Radians, 0d, 0d, 0d, 0d, utc1, utc2, deltaUT, longitude.Radians, latitude.Radians, elevation, 0d, 0d, pressurehPa, tempCelcius, relativeHumidity, wavelength, ref aob, ref zob, ref hob, ref dob, ref rob, ref eo);
 
             var az = Angle.ByRadians(aob);
             var alt = Angle.ByDegree(90) - Angle.ByRadians(zob);

--- a/NINA.Astrometry/MoonInfo.cs
+++ b/NINA.Astrometry/MoonInfo.cs
@@ -121,7 +121,7 @@ namespace NINA.Astrometry {
         }
 
         private void CalculateSeparation(DateTime time) {
-            NOVAS.SkyPosition pos = AstroUtil.GetMoonPosition(time, AstroUtil.GetJulianDate(time), _observer);
+            NOVAS.SkyPosition pos = AstroUtil.GetMoonPosition(time, _observer);
             var moonRaRadians = AstroUtil.ToRadians(AstroUtil.HoursToDegrees(pos.RA));
             var moonDecRadians = AstroUtil.ToRadians(pos.Dec);
 

--- a/NINA.Astrometry/RiseAndSet/CustomRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/CustomRiseAndSet.cs
@@ -32,8 +32,8 @@ namespace NINA.Astrometry.RiseAndSet {
         public CustomRiseAndSet(DateTime date, double latitude, double longitude, double elevation) : base(date, latitude, longitude, elevation) {
         }
 
-        public override Task<bool> Calculate() {
-            return Task.FromResult(true);
+        public override bool Calculate() {
+            return true;
         }
 
         public override DateTime? Rise => rise;

--- a/NINA.Astrometry/RiseAndSet/RiseAndSetEvent.cs
+++ b/NINA.Astrometry/RiseAndSet/RiseAndSetEvent.cs
@@ -14,7 +14,6 @@
 
 using NINA.Astrometry.Body;
 using System;
-using System.Threading.Tasks;
 
 namespace NINA.Astrometry.RiseAndSet {
 
@@ -45,126 +44,122 @@ namespace NINA.Astrometry.RiseAndSet {
         /// Caveat: does not consider more than one rise and one set event
         /// </summary>
         /// <returns></returns>
-        public virtual Task<bool> Calculate() {
-            return Task.Run(async () => {
-                // Check rise and set events in two hour periods
-                var offset = 0;
+        public virtual bool Calculate() {
+            // Check rise and set events in two hour periods
+            var offset = 0;
 
-                do {
-                    // Shift date by offset
-                    var offsetDate = Date.AddHours(offset);
+            do {
+                // Shift date by offset
+                var offsetDate = Date.AddHours(offset);
 
-                    // Get three body locations for date, date + 1 hour and date + 2 hours
-                    var bodyAt0 = GetBody(offsetDate);
-                    var bodyAt1 = GetBody(offsetDate.AddHours(1));
-                    var bodyAt2 = GetBody(offsetDate.AddHours(2));
+                // Get three body locations for date, date + 1 hour and date + 2 hours
+                var bodyAt0 = GetBody(offsetDate);
+                var bodyAt1 = GetBody(offsetDate.AddHours(1));
+                var bodyAt2 = GetBody(offsetDate.AddHours(2));
 
-                    await Task.WhenAll(bodyAt0.Calculate(), bodyAt1.Calculate(), bodyAt2.Calculate());
+                bodyAt0.Calculate();
+                bodyAt1.Calculate();
+                bodyAt2.Calculate();
 
-                    var location = new NOVAS.OnSurface() {
-                        Latitude = Latitude,
-                        Longitude = Longitude,
-                        Height = Elevation
-                    };
+                // Adjust altitude for the three body parameters
+                var altitude0 = AdjustAltitude(bodyAt0);
+                var altitude1 = AdjustAltitude(bodyAt1);
+                var altitude2 = AdjustAltitude(bodyAt2);
 
-                    // Adjust altitude for the three body parameters
-                    var altitude0 = AdjustAltitude(bodyAt0);
-                    var altitude1 = AdjustAltitude(bodyAt1);
-                    var altitude2 = AdjustAltitude(bodyAt2);
+                // fit the three reference positions into a quadratic equation
 
-                    // fit the three reference positions into a quadratic equation
+                //P1 (offsetDate | altitude0) => (0 | altitude0)
+                //P2 (offsetDate + 1 | altitude1) => (1 | altitude1)
+                //P3 (offsetDate + 2 | altitude2) => (2 | altitude2)
 
-                    //P1 (offsetDate | altitude0) => (0 | altitude0)
-                    //P2 (offsetDate + 1 | altitude1) => (1 | altitude1)
-                    //P3 (offsetDate + 2 | altitude2) => (2 | altitude2)
+                // ax^2 + bx + c
 
-                    // ax?? + bx + c
+                // Solve for c
+                // => altitude0 = 0 * x^2 + 0 * x + c => altitude0 = c
 
-                    // Solve for c
-                    // => altitude0 = 0 * x?? + 0 * x + c => altitude0 = c
+                // Solve for b using c
+                // altitude1 = a * 1^2 + b * 1 + altitude0
+                //    => altitude1 = a + b + altitude0
+                //    => b = altitude1 - a - altitude0
 
-                    // Solve for b using c
-                    // altitude1 = a * 1?? + b * 1 + altitude0
-                    //    => altitude1 = a + b + altitude0
-                    //    => b = altitude1 - a - altitude0
+                // Solve for a using b and c
+                // altitude2 = a * 2^2 + b * 2 + altitude0
+                //   => altitude2 = 4a + 2(altitude1 - a - altitude0) + altitude0
+                //   => altitude2 = 4a + 2*altitude1 - 2a - 2*altitude0 + altitude0
+                //   => altitude2 = 2a + 2*altitude1 - altitude0
+                //   => 2a = altitude2 - 2*altitude1 + altitude0
+                //   => a = 0.5 * altitude2  - altitude1 + 0.5 * altitude0
+                //   => a = 0.5 * (altitude2 + altitude0) - altitude1
 
-                    // Solve for a using b and c
-                    // altitude2 = a * 2?? + b * 2 + altitude0
-                    //   => altitude2 = 4a + 2(altitude1 - a - altitude0) + altitude0
-                    //   => altitude2 = 4a + 2*altitude1 - 2a - 2*altitude0 + altitude0
-                    //   => altitude2 = 2a + 2*altitude1 - altitude0
-                    //   => 2a = altitude2 - 2*altitude1 + altitude0
-                    //   => a = 0.5 * altitude2  - altitude1 + 0.5 * altitude0
-                    //   => a = 0.5 * (altitude2 + altitude0) - altitude1
+                // Solve for b using a and c
+                //   => b = altitude1 - (0.5 * (altitude2 + altitude0) - altitude1) - altitude0
+                //   => b = altitude1 - 0.5 * altitude2 - 0.5 * altitude0 + altitude1 - altitude0
+                //   => b = 2 * altitude1 - 0.5 * altitude2 - 1.5 * altitude0
 
-                    // Solve for b using a and c
-                    //   => b = altitude1 - (0.5 * (altitude2 + altitude0) - altitude1) - altitude0
-                    //   => b = altitude1 - 0.5 * altitude2 - 0.5 * altitude0 + altitude1 - altitude0
-                    //   => b = 2 * altitude1 - 0.5 * altitude2 - 1.5 * altitude0
+                var a = 0.5 * (altitude2 + altitude0) - altitude1;
+                var b = 2 * altitude1 - 0.5 * altitude2 - 1.5 * altitude0;
+                var c = altitude0;
 
-                    var a = 0.5 * (altitude2 + altitude0) - altitude1;
-                    var b = 2 * altitude1 - 0.5 * altitude2 - 1.5 * altitude0;
-                    var c = altitude0;
+                // a-b-c formula
+                // x = -b +- Sqrt(b^2 - 4ac) / 2a
 
-                    // a-b-c formula
-                    // x = -b +- Sqrt(b?? - 4ac) / 2a
+                // Discriminant definition: b^2 - 4ac
+                var discriminant = (b * b) - (4.0 * a * c);
 
-                    // Discriminant definition: b?? - 4ac
-                    var discriminant = (Math.Pow(b, 2)) - (4.0 * a * c);
+                const double epsilon = 1e-5;
+                const double discEps = 1e-10;
 
-                    var zeroPoint1 = double.NaN;
-                    var zeroPoint2 = double.NaN;
-                    var events = 0;
+                if (discriminant >= -discEps) {
+                    if (discriminant < 0) { 
+                        discriminant = 0; 
+                    }
+                    double sqrtD = Math.Sqrt(discriminant);
 
-                    if (discriminant == 1) {
-                        zeroPoint1 = (-b + Math.Sqrt(discriminant)) / (2 * a);
-                        if (zeroPoint1 >= 0 && zeroPoint1 <= 2) {
-                            events++;
+                    double x1, x2;
+                    if (Math.Abs(a) < epsilon) {
+                        if (Math.Abs(b) < epsilon) {
+                            continue; // no usable root in this window
                         }
-                    } else if (discriminant > 1) {
-                        zeroPoint1 = (-b + Math.Sqrt(discriminant)) / (2 * a);
-                        zeroPoint2 = (-b - Math.Sqrt(discriminant)) / (2 * a);
-
-                        // Check if zero point is inside the span of 0 to 2 (to be inside the checked timeframe)
-                        if (zeroPoint1 >= 0 && zeroPoint1 <= 2) {
-                            events++;
-                        }
-                        if (zeroPoint2 >= 0 && zeroPoint2 <= 2) {
-                            events++;
-                        }
-                        if (zeroPoint1 < 0 || zeroPoint1 > 2) {
-                            zeroPoint1 = zeroPoint2;
-                        }
+                        // Linear fallback: bx + c = 0
+                        x1 = x2 = -c / b;
+                    } else {
+                        x1 = (-b + sqrtD) / (2 * a);
+                        x2 = (-b - sqrtD) / (2 * a);
                     }
 
-                    //find the gradient at zeroPoint1. positive => rise event, negative => set event
-                    var gradient = 2 * a * zeroPoint1 + b;
+                    bool x1Valid = !double.IsNaN(x1) && x1 >= -epsilon && x1 <= 2 + epsilon;
+                    bool x2Valid = !double.IsNaN(x2) && x2 >= -epsilon && x2 <= 2 + epsilon && Math.Abs(x1 - x2) > epsilon;
 
-                    if (events == 1) {
-                        if (gradient > 0) {
-                            // rise
-                            this.Rise = offsetDate.AddHours(zeroPoint1);
-                        } else {
-                            // set
-                            this.Set = offsetDate.AddHours(zeroPoint1);
-                        }
-                    } else if (events == 2) {
-                        if (gradient > 0) {
-                            // rise and set
-                            this.Rise = offsetDate.AddHours(zeroPoint1);
-                            this.Set = offsetDate.AddHours(zeroPoint2);
-                        } else {
-                            // set and rise
-                            this.Rise = offsetDate.AddHours(zeroPoint2);
-                            this.Set = offsetDate.AddHours(zeroPoint1);
-                        }
+                    if (x1Valid) x1 = Math.Clamp(x1, 0, 2);
+                    if (x2Valid) x2 = Math.Clamp(x2, 0, 2);
+
+                    if (x1Valid) { 
+                        AssignEvent(x1, a, b, offsetDate); 
                     }
-                    offset += 2;
-                    //Repeat until rise and set events are found, or after a whole day
-                } while (!((this.Rise != null && this.Set != null) || offset > 24));
+                    if (x2Valid) { 
+                        AssignEvent(x2, a, b, offsetDate); 
+                    }
+                }
+                offset += 2;
+                //Repeat until rise and set events are found, or after a whole day
+            } while (!((this.Rise != null && this.Set != null) || offset > 24));
 
-                return true;
-            });
+            return Rise != null || Set != null;
+        }
+
+        private void AssignEvent(double x, double a, double b, DateTime offsetDate) {
+            var slope = 2 * a * x + b;
+            var eventTime = offsetDate.AddHours(x);
+
+            if (slope > 0) {
+                if (Rise == null || eventTime < Rise.Value) {
+                    Rise = eventTime;
+                }
+            } else {
+                if (Set == null || eventTime < Set.Value) {
+                    Set = eventTime;
+                }
+            }
         }
     }
 }

--- a/NINA.Astrometry/RiseAndSet/SunCustomRiseAndSet.cs
+++ b/NINA.Astrometry/RiseAndSet/SunCustomRiseAndSet.cs
@@ -13,7 +13,7 @@ namespace NINA.Astrometry.RiseAndSet {
             SunAltitude = sunAltitude;
         }
 
-        private double SunAltitude { get; }
+        public double SunAltitude { get; }
 
         protected override double AdjustAltitude(BasicBody body) {
             return body.Altitude - SunAltitude;

--- a/NINA.Astrometry/SOFA.cs
+++ b/NINA.Astrometry/SOFA.cs
@@ -23,7 +23,7 @@ namespace NINA.Astrometry {
     /// http://www.iausofa.org/current_C.html#Downloads
     /// </summary>
     public static class SOFA {
-        private const string DLLNAME = "SOFAlib.dll";
+        private const string DLLNAME = "SOFA-2023-10-11.dll";
 
         static SOFA() {
             DllLoader.LoadDll(Path.Combine("SOFA", DLLNAME));

--- a/NINA.Astrometry/TopocentricCoordinates.cs
+++ b/NINA.Astrometry/TopocentricCoordinates.cs
@@ -93,14 +93,13 @@ namespace NINA.Astrometry {
         /// <param name="db">NINA database</param>
         /// <returns>Celestial coordinates</returns>
         public Coordinates Transform(DateTime now, Epoch epoch, double pressurehPa, double tempCelcius, double relativeHumidity, double wavelength, DatabaseInteraction db = null) {
-            var jdUTC = AstroUtil.GetJulianDate(now);
-
             var zenithDistance = AstroUtil.ToRadians(90d - Altitude.Degree);
             var deltaUT = AstroUtil.DeltaUT(now, db);
 
             var raRad = 0d;
             var decRad = 0d;
-            SOFA.TopocentricToCelestial("A", Azimuth.Radians, zenithDistance, jdUTC, 0d, deltaUT, Longitude.Radians, Latitude.Radians, Elevation, 0d, 0d, pressurehPa, tempCelcius, relativeHumidity, wavelength, ref raRad, ref decRad);
+            var (utc1, utc2) = AstroUtil.GetJulianDateUTCParts(now);
+            SOFA.TopocentricToCelestial("A", Azimuth.Radians, zenithDistance, utc1, utc2, deltaUT, Longitude.Radians, Latitude.Radians, Elevation, 0d, 0d, pressurehPa, tempCelcius, relativeHumidity, wavelength, ref raRad, ref decRad);
             var ra = Angle.ByRadians(raRad);
             var dec = Angle.ByRadians(decRad);
 

--- a/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
@@ -85,7 +85,7 @@ namespace NINA.Sequencer.Conditions {
         private DateTime CalculateExpectedDateTime(DateTime time) {
             // The MoonRiseAndSet already models refraction and moon disk size
             var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
-            AsyncContext.Run(customRiseAndSet.Calculate);
+            customRiseAndSet.Calculate();
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN || Data.Comparator == ComparisonOperatorEnum.GREATER_THAN_OR_EQUAL ? customRiseAndSet.Rise : customRiseAndSet.Set) ?? DateTime.MaxValue;
         }
     }

--- a/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
@@ -79,7 +79,7 @@ namespace NINA.Sequencer.Conditions {
 
         private DateTime CalculateExpectedDateTime(DateTime time) {
             var customRiseAndSet = new SunCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
-            AsyncContext.Run(customRiseAndSet.Calculate);
+            customRiseAndSet.Calculate();
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN || Data.Comparator == ComparisonOperatorEnum.GREATER_THAN_OR_EQUAL ? customRiseAndSet.Rise : customRiseAndSet.Set) ?? DateTime.MaxValue;
         }
 

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
@@ -113,7 +113,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
 
         private DateTime CalculateExpectedDateTime(DateTime time) {
             var customRiseAndSet = new MoonCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
-            AsyncContext.Run(customRiseAndSet.Calculate);
+            customRiseAndSet.Calculate();
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN ? customRiseAndSet.Set : customRiseAndSet?.Rise) ?? DateTime.MaxValue;
         }
 

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForSunAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForSunAltitude.cs
@@ -113,7 +113,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
 
         private DateTime CalculateExpectedDateTime(DateTime time) {
             var customRiseAndSet = new SunCustomRiseAndSet(NighttimeCalculator.GetReferenceDate(time), Data.Observer.Latitude, Data.Observer.Longitude, Data.Observer.Elevation, GetDataOffset());
-            AsyncContext.Run(customRiseAndSet.Calculate);
+            customRiseAndSet.Calculate();
             return (Data.Comparator == ComparisonOperatorEnum.GREATER_THAN ? customRiseAndSet.Set : customRiseAndSet?.Rise) ?? DateTime.MaxValue;
         }
 

--- a/NINA.Sequencer/Utility/ItemUtility.cs
+++ b/NINA.Sequencer/Utility/ItemUtility.cs
@@ -377,15 +377,13 @@ namespace NINA.Sequencer.Utility {
 
         [Obsolete]
         public static Coordinates CalculateSunRADec(ObserverInfo observer) {
-            double jd = AstroUtil.GetJulianDate(DateTime.Now);
-            NOVAS.SkyPosition skyPos = AstroUtil.GetSunPosition(DateTime.Now, jd, observer);
+            NOVAS.SkyPosition skyPos = AstroUtil.GetSunPosition(DateTime.Now, observer);
             return new Coordinates(skyPos.RA, skyPos.Dec, Epoch.JNOW, Coordinates.RAType.Hours);
         }
 
         [Obsolete]
         public static Coordinates CalculateMoonRADec(ObserverInfo observer) {
-            double jd = AstroUtil.GetJulianDate(DateTime.Now);
-            NOVAS.SkyPosition skyPos = AstroUtil.GetMoonPosition(DateTime.Now, jd, observer);
+            NOVAS.SkyPosition skyPos = AstroUtil.GetMoonPosition(DateTime.Now, observer);
             return new Coordinates(skyPos.RA, skyPos.Dec, Epoch.JNOW, Coordinates.RAType.Hours);
         }
     }

--- a/NINA.Setup/Product.wxs
+++ b/NINA.Setup/Product.wxs
@@ -2195,8 +2195,8 @@
   </Fragment>
   <Fragment>
     <ComponentGroup Id="External_x64_SOFA_files" Directory="External_x64_SOFA">
-      <Component Id="External_x64_SOFA_SOFAlib.dll" Guid="7e84f09e-ef65-4075-93f9-34a61f47a2af" Bitness="$(var.Win64)">
-        <File Id="External_x64_SOFA_SOFAlib.dll" Name="SOFAlib.dll" Source="$(var.NINA_TargetDir)External\x64\SOFA\SOFAlib.dll" />
+      <Component Id="External_x64_SOFA_SOFA-2023-10-11.dll" Guid="81FF5D30-3236-4516-89F9-C2FD3C655A22" Bitness="$(var.Win64)">
+        <File Id="External_x64_SOFA_SOFA-2023-10-11.dll" Name="SOFA-2023-10-11.dll" Source="$(var.NINA_TargetDir)External\x64\SOFA\SOFA-2023-10-11.dll" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/NINA/NINA.csproj
+++ b/NINA/NINA.csproj
@@ -101,6 +101,7 @@
     <None Remove="External\x64\Cfitsio\pthreadVC2.dll" />
     <None Remove="External\x64\Cfitsio\zlib.dll" />
     <None Remove="External\x64\PlayerOne\PlayerOnePW.dll" />
+    <None Remove="External\x64\SOFA\SOFA-2023-10-11.dll" />
     <None Remove="External\x64\SVBony\svbonycam.dll" />
   </ItemGroup>
   <ItemGroup>
@@ -173,6 +174,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="External\x64\SBIG\SBIGUDrv.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="External\x64\SOFA\SOFA-2023-10-11.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="External\x64\SVBony\svbonycam.dll">
@@ -290,9 +294,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>qhyccd.ini</TargetPath>
     </ContentWithTargetPath>
-    <Content Include="External\x64\SOFA\SOFAlib.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="External\x64\ToupTek\toupcam.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/SOFA/SOFA/00READ.ME
+++ b/SOFA/SOFA/00READ.ME
@@ -1,8 +1,8 @@
 
-SOFA-Issue: 2020-07-21
+SOFA-Issue: 2023-10-11
 
 This is the IAU Standards of Fundamental Astronomy (SOFA) Libraries product, 
-issued on 2020-07-21.  The tag `SOFA-Issue' above defines this release and 
+issued on 2023-10-11. The tag `SOFA-Issue' above defines this release and 
 differentiates it from previous or subsequent releases of the SOFA product.
 The 00READ.ME file must remain with this distribution set.
 
@@ -46,4 +46,4 @@ Notes:
     development environment to create the appropriate library or DLL.
 
 IAU SOFA Center
-2020/07/21
+2023/10/11

--- a/SOFA/SOFA/SOFA.vcxproj
+++ b/SOFA/SOFA/SOFA.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{C6BBBBD5-9C87-4CAA-8BA4-7055D58287A8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SOFA</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -151,246 +151,726 @@
     <ClInclude Include="src\sofam.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\a2af.c" />
-    <ClCompile Include="src\a2tf.c" />
-    <ClCompile Include="src\ab.c" />
-    <ClCompile Include="src\ae2hd.c" />
-    <ClCompile Include="src\af2a.c" />
-    <ClCompile Include="src\anp.c" />
-    <ClCompile Include="src\anpm.c" />
-    <ClCompile Include="src\apcg.c" />
-    <ClCompile Include="src\apcg13.c" />
-    <ClCompile Include="src\apci.c" />
-    <ClCompile Include="src\apci13.c" />
-    <ClCompile Include="src\apco.c" />
-    <ClCompile Include="src\apco13.c" />
-    <ClCompile Include="src\apcs.c" />
-    <ClCompile Include="src\apcs13.c" />
-    <ClCompile Include="src\aper.c" />
-    <ClCompile Include="src\aper13.c" />
-    <ClCompile Include="src\apio.c" />
-    <ClCompile Include="src\apio13.c" />
-    <ClCompile Include="src\atci13.c" />
-    <ClCompile Include="src\atciq.c" />
-    <ClCompile Include="src\atciqn.c" />
-    <ClCompile Include="src\atciqz.c" />
-    <ClCompile Include="src\atco13.c" />
-    <ClCompile Include="src\atic13.c" />
-    <ClCompile Include="src\aticq.c" />
-    <ClCompile Include="src\aticqn.c" />
-    <ClCompile Include="src\atio13.c" />
-    <ClCompile Include="src\atioq.c" />
-    <ClCompile Include="src\atoc13.c" />
-    <ClCompile Include="src\atoi13.c" />
-    <ClCompile Include="src\atoiq.c" />
-    <ClCompile Include="src\bi00.c" />
-    <ClCompile Include="src\bp00.c" />
-    <ClCompile Include="src\bp06.c" />
-    <ClCompile Include="src\bpn2xy.c" />
-    <ClCompile Include="src\c2i00a.c" />
-    <ClCompile Include="src\c2i00b.c" />
-    <ClCompile Include="src\c2i06a.c" />
-    <ClCompile Include="src\c2ibpn.c" />
-    <ClCompile Include="src\c2ixy.c" />
-    <ClCompile Include="src\c2ixys.c" />
-    <ClCompile Include="src\c2s.c" />
-    <ClCompile Include="src\c2t00a.c" />
-    <ClCompile Include="src\c2t00b.c" />
-    <ClCompile Include="src\c2t06a.c" />
-    <ClCompile Include="src\c2tcio.c" />
-    <ClCompile Include="src\c2teqx.c" />
-    <ClCompile Include="src\c2tpe.c" />
-    <ClCompile Include="src\c2txy.c" />
-    <ClCompile Include="src\cal2jd.c" />
-    <ClCompile Include="src\cp.c" />
-    <ClCompile Include="src\cpv.c" />
-    <ClCompile Include="src\cr.c" />
-    <ClCompile Include="src\d2dtf.c" />
-    <ClCompile Include="src\d2tf.c" />
-    <ClCompile Include="src\dat.c" />
-    <ClCompile Include="src\dtdb.c" />
-    <ClCompile Include="src\dtf2d.c" />
-    <ClCompile Include="src\eceq06.c" />
-    <ClCompile Include="src\ecm06.c" />
-    <ClCompile Include="src\ee00.c" />
-    <ClCompile Include="src\ee00a.c" />
-    <ClCompile Include="src\ee00b.c" />
-    <ClCompile Include="src\ee06a.c" />
-    <ClCompile Include="src\eect00.c" />
-    <ClCompile Include="src\eform.c" />
-    <ClCompile Include="src\eo06a.c" />
-    <ClCompile Include="src\eors.c" />
-    <ClCompile Include="src\epb.c" />
-    <ClCompile Include="src\epb2jd.c" />
-    <ClCompile Include="src\epj.c" />
-    <ClCompile Include="src\epj2jd.c" />
-    <ClCompile Include="src\epv00.c" />
-    <ClCompile Include="src\eqec06.c" />
-    <ClCompile Include="src\eqeq94.c" />
-    <ClCompile Include="src\era00.c" />
-    <ClCompile Include="src\fad03.c" />
-    <ClCompile Include="src\fae03.c" />
-    <ClCompile Include="src\faf03.c" />
-    <ClCompile Include="src\faju03.c" />
-    <ClCompile Include="src\fal03.c" />
-    <ClCompile Include="src\falp03.c" />
-    <ClCompile Include="src\fama03.c" />
-    <ClCompile Include="src\fame03.c" />
-    <ClCompile Include="src\fane03.c" />
-    <ClCompile Include="src\faom03.c" />
-    <ClCompile Include="src\fapa03.c" />
-    <ClCompile Include="src\fasa03.c" />
-    <ClCompile Include="src\faur03.c" />
-    <ClCompile Include="src\fave03.c" />
-    <ClCompile Include="src\fk52h.c" />
-    <ClCompile Include="src\fk5hip.c" />
-    <ClCompile Include="src\fk5hz.c" />
-    <ClCompile Include="src\fw2m.c" />
-    <ClCompile Include="src\fw2xy.c" />
-    <ClCompile Include="src\g2icrs.c" />
-    <ClCompile Include="src\gc2gd.c" />
-    <ClCompile Include="src\gc2gde.c" />
-    <ClCompile Include="src\gd2gc.c" />
-    <ClCompile Include="src\gd2gce.c" />
-    <ClCompile Include="src\gmst00.c" />
-    <ClCompile Include="src\gmst06.c" />
-    <ClCompile Include="src\gmst82.c" />
-    <ClCompile Include="src\gst00a.c" />
-    <ClCompile Include="src\gst00b.c" />
-    <ClCompile Include="src\gst06.c" />
-    <ClCompile Include="src\gst06a.c" />
-    <ClCompile Include="src\gst94.c" />
-    <ClCompile Include="src\h2fk5.c" />
-    <ClCompile Include="src\hd2ae.c" />
-    <ClCompile Include="src\hd2pa.c" />
-    <ClCompile Include="src\hfk5z.c" />
-    <ClCompile Include="src\icrs2g.c" />
-    <ClCompile Include="src\ir.c" />
-    <ClCompile Include="src\jd2cal.c" />
-    <ClCompile Include="src\jdcalf.c" />
-    <ClCompile Include="src\ld.c" />
-    <ClCompile Include="src\ldn.c" />
-    <ClCompile Include="src\ldsun.c" />
-    <ClCompile Include="src\lteceq.c" />
-    <ClCompile Include="src\ltecm.c" />
-    <ClCompile Include="src\lteqec.c" />
-    <ClCompile Include="src\ltp.c" />
-    <ClCompile Include="src\ltpb.c" />
-    <ClCompile Include="src\ltpecl.c" />
-    <ClCompile Include="src\ltpequ.c" />
-    <ClCompile Include="src\num00a.c" />
-    <ClCompile Include="src\num00b.c" />
-    <ClCompile Include="src\num06a.c" />
-    <ClCompile Include="src\numat.c" />
-    <ClCompile Include="src\nut00a.c" />
-    <ClCompile Include="src\nut00b.c" />
-    <ClCompile Include="src\nut06a.c" />
-    <ClCompile Include="src\nut80.c" />
-    <ClCompile Include="src\nutm80.c" />
-    <ClCompile Include="src\obl06.c" />
-    <ClCompile Include="src\obl80.c" />
-    <ClCompile Include="src\p06e.c" />
-    <ClCompile Include="src\p2pv.c" />
-    <ClCompile Include="src\p2s.c" />
-    <ClCompile Include="src\pap.c" />
-    <ClCompile Include="src\pas.c" />
-    <ClCompile Include="src\pb06.c" />
-    <ClCompile Include="src\pdp.c" />
-    <ClCompile Include="src\pfw06.c" />
-    <ClCompile Include="src\plan94.c" />
-    <ClCompile Include="src\pm.c" />
-    <ClCompile Include="src\pmat00.c" />
-    <ClCompile Include="src\pmat06.c" />
-    <ClCompile Include="src\pmat76.c" />
-    <ClCompile Include="src\pmp.c" />
-    <ClCompile Include="src\pmpx.c" />
-    <ClCompile Include="src\pmsafe.c" />
-    <ClCompile Include="src\pn.c" />
-    <ClCompile Include="src\pn00.c" />
-    <ClCompile Include="src\pn00a.c" />
-    <ClCompile Include="src\pn00b.c" />
-    <ClCompile Include="src\pn06.c" />
-    <ClCompile Include="src\pn06a.c" />
-    <ClCompile Include="src\pnm00a.c" />
-    <ClCompile Include="src\pnm00b.c" />
-    <ClCompile Include="src\pnm06a.c" />
-    <ClCompile Include="src\pnm80.c" />
-    <ClCompile Include="src\pom00.c" />
-    <ClCompile Include="src\ppp.c" />
-    <ClCompile Include="src\ppsp.c" />
-    <ClCompile Include="src\pr00.c" />
-    <ClCompile Include="src\prec76.c" />
-    <ClCompile Include="src\pv2p.c" />
-    <ClCompile Include="src\pv2s.c" />
-    <ClCompile Include="src\pvdpv.c" />
-    <ClCompile Include="src\pvm.c" />
-    <ClCompile Include="src\pvmpv.c" />
-    <ClCompile Include="src\pvppv.c" />
-    <ClCompile Include="src\pvstar.c" />
-    <ClCompile Include="src\pvtob.c" />
-    <ClCompile Include="src\pvu.c" />
-    <ClCompile Include="src\pvup.c" />
-    <ClCompile Include="src\pvxpv.c" />
-    <ClCompile Include="src\pxp.c" />
-    <ClCompile Include="src\refco.c" />
-    <ClCompile Include="src\rm2v.c" />
-    <ClCompile Include="src\rv2m.c" />
-    <ClCompile Include="src\rx.c" />
-    <ClCompile Include="src\rxp.c" />
-    <ClCompile Include="src\rxpv.c" />
-    <ClCompile Include="src\rxr.c" />
-    <ClCompile Include="src\ry.c" />
-    <ClCompile Include="src\rz.c" />
-    <ClCompile Include="src\s00.c" />
-    <ClCompile Include="src\s00a.c" />
-    <ClCompile Include="src\s00b.c" />
-    <ClCompile Include="src\s06.c" />
-    <ClCompile Include="src\s06a.c" />
-    <ClCompile Include="src\s2c.c" />
-    <ClCompile Include="src\s2p.c" />
-    <ClCompile Include="src\s2pv.c" />
-    <ClCompile Include="src\s2xpv.c" />
-    <ClCompile Include="src\sepp.c" />
-    <ClCompile Include="src\seps.c" />
-    <ClCompile Include="src\sp00.c" />
-    <ClCompile Include="src\starpm.c" />
-    <ClCompile Include="src\starpv.c" />
-    <ClCompile Include="src\sxp.c" />
-    <ClCompile Include="src\sxpv.c" />
-    <ClCompile Include="src\taitt.c" />
-    <ClCompile Include="src\taiut1.c" />
-    <ClCompile Include="src\taiutc.c" />
-    <ClCompile Include="src\tcbtdb.c" />
-    <ClCompile Include="src\tcgtt.c" />
-    <ClCompile Include="src\tdbtcb.c" />
-    <ClCompile Include="src\tdbtt.c" />
-    <ClCompile Include="src\tf2a.c" />
-    <ClCompile Include="src\tf2d.c" />
-    <ClCompile Include="src\tpors.c" />
-    <ClCompile Include="src\tporv.c" />
-    <ClCompile Include="src\tpsts.c" />
-    <ClCompile Include="src\tpstv.c" />
-    <ClCompile Include="src\tpxes.c" />
-    <ClCompile Include="src\tpxev.c" />
-    <ClCompile Include="src\tr.c" />
-    <ClCompile Include="src\trxp.c" />
-    <ClCompile Include="src\trxpv.c" />
-    <ClCompile Include="src\tttai.c" />
-    <ClCompile Include="src\tttcg.c" />
-    <ClCompile Include="src\tttdb.c" />
-    <ClCompile Include="src\ttut1.c" />
-    <ClCompile Include="src\ut1tai.c" />
-    <ClCompile Include="src\ut1tt.c" />
-    <ClCompile Include="src\ut1utc.c" />
-    <ClCompile Include="src\utctai.c" />
-    <ClCompile Include="src\utcut1.c" />
-    <ClCompile Include="src\xy06.c" />
-    <ClCompile Include="src\xys00a.c" />
-    <ClCompile Include="src\xys00b.c" />
-    <ClCompile Include="src\xys06a.c" />
-    <ClCompile Include="src\zp.c" />
-    <ClCompile Include="src\zpv.c" />
-    <ClCompile Include="src\zr.c" />
+    <ClCompile Include="src\a2af.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\a2tf.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ab.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ae2hd.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\af2a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\anp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\anpm.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apcg.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apcg13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apci.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apci13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apco.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apco13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apcs.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apcs13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\aper.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\aper13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apio.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\apio13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atci13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atciq.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atciqn.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atciqz.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atco13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atic13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\aticq.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\aticqn.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atio13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atioq.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atoc13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atoi13.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\atoiq.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\bi00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\bp00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\bp06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\bpn2xy.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2i00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2i00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2i06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2ibpn.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2ixy.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2ixys.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2s.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2t00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2t00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2t06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2tcio.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2teqx.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2tpe.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\c2txy.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\cal2jd.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\cp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\cpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\cr.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\d2dtf.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\d2tf.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\dat.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\dtdb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\dtf2d.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eceq06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ecm06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ee00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ee00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ee00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ee06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eect00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eform.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eo06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eors.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\epb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\epb2jd.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\epj.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\epj2jd.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\epv00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eqec06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\eqeq94.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\era00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fad03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fae03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\faf03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\faju03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fal03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\falp03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fama03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fame03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fane03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\faom03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fapa03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fasa03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\faur03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fave03.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fk52h.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fk5hip.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fk5hz.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fw2m.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\fw2xy.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\g2icrs.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gc2gd.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gc2gde.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gd2gc.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gd2gce.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gmst00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gmst06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gmst82.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gst00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gst00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gst06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gst06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\gst94.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\h2fk5.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\hd2ae.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\hd2pa.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\hfk5z.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\icrs2g.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ir.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\jd2cal.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\jdcalf.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ld.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ldn.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ldsun.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\lteceq.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ltecm.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\lteqec.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ltp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ltpb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ltpecl.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ltpequ.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\num00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\num00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\num06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\numat.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nut00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nut00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nut06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nut80.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nutm80.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\obl06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\obl80.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\p06e.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\p2pv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\p2s.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pap.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pas.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pb06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pdp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pfw06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\plan94.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pm.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmat00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmat06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmat76.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmpx.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pmsafe.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pn06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pnm00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pnm00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pnm06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pnm80.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pom00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ppp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ppsp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pr00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\prec76.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pv2p.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pv2s.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvdpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvm.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvmpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvppv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvstar.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvtob.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvu.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvup.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pvxpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\pxp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\refco.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rm2v.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rv2m.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rx.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rxp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rxpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rxr.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ry.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\rz.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s2c.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s2p.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s2pv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\s2xpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\sepp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\seps.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\sp00.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\starpm.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\starpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\sxp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\sxpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\taitt.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\taiut1.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\taiutc.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tcbtdb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tcgtt.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tdbtcb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tdbtt.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tf2a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tf2d.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tpors.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tporv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tpsts.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tpstv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tpxes.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tpxev.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tr.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\trxp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\trxpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tttai.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tttcg.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\tttdb.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ttut1.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ut1tai.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ut1tt.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\ut1utc.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\utctai.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\utcut1.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\xy06.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\xys00a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\xys00b.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\xys06a.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\zp.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\zpv.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\zr.c">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/SOFA/SOFA/src/a2af.c
+++ b/SOFA/SOFA/src/a2af.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauA2af(int ndp, double angle, char *sign, int idmsf[4])
 /*
@@ -9,7 +10,7 @@ void iauA2af(int ndp, double angle, char *sign, int idmsf[4])
 **  Decompose radians into degrees, arcminutes, arcseconds, fraction.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -56,11 +57,11 @@ void iauA2af(int ndp, double angle, char *sign, int idmsf[4])
 **  Called:
 **     iauD2tf      decompose days to hms
 **
-**  This revision:  2020 April 1
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Hours to degrees * radians to turns */
@@ -70,12 +71,12 @@ void iauA2af(int ndp, double angle, char *sign, int idmsf[4])
 /* Scale then use days to h,m,s function. */
    iauD2tf(ndp, angle*F, sign, idmsf);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/a2tf.c
+++ b/SOFA/SOFA/src/a2tf.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 /*
@@ -9,7 +10,7 @@ void iauA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 **  Decompose radians into hours, minutes, seconds, fraction.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -56,22 +57,22 @@ void iauA2tf(int ndp, double angle, char *sign, int ihmsf[4])
 **  Called:
 **     iauD2tf      decompose days to hms
 **
-**  This revision:  2020 April 1
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Scale then use days to h,m,s function. */
    iauD2tf(ndp, angle/D2PI, sign, ihmsf);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ab.c
+++ b/SOFA/SOFA/src/ab.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauAb(double pnat[3], double v[3], double s, double bm1,
            double ppr[3])
@@ -53,11 +54,11 @@ void iauAb(double pnat[3], double v[3], double s, double bm1,
 **  Called:
 **     iauPdp       scalar product of two p-vectors
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -82,8 +83,8 @@ void iauAb(double pnat[3], double v[3], double s, double bm1,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ae2hd.c
+++ b/SOFA/SOFA/src/ae2hd.c
@@ -59,9 +59,9 @@ void iauAe2hd (double az, double el, double phi,
 **
 **  Last revision:   2017 September 12
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double sa, ca, se, ce, sp, cp, x, y, z, r;
@@ -89,8 +89,8 @@ void iauAe2hd (double az, double el, double phi,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/af2a.c
+++ b/SOFA/SOFA/src/af2a.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 #include <stdlib.h>
 
 int iauAf2a(char s, int ideg, int iamin, double asec, double *rad)
@@ -39,11 +40,11 @@ int iauAf2a(char s, int ideg, int iamin, double asec, double *rad)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -59,10 +60,12 @@ int iauAf2a(char s, int ideg, int iamin, double asec, double *rad)
    if ( asec < 0.0 || asec >= 60.0 ) return 3;
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/anp.c
+++ b/SOFA/SOFA/src/anp.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauAnp(double a)
 /*
@@ -9,7 +10,7 @@ double iauAnp(double a)
 **  Normalize angle into the range 0 <= a < 2pi.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -19,11 +20,11 @@ double iauAnp(double a)
 **  Returned (function value):
 **              double     angle in range 0-2pi
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double w;
@@ -34,10 +35,12 @@ double iauAnp(double a)
 
    return w;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/anpm.c
+++ b/SOFA/SOFA/src/anpm.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauAnpm(double a)
 /*
@@ -9,7 +10,7 @@ double iauAnpm(double a)
 **  Normalize angle into the range -pi <= a < +pi.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -19,11 +20,11 @@ double iauAnpm(double a)
 **  Returned (function value):
 **              double     angle in range +/-pi
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double w;
@@ -34,10 +35,12 @@ double iauAnpm(double a)
 
    return w;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apcg.c
+++ b/SOFA/SOFA/src/apcg.c
@@ -109,9 +109,9 @@ void iauApcg(double date1, double date2,
 **
 **  This revision:   2013 October 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Geocentric observer */
@@ -126,8 +126,8 @@ void iauApcg(double date1, double date2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apcg13.c
+++ b/SOFA/SOFA/src/apcg13.c
@@ -111,9 +111,9 @@ void iauApcg13(double date1, double date2, iauASTROM *astrom)
 **
 **  This revision:   2013 October 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ehpv[2][3], ebpv[2][3];
@@ -129,8 +129,8 @@ void iauApcg13(double date1, double date2, iauASTROM *astrom)
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apci.c
+++ b/SOFA/SOFA/src/apci.c
@@ -119,9 +119,9 @@ void iauApci(double date1, double date2,
 **
 **  This revision:   2013 September 25
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -135,8 +135,8 @@ void iauApci(double date1, double date2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apci13.c
+++ b/SOFA/SOFA/src/apci13.c
@@ -43,7 +43,7 @@ void iauApci13(double date1, double date2,
 **      eral   double       unchanged
 **      refa   double       unchanged
 **      refb   double       unchanged
-**     eo     double*     equation of the origins (ERA-GST)
+**     eo     double*     equation of the origins (ERA-GST, radians)
 **
 **  Notes:
 **
@@ -115,11 +115,11 @@ void iauApci13(double date1, double date2,
 **     iauApci      astrometry parameters, ICRS-CIRS
 **     iauEors      equation of the origins, given NPB matrix and s
 **
-**  This revision:   2013 October 9
+**  This revision:   2022 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ehpv[2][3], ebpv[2][3], r[3][3], x, y, s;
@@ -147,8 +147,8 @@ void iauApci13(double date1, double date2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apco.c
+++ b/SOFA/SOFA/src/apco.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauApco(double date1, double date2,
              double ebpv[2][3], double ehp[3],
@@ -48,7 +49,7 @@ void iauApco(double date1, double date2,
 **      v      double[3]    barycentric observer velocity (vector, c)
 **      bm1    double       sqrt(1-|v|^2): reciprocal of Lorenz factor
 **      bpn    double[3][3] bias-precession-nutation matrix
-**      along  double       longitude + s' (radians)
+**      along  double       adjusted longitude (radians)
 **      xpl    double       polar motion xp wrt local meridian (radians)
 **      ypl    double       polar motion yp wrt local meridian (radians)
 **      sphi   double       sine of geodetic latitude
@@ -92,6 +93,9 @@ void iauApco(double date1, double date2,
 **     CONVENTION:  the longitude required by the present function is
 **     right-handed, i.e. east-positive, in accordance with geographical
 **     convention.
+**
+**     The adjusted longitude stored in the astrom array takes into
+**     account the TIO locator and polar motion.
 **
 **  4) xp and yp are the coordinates (in radians) of the Celestial
 **     Intermediate Pole with respect to the International Terrestrial
@@ -150,31 +154,50 @@ void iauApco(double date1, double date2,
 **     iauAtioq, iauAtoiq, iauAtciq* and iauAticq*.
 **
 **  Called:
-**     iauAper      astrometry parameters: update ERA
+**     iauIr        initialize r-matrix to identity
+**     iauRz        rotate around Z-axis
+**     iauRy        rotate around Y-axis
+**     iauRx        rotate around X-axis
+**     iauAnpm      normalize angle into range +/- pi
 **     iauC2ixys    celestial-to-intermediate matrix, given X,Y and s
 **     iauPvtob     position/velocity of terrestrial station
 **     iauTrxpv     product of transpose of r-matrix and pv-vector
 **     iauApcs      astrometry parameters, ICRS-GCRS, space observer
 **     iauCr        copy r-matrix
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
-   double sl, cl, r[3][3], pvc[2][3], pv[2][3];
+   double r[3][3], a, b, eral, c, pvc[2][3], pv[2][3];
 
 
-/* Longitude with adjustment for TIO locator s'. */
-   astrom->along = elong + sp;
+/* Form the rotation matrix, CIRS to apparent [HA,Dec]. */
+   iauIr(r);
+   iauRz(theta+sp, r);
+   iauRy(-xp, r);
+   iauRx(-yp, r);
+   iauRz(elong, r);
 
-/* Polar motion, rotated onto the local meridian. */
-   sl = sin(astrom->along);
-   cl = cos(astrom->along);
-   astrom->xpl = xp*cl - yp*sl;
-   astrom->ypl = xp*sl + yp*cl;
+/* Solve for local Earth rotation angle. */
+   a = r[0][0];
+   b = r[0][1];
+   eral = ( a != 0.0 || b != 0.0 ) ?  atan2(b, a) : 0.0;
+   astrom->eral = eral;
+
+/* Solve for polar motion [X,Y] with respect to local meridian. */
+   a = r[0][0];
+   c = r[0][2];
+   astrom->xpl = atan2(c, sqrt(a*a+b*b));
+   a = r[1][2];
+   b = r[2][2];
+   astrom->ypl = ( a != 0.0 || b != 0.0 ) ? -atan2(a, b) : 0.0;
+
+/* Adjusted longitude. */
+   astrom->along = iauAnpm(eral - theta);
 
 /* Functions of latitude. */
    astrom->sphi = sin(phi);
@@ -183,9 +206,6 @@ void iauApco(double date1, double date2,
 /* Refraction constants. */
    astrom->refa = refa;
    astrom->refb = refb;
-
-/* Local Earth rotation angle. */
-   iauAper(theta, astrom);
 
 /* Disable the (redundant) diurnal aberration step. */
    astrom->diurab = 0.0;
@@ -209,8 +229,8 @@ void iauApco(double date1, double date2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apco13.c
+++ b/SOFA/SOFA/src/apco13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauApco13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
@@ -55,7 +56,7 @@ int iauApco13(double utc1, double utc2, double dut1,
 **      eral   double       "local" Earth rotation angle (radians)
 **      refa   double       refraction constant A (radians)
 **      refb   double       refraction constant B (radians)
-**     eo     double*    equation of the origins (ERA-GST)
+**     eo     double*    equation of the origins (ERA-GST, radians)
 **
 **  Returned (function value):
 **            int        status: +1 = dubious year (Note 2)
@@ -178,11 +179,11 @@ int iauApco13(double utc1, double utc2, double dut1,
 **     iauApco      astrometry parameters, ICRS-observed
 **     iauEors      equation of the origins, given NPB matrix and s
 **
-**  This revision:   2013 December 5
+**  This revision:   2022 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -232,8 +233,8 @@ int iauApco13(double utc1, double utc2, double dut1,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apcs.c
+++ b/SOFA/SOFA/src/apcs.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauApcs(double date1, double date2, double pv[2][3],
              double ebpv[2][3], double ehp[3],
@@ -127,11 +128,11 @@ void iauApcs(double date1, double date2, double pv[2][3],
 **     iauPn        decompose p-vector into modulus and direction
 **     iauIr        initialize r-matrix to identity
 **
-**  This revision:   2017 March 16
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* au/d to m/s */
@@ -178,8 +179,8 @@ void iauApcs(double date1, double date2, double pv[2][3],
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apcs13.c
+++ b/SOFA/SOFA/src/apcs13.c
@@ -118,9 +118,9 @@ void iauApcs13(double date1, double date2, double pv[2][3],
 **
 **  This revision:   2013 October 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ehpv[2][3], ebpv[2][3];
@@ -136,8 +136,8 @@ void iauApcs13(double date1, double date2, double pv[2][3],
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/aper.c
+++ b/SOFA/SOFA/src/aper.c
@@ -96,9 +96,9 @@ void iauAper(double theta, iauASTROM *astrom)
 **
 **  This revision:   2013 September 25
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    astrom->eral = theta + astrom->along;
@@ -107,8 +107,8 @@ void iauAper(double theta, iauASTROM *astrom)
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/aper13.c
+++ b/SOFA/SOFA/src/aper13.c
@@ -115,9 +115,9 @@ void iauAper13(double ut11, double ut12, iauASTROM *astrom)
 **
 **  This revision:   2013 September 25
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauAper(iauEra00(ut11,ut12), astrom);
@@ -126,8 +126,8 @@ void iauAper13(double ut11, double ut12, iauASTROM *astrom)
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apio.c
+++ b/SOFA/SOFA/src/apio.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauApio(double sp, double theta,
              double elong, double phi, double hm, double xp, double yp,
@@ -38,7 +39,7 @@ void iauApio(double sp, double theta,
 **      v      double[3]    unchanged
 **      bm1    double       unchanged
 **      bpn    double[3][3] unchanged
-**      along  double       longitude + s' (radians)
+**      along  double       adjusted longitude (radians)
 **      xpl    double       polar motion xp wrt local meridian (radians)
 **      ypl    double       polar motion yp wrt local meridian (radians)
 **      sphi   double       sine of geodetic latitude
@@ -115,27 +116,46 @@ void iauApio(double sp, double theta,
 **     iauAtioq and iauAtoiq.
 **
 **  Called:
+**     iauIr        initialize r-matrix to identity
+**     iauRz        rotate around Z-axis
+**     iauRy        rotate around Y-axis
+**     iauRx        rotate around X-axis
+**     iauAnpm      normalize angle into range +/- pi
 **     iauPvtob     position/velocity of terrestrial station
-**     iauAper      astrometry parameters: update ERA
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
-   double sl, cl, pv[2][3];
+   double r[3][3], a, b, eral, c, pv[2][3];
 
 
-/* Longitude with adjustment for TIO locator s'. */
-   astrom->along = elong + sp;
+/* Form the rotation matrix, CIRS to apparent [HA,Dec]. */
+   iauIr(r);
+   iauRz(theta+sp, r);
+   iauRy(-xp, r);
+   iauRx(-yp, r);
+   iauRz(elong, r);
 
-/* Polar motion, rotated onto the local meridian. */
-   sl = sin(astrom->along);
-   cl = cos(astrom->along);
-   astrom->xpl = xp*cl - yp*sl;
-   astrom->ypl = xp*sl + yp*cl;
+/* Solve for local Earth rotation angle. */
+   a = r[0][0];
+   b = r[0][1];
+   eral = ( a != 0.0 || b != 0.0 ) ?  atan2(b, a) : 0.0;
+   astrom->eral = eral;
+
+/* Solve for polar motion [X,Y] with respect to local meridian. */
+   a = r[0][0];
+   c = r[0][2];
+   astrom->xpl = atan2(c, sqrt(a*a+b*b));
+   a = r[1][2];
+   b = r[2][2];
+   astrom->ypl = ( a != 0.0 || b != 0.0 ) ? -atan2(a, b) : 0.0;
+
+/* Adjusted longitude. */
+   astrom->along = iauAnpm(eral - theta);
 
 /* Functions of latitude. */
    astrom->sphi = sin(phi);
@@ -151,15 +171,12 @@ void iauApio(double sp, double theta,
    astrom->refa = refa;
    astrom->refb = refb;
 
-/* Local Earth rotation angle. */
-   iauAper(theta, astrom);
-
 /* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/apio13.c
+++ b/SOFA/SOFA/src/apio13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauApio13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
@@ -167,11 +168,11 @@ int iauApio13(double utc1, double utc2, double dut1,
 **     iauRefco     refraction constants for given ambient conditions
 **     iauApio      astrometry parameters, CIRS-observed
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -204,8 +205,8 @@ int iauApio13(double utc1, double utc2, double dut1,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atcc13.c
+++ b/SOFA/SOFA/src/atcc13.c
@@ -1,15 +1,16 @@
 #include "sofa.h"
-#include "sofam.h"
-#include <float.h>
 
-int iauJd2cal(double dj1, double dj2,
-              int *iy, int *im, int *id, double *fd)
+void iauAtcc13(double rc, double dc,
+               double pr, double pd, double px, double rv,
+               double date1, double date2,
+               double *ra, double *da)
 /*
 **  - - - - - - - - - -
-**   i a u J d 2 c a l
+**   i a u A t c c 1 3
 **  - - - - - - - - - -
 **
-**  Julian Date to Gregorian year, month, day, and fraction of a day.
+**  Transform a star's ICRS catalog entry (epoch J2000.0) into ICRS
+**  astrometric place.
 **
 **  This function is part of the International Astronomical Union's
 **  SOFA (Standards of Fundamental Astronomy) software collection.
@@ -17,139 +18,72 @@ int iauJd2cal(double dj1, double dj2,
 **  Status:  support function.
 **
 **  Given:
-**     dj1,dj2   double   Julian Date (Notes 1, 2)
+**     rc     double   ICRS right ascension at J2000.0 (radians, Note 1)
+**     dc     double   ICRS declination at J2000.0 (radians, Note 1)
+**     pr     double   RA proper motion (radians/year, Note 2)
+**     pd     double   Dec proper motion (radians/year)
+**     px     double   parallax (arcsec)
+**     rv     double   radial velocity (km/s, +ve if receding)
+**     date1  double   TDB as a 2-part...
+**     date2  double   ...Julian Date (Note 3)
 **
-**  Returned (arguments):
-**     iy        int      year
-**     im        int      month
-**     id        int      day
-**     fd        double   fraction of day
-**
-**  Returned (function value):
-**               int      status:
-**                           0 = OK
-**                          -1 = unacceptable date (Note 1)
+**  Returned:
+**     ra,da  double*  ICRS astrometric RA,Dec (radians)
 **
 **  Notes:
 **
-**  1) The earliest valid date is -68569.5 (-4900 March 1).  The
-**     largest value accepted is 1e9.
+**  1) Star data for an epoch other than J2000.0 (for example from the
+**     Hipparcos catalog, which has an epoch of J1991.25) will require a
+**     preliminary call to iauPmsafe before use.
 **
-**  2) The Julian Date is apportioned in any convenient way between
-**     the arguments dj1 and dj2.  For example, JD=2450123.7 could
-**     be expressed in any of these ways, among others:
+**  2) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
 **
-**            dj1             dj2
+**  3) The TDB date date1+date2 is a Julian Date, apportioned in any
+**     convenient way between the two arguments.  For example,
+**     JD(TDB)=2450123.7 could be expressed in any of these ways, among
+**     others:
+**
+**            date1          date2
 **
 **         2450123.7           0.0       (JD method)
 **         2451545.0       -1421.3       (J2000 method)
 **         2400000.5       50123.2       (MJD method)
 **         2450123.5           0.2       (date & time method)
 **
-**     Separating integer and fraction uses the "compensated summation"
-**     algorithm of Kahan-Neumaier to preserve as much precision as
-**     possible irrespective of the jd1+jd2 apportionment.
+**     The JD method is the most natural and convenient to use in cases
+**     where the loss of several decimal digits of resolution is
+**     acceptable.  The J2000 method is best matched to the way the
+**     argument is handled internally and will deliver the optimum
+**     resolution.  The MJD method and the date & time methods are both
+**     good compromises between resolution and convenience.  For most
+**     applications of this function the choice will not be at all
+**     critical.
 **
-**  3) In early eras the conversion is from the "proleptic Gregorian
-**     calendar";  no account is taken of the date(s) of adoption of
-**     the Gregorian calendar, nor is the AD/BC numbering convention
-**     observed.
+**     TT can be used instead of TDB without any significant impact on
+**     accuracy.
 **
-**  References:
+**  Called:
+**     iauApci13    astrometry parameters, ICRS-CIRS, 2013
+**     iauAtccq     quick catalog ICRS to astrometric
 **
-**     Explanatory Supplement to the Astronomical Almanac,
-**     P. Kenneth Seidelmann (ed), University Science Books (1992),
-**     Section 12.92 (p604).
-**
-**     Klein, A., A Generalized Kahan-Babuska-Summation-Algorithm.
-**     Computing, 76, 279-293 (2006), Section 3.
-**
-**  This revision:  2021 May 11
+**  This revision:   2021 April 18
 **
 **  SOFA release 2023-10-11
 **
 **  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
-/* Minimum and maximum allowed JD */
-   const double DJMIN = -68569.5;
-   const double DJMAX = 1e9;
+/* Star-independent astrometry parameters */
+   iauASTROM astrom;
 
-   long jd, i, l, n, k;
-   double dj, f1, f2, d, s, cs, v[2], x, t, f;
+   double w;
 
 
-/* Verify date is acceptable. */
-   dj = dj1 + dj2;
-   if (dj < DJMIN || dj > DJMAX) return -1;
+/* The transformation parameters. */
+   iauApci13(date1, date2, &astrom, &w);
 
-/* Separate day and fraction (where -0.5 <= fraction < 0.5). */
-   d = dnint(dj1);
-   f1 = dj1 - d;
-   jd = (long) d;
-   d = dnint(dj2);
-   f2 = dj2 - d;
-   jd += (long) d;
-
-/* Compute f1+f2+0.5 using compensated summation (Klein 2006). */
-   s = 0.5;
-   cs = 0.0;
-   v[0] = f1;
-   v[1] = f2;
-   for ( i = 0; i < 2; i++ ) {
-      x = v[i];
-      t = s + x;
-      cs += fabs(s) >= fabs(x) ? (s-t) + x : (x-t) + s;
-      s = t;
-      if ( s >= 1.0 ) {
-         jd++;
-         s -= 1.0;
-      }
-   }
-   f = s + cs;
-   cs = f - s;
-
-/* Deal with negative f. */
-   if ( f < 0.0 ) {
-
-   /* Compensated summation: assume that |s| <= 1.0. */
-      f = s + 1.0;
-      cs += (1.0-f) + s;
-      s  = f;
-      f = s + cs;
-      cs = f - s;
-      jd--;
-   }
-
-/* Deal with f that is 1.0 or more (when rounded to double). */
-   if ( (f-1.0) >= -DBL_EPSILON/4.0 ) {
-
-   /* Compensated summation: assume that |s| <= 1.0. */
-      t = s - 1.0;
-      cs += (s-t) - 1.0;
-      s = t;
-      f = s + cs;
-      if ( -DBL_EPSILON/2.0 < f ) {
-         jd++;
-         f = gmax(f, 0.0);
-      }
-   }
-
-/* Express day in Gregorian calendar. */
-   l = jd + 68569L;
-   n = (4L * l) / 146097L;
-   l -= (146097L * n + 3L) / 4L;
-   i = (4000L * (l + 1L)) / 1461001L;
-   l -= (1461L * i) / 4L - 31L;
-   k = (80L * l) / 2447L;
-   *id = (int) (l - (2447L * k) / 80L);
-   l = k / 11L;
-   *im = (int) (k + 2L - 12L * l);
-   *iy = (int) (100L * (n - 49L) + i + l);
-   *fd = f;
-
-/* Success. */
-   return 0;
+/* Catalog ICRS (epoch J2000.0) to astrometric. */
+   iauAtccq(rc, dc, pr, pd, px, rv, &astrom, ra, da);
 
 /* Finished. */
 

--- a/SOFA/SOFA/src/atccq.c
+++ b/SOFA/SOFA/src/atccq.c
@@ -1,15 +1,24 @@
 #include "sofa.h"
-#include "sofam.h"
-#include <float.h>
 
-int iauJd2cal(double dj1, double dj2,
-              int *iy, int *im, int *id, double *fd)
+void iauAtccq(double rc, double dc,
+              double pr, double pd, double px, double rv,
+              iauASTROM *astrom, double *ra, double *da)
 /*
-**  - - - - - - - - - -
-**   i a u J d 2 c a l
-**  - - - - - - - - - -
+**  - - - - - - - - -
+**   i a u A t c c q
+**  - - - - - - - - -
 **
-**  Julian Date to Gregorian year, month, day, and fraction of a day.
+**  Quick transformation of a star's ICRS catalog entry (epoch J2000.0)
+**  into ICRS astrometric place, given precomputed star-independent
+**  astrometry parameters.
+**
+**  Use of this function is appropriate when efficiency is important and
+**  where many star positions are to be transformed for one date.  The
+**  star-independent parameters can be obtained by calling one of the
+**  functions iauApci[13], iauApcg[13], iauApco[13] or iauApcs[13].
+**
+**  If the parallax and proper motions are zero the transformation has
+**  no effect.
 **
 **  This function is part of the International Astronomical Union's
 **  SOFA (Standards of Fundamental Astronomy) software collection.
@@ -17,139 +26,63 @@ int iauJd2cal(double dj1, double dj2,
 **  Status:  support function.
 **
 **  Given:
-**     dj1,dj2   double   Julian Date (Notes 1, 2)
+**     rc,dc  double     ICRS RA,Dec at J2000.0 (radians)
+**     pr     double     RA proper motion (radians/year, Note 3)
+**     pd     double     Dec proper motion (radians/year)
+**     px     double     parallax (arcsec)
+**     rv     double     radial velocity (km/s, +ve if receding)
+**     astrom iauASTROM* star-independent astrometry parameters:
+**      pmt    double       PM time interval (SSB, Julian years)
+**      eb     double[3]    SSB to observer (vector, au)
+**      eh     double[3]    Sun to observer (unit vector)
+**      em     double       distance from Sun to observer (au)
+**      v      double[3]    barycentric observer velocity (vector, c)
+**      bm1    double       sqrt(1-|v|^2): reciprocal of Lorenz factor
+**      bpn    double[3][3] bias-precession-nutation matrix
+**      along  double       longitude + s' (radians)
+**      xpl    double       polar motion xp wrt local meridian (radians)
+**      ypl    double       polar motion yp wrt local meridian (radians)
+**      sphi   double       sine of geodetic latitude
+**      cphi   double       cosine of geodetic latitude
+**      diurab double       magnitude of diurnal aberration vector
+**      eral   double       "local" Earth rotation angle (radians)
+**      refa   double       refraction constant A (radians)
+**      refb   double       refraction constant B (radians)
 **
-**  Returned (arguments):
-**     iy        int      year
-**     im        int      month
-**     id        int      day
-**     fd        double   fraction of day
-**
-**  Returned (function value):
-**               int      status:
-**                           0 = OK
-**                          -1 = unacceptable date (Note 1)
+**  Returned:
+**     ra,da  double*    ICRS astrometric RA,Dec (radians)
 **
 **  Notes:
 **
-**  1) The earliest valid date is -68569.5 (-4900 March 1).  The
-**     largest value accepted is 1e9.
+**  1) All the vectors are with respect to BCRS axes.
 **
-**  2) The Julian Date is apportioned in any convenient way between
-**     the arguments dj1 and dj2.  For example, JD=2450123.7 could
-**     be expressed in any of these ways, among others:
+**  2) Star data for an epoch other than J2000.0 (for example from the
+**     Hipparcos catalog, which has an epoch of J1991.25) will require a
+**     preliminary call to iauPmsafe before use.
 **
-**            dj1             dj2
+**  3) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
 **
-**         2450123.7           0.0       (JD method)
-**         2451545.0       -1421.3       (J2000 method)
-**         2400000.5       50123.2       (MJD method)
-**         2450123.5           0.2       (date & time method)
+**  Called:
+**     iauPmpx      proper motion and parallax
+**     iauC2s       p-vector to spherical
+**     iauAnp       normalize angle into range 0 to 2pi
 **
-**     Separating integer and fraction uses the "compensated summation"
-**     algorithm of Kahan-Neumaier to preserve as much precision as
-**     possible irrespective of the jd1+jd2 apportionment.
-**
-**  3) In early eras the conversion is from the "proleptic Gregorian
-**     calendar";  no account is taken of the date(s) of adoption of
-**     the Gregorian calendar, nor is the AD/BC numbering convention
-**     observed.
-**
-**  References:
-**
-**     Explanatory Supplement to the Astronomical Almanac,
-**     P. Kenneth Seidelmann (ed), University Science Books (1992),
-**     Section 12.92 (p604).
-**
-**     Klein, A., A Generalized Kahan-Babuska-Summation-Algorithm.
-**     Computing, 76, 279-293 (2006), Section 3.
-**
-**  This revision:  2021 May 11
+**  This revision:   2021 April 18
 **
 **  SOFA release 2023-10-11
 **
 **  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
-/* Minimum and maximum allowed JD */
-   const double DJMIN = -68569.5;
-   const double DJMAX = 1e9;
-
-   long jd, i, l, n, k;
-   double dj, f1, f2, d, s, cs, v[2], x, t, f;
+   double p[3], w;
 
 
-/* Verify date is acceptable. */
-   dj = dj1 + dj2;
-   if (dj < DJMIN || dj > DJMAX) return -1;
+/* Proper motion and parallax, giving BCRS coordinate direction. */
+   iauPmpx(rc, dc, pr, pd, px, rv, astrom->pmt, astrom->eb, p);
 
-/* Separate day and fraction (where -0.5 <= fraction < 0.5). */
-   d = dnint(dj1);
-   f1 = dj1 - d;
-   jd = (long) d;
-   d = dnint(dj2);
-   f2 = dj2 - d;
-   jd += (long) d;
-
-/* Compute f1+f2+0.5 using compensated summation (Klein 2006). */
-   s = 0.5;
-   cs = 0.0;
-   v[0] = f1;
-   v[1] = f2;
-   for ( i = 0; i < 2; i++ ) {
-      x = v[i];
-      t = s + x;
-      cs += fabs(s) >= fabs(x) ? (s-t) + x : (x-t) + s;
-      s = t;
-      if ( s >= 1.0 ) {
-         jd++;
-         s -= 1.0;
-      }
-   }
-   f = s + cs;
-   cs = f - s;
-
-/* Deal with negative f. */
-   if ( f < 0.0 ) {
-
-   /* Compensated summation: assume that |s| <= 1.0. */
-      f = s + 1.0;
-      cs += (1.0-f) + s;
-      s  = f;
-      f = s + cs;
-      cs = f - s;
-      jd--;
-   }
-
-/* Deal with f that is 1.0 or more (when rounded to double). */
-   if ( (f-1.0) >= -DBL_EPSILON/4.0 ) {
-
-   /* Compensated summation: assume that |s| <= 1.0. */
-      t = s - 1.0;
-      cs += (s-t) - 1.0;
-      s = t;
-      f = s + cs;
-      if ( -DBL_EPSILON/2.0 < f ) {
-         jd++;
-         f = gmax(f, 0.0);
-      }
-   }
-
-/* Express day in Gregorian calendar. */
-   l = jd + 68569L;
-   n = (4L * l) / 146097L;
-   l -= (146097L * n + 3L) / 4L;
-   i = (4000L * (l + 1L)) / 1461001L;
-   l -= (1461L * i) / 4L - 31L;
-   k = (80L * l) / 2447L;
-   *id = (int) (l - (2447L * k) / 80L);
-   l = k / 11L;
-   *im = (int) (k + 2L - 12L * l);
-   *iy = (int) (100L * (n - 49L) + i + l);
-   *fd = f;
-
-/* Success. */
-   return 0;
+/* ICRS astrometric RA,Dec. */
+   iauC2s(p, &w, da);
+   *ra = iauAnp(w);
 
 /* Finished. */
 

--- a/SOFA/SOFA/src/atci13.c
+++ b/SOFA/SOFA/src/atci13.c
@@ -17,18 +17,18 @@ void iauAtci13(double rc, double dc,
 **  Status:  support function.
 **
 **  Given:
-**     rc     double   ICRS right ascension at J2000.0 (radians, Note 1)
-**     dc     double   ICRS declination at J2000.0 (radians, Note 1)
-**     pr     double   RA proper motion (radians/year; Note 2)
-**     pd     double   Dec proper motion (radians/year)
-**     px     double   parallax (arcsec)
-**     rv     double   radial velocity (km/s, +ve if receding)
-**     date1  double   TDB as a 2-part...
-**     date2  double   ...Julian Date (Note 3)
+**     rc     double  ICRS right ascension at J2000.0 (radians, Note 1)
+**     dc     double  ICRS declination at J2000.0 (radians, Note 1)
+**     pr     double  RA proper motion (radians/year, Note 2)
+**     pd     double  Dec proper motion (radians/year)
+**     px     double  parallax (arcsec)
+**     rv     double  radial velocity (km/s, +ve if receding)
+**     date1  double  TDB as a 2-part...
+**     date2  double  ...Julian Date (Note 3)
 **
 **  Returned:
-**     ri,di  double*  CIRS geocentric RA,Dec (radians)
-**     eo     double*  equation of the origins (ERA-GST, Note 5)
+**     ri,di  double* CIRS geocentric RA,Dec (radians)
+**     eo     double* equation of the origins (ERA-GST, radians, Note 5)
 **
 **  Notes:
 **
@@ -83,11 +83,11 @@ void iauAtci13(double rc, double dc,
 **     iauApci13    astrometry parameters, ICRS-CIRS, 2013
 **     iauAtciq     quick ICRS to CIRS
 **
-**  This revision:   2017 March 12
+**  This revision:   2022 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Star-independent astrometry parameters */
@@ -104,8 +104,8 @@ void iauAtci13(double rc, double dc,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atciq.c
+++ b/SOFA/SOFA/src/atciq.c
@@ -25,8 +25,8 @@ void iauAtciq(double rc, double dc,
 **  Status:  support function.
 **
 **  Given:
-**     rc,dc  double     ICRS RA,Dec at J2000.0 (radians)
-**     pr     double     RA proper motion (radians/year; Note 3)
+**     rc,dc  double     ICRS RA,Dec at J2000.0 (radians, Note 1)
+**     pr     double     RA proper motion (radians/year, Note 2)
 **     pd     double     Dec proper motion (radians/year)
 **     px     double     parallax (arcsec)
 **     rv     double     radial velocity (km/s, +ve if receding)
@@ -53,13 +53,11 @@ void iauAtciq(double rc, double dc,
 **
 **  Notes:
 **
-**  1) All the vectors are with respect to BCRS axes.
-**
-**  2) Star data for an epoch other than J2000.0 (for example from the
+**  1) Star data for an epoch other than J2000.0 (for example from the
 **     Hipparcos catalog, which has an epoch of J1991.25) will require a
 **     preliminary call to iauPmsafe before use.
 **
-**  3) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
+**  2) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
 **
 **  Called:
 **     iauPmpx      proper motion and parallax
@@ -69,11 +67,11 @@ void iauAtciq(double rc, double dc,
 **     iauC2s       p-vector to spherical
 **     iauAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 April 19
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
@@ -99,8 +97,8 @@ void iauAtciq(double rc, double dc,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atciqn.c
+++ b/SOFA/SOFA/src/atciqn.c
@@ -30,7 +30,7 @@ void iauAtciqn(double rc, double dc, double pr, double pd,
 **
 **  Given:
 **     rc,dc  double       ICRS RA,Dec at J2000.0 (radians)
-**     pr     double       RA proper motion (radians/year; Note 3)
+**     pr     double       RA proper motion (radians/year, Note 3)
 **     pd     double       Dec proper motion (radians/year)
 **     px     double       parallax (arcsec)
 **     rv     double       radial velocity (km/s, +ve if receding)
@@ -51,11 +51,11 @@ void iauAtciqn(double rc, double dc, double pr, double pd,
 **      eral   double       "local" Earth rotation angle (radians)
 **      refa   double       refraction constant A (radians)
 **      refb   double       refraction constant B (radians)
-**      n     int           number of bodies (Note 3)
-**      b     iauLDBODY[n] data for each of the n bodies (Notes 3,4):
-**       bm    double        mass of the body (solar masses, Note 5)
-**       dl    double        deflection limiter (Note 6)
-**       pv    [2][3]        barycentric PV of the body (au, au/day)
+**     n      int          number of bodies (Note 3)
+**     b      iauLDBODY[n] data for each of the n bodies (Notes 3,4):
+**      bm     double       mass of the body (solar masses, Note 5)
+**      dl     double       deflection limiter (Note 6)
+**      pv     [2][3]       barycentric PV of the body (au, au/day)
 **
 **  Returned:
 **     ri,di   double    CIRS RA,Dec (radians)
@@ -106,11 +106,11 @@ void iauAtciqn(double rc, double dc, double pr, double pd,
 **     iauC2s       p-vector to spherical
 **     iauAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 April 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
@@ -136,8 +136,8 @@ void iauAtciqn(double rc, double dc, double pr, double pd,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atciqz.c
+++ b/SOFA/SOFA/src/atciqz.c
@@ -70,9 +70,9 @@ void iauAtciqz(double rc, double dc, iauASTROM *astrom,
 **
 **  This revision:   2013 October 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double pco[3], pnat[3], ppr[3], pi[3], w;
@@ -98,8 +98,8 @@ void iauAtciqz(double rc, double dc, iauASTROM *astrom,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atco13.c
+++ b/SOFA/SOFA/src/atco13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauAtco13(double rc, double dc,
               double pr, double pd, double px, double rv,
@@ -25,7 +26,7 @@ int iauAtco13(double rc, double dc,
 **
 **  Given:
 **     rc,dc  double   ICRS right ascension at J2000.0 (radians, Note 1)
-**     pr     double   RA proper motion (radians/year; Note 2)
+**     pr     double   RA proper motion (radians/year, Note 2)
 **     pd     double   Dec proper motion (radians/year)
 **     px     double   parallax (arcsec)
 **     rv     double   radial velocity (km/s, +ve if receding)
@@ -47,7 +48,7 @@ int iauAtco13(double rc, double dc,
 **     hob    double*  observed hour angle (radians)
 **     dob    double*  observed declination (radians)
 **     rob    double*  observed right ascension (CIO-based, radians)
-**     eo     double*  equation of the origins (ERA-GST)
+**     eo     double*  equation of the origins (ERA-GST, radians)
 **
 **  Returned (function value):
 **            int      status: +1 = dubious year (Note 4)
@@ -156,11 +157,11 @@ int iauAtco13(double rc, double dc,
 **     iauAtciq     quick ICRS to CIRS
 **     iauAtioq     quick CIRS to observed
 **
-**  This revision:   2016 February 2
+**  This revision:   2022 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -188,8 +189,8 @@ int iauAtco13(double rc, double dc,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atic13.c
+++ b/SOFA/SOFA/src/atic13.c
@@ -21,7 +21,7 @@ void iauAtic13(double ri, double di, double date1, double date2,
 **
 **  Returned:
 **     rc,dc  double  ICRS astrometric RA,Dec (radians)
-**     eo     double  equation of the origins (ERA-GST, Note 4)
+**     eo     double  equation of the origins (ERA-GST, radians, Note 4)
 **
 **  Notes:
 **
@@ -76,11 +76,11 @@ void iauAtic13(double ri, double di, double date1, double date2,
 **     iauApci13    astrometry parameters, ICRS-CIRS, 2013
 **     iauAticq     quick CIRS to ICRS astrometric
 **
-**  This revision:   2013 October 9
+**  This revision:   2022 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Star-independent astrometry parameters */
@@ -97,8 +97,8 @@ void iauAtic13(double ri, double di, double date1, double date2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/aticq.c
+++ b/SOFA/SOFA/src/aticq.c
@@ -66,9 +66,9 @@ void iauAticq(double ri, double di, iauASTROM *astrom,
 **
 **  This revision:   2013 October 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j, i;
@@ -144,8 +144,8 @@ void iauAticq(double ri, double di, iauASTROM *astrom,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/aticqn.c
+++ b/SOFA/SOFA/src/aticqn.c
@@ -44,11 +44,11 @@ void iauAticqn(double ri, double di, iauASTROM *astrom,
 **      eral   double       "local" Earth rotation angle (radians)
 **      refa   double       refraction constant A (radians)
 **      refb   double       refraction constant B (radians)
-**      n     int           number of bodies (Note 3)
-**      b     iauLDBODY[n] data for each of the n bodies (Notes 3,4):
-**       bm    double       mass of the body (solar masses, Note 5)
-**       dl    double       deflection limiter (Note 6)
-**       pv    [2][3]       barycentric PV of the body (au, au/day)
+**     n      int          number of bodies (Note 3)
+**     b      iauLDBODY[n] data for each of the n bodies (Notes 3,4):
+**      bm     double       mass of the body (solar masses, Note 5)
+**      dl     double       deflection limiter (Note 6)
+**      pv     [2][3]       barycentric PV of the body (au, au/day)
 **
 **  Returned:
 **     rc,dc  double     ICRS astrometric RA,Dec (radians)
@@ -102,11 +102,11 @@ void iauAticqn(double ri, double di, iauASTROM *astrom,
 **     iauC2s       p-vector to spherical
 **     iauAnp       normalize angle into range +/- pi
 **
-**  This revision:   2018 December 13
+**  This revision:   2021 January 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j, i;
@@ -182,8 +182,8 @@ void iauAticqn(double ri, double di, iauASTROM *astrom,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atio13.c
+++ b/SOFA/SOFA/src/atio13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauAtio13(double ri, double di,
               double utc1, double utc2, double dut1,
@@ -139,11 +140,11 @@ int iauAtio13(double ri, double di,
 **     iauApio13    astrometry parameters, CIRS-observed, 2013
 **     iauAtioq     quick CIRS to observed
 **
-**  This revision:   2016 February 2
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -167,8 +168,8 @@ int iauAtio13(double ri, double di,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atioq.c
+++ b/SOFA/SOFA/src/atioq.c
@@ -87,8 +87,9 @@ void iauAtioq(double ri, double di, iauASTROM *astrom,
 **     then adjusting for refraction.  The HA,Dec is obtained by
 **     rotating back into equatorial coordinates, and is the position
 **     that would be seen by a perfect equatorial with its polar axis
-**     aligned to the Earth's axis of rotation.  Finally, the RA is
-**     obtained by subtracting the HA from the local ERA.
+**     aligned to the Earth's axis of rotation.  Finally, the
+**     (CIO-based) RA is obtained by subtracting the HA from the local
+**     ERA.
 **
 **  6) The star-independent CIRS-to-observed-place parameters in ASTROM
 **     may be computed with iauApio[13] or iauApco[13].  If nothing has
@@ -100,20 +101,20 @@ void iauAtioq(double ri, double di, iauASTROM *astrom,
 **     iauC2s       p-vector to spherical
 **     iauAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2016 March 9
+**  This revision:   2022 August 30
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Minimum cos(alt) and sin(alt) for refraction purposes */
    const double CELMIN = 1e-6;
    const double SELMIN = 0.05;
 
-   double v[3], x, y, z, xhd, yhd, zhd, f, xhdt, yhdt, zhdt,
-          xaet, yaet, zaet, azobs, r, tz, w, del, cosdel,
-          xaeo, yaeo, zaeo, zdobs, hmobs, dcobs, raobs;
+   double v[3], x, y, z, sx, cx, sy, cy, xhd, yhd, zhd, f,
+          xhdt, yhdt, zhdt, xaet, yaet, zaet, azobs, r, tz, w, del,
+          cosdel, xaeo, yaeo, zaeo, zdobs, hmobs, dcobs, raobs;
 
 
 /* CIRS RA,Dec to Cartesian -HA,Dec. */
@@ -123,9 +124,13 @@ void iauAtioq(double ri, double di, iauASTROM *astrom,
    z = v[2];
 
 /* Polar motion. */
-   xhd = x + astrom->xpl*z;
-   yhd = y - astrom->ypl*z;
-   zhd = z - astrom->xpl*x + astrom->ypl*y;
+   sx = sin(astrom->xpl);
+   cx = cos(astrom->xpl);
+   sy = sin(astrom->ypl);
+   cy = cos(astrom->ypl);
+   xhd = cx*x + sx*z;
+   yhd = sx*sy*x + cy*y - cx*sy*z;
+   zhd = -sx*cy*x + sy*y + cx*cy*z;
 
 /* Diurnal aberration. */
    f = ( 1.0 - astrom->diurab*yhd );
@@ -188,8 +193,8 @@ void iauAtioq(double ri, double di, iauASTROM *astrom,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atoc13.c
+++ b/SOFA/SOFA/src/atoc13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauAtoc13(const char *type, double ob1, double ob2,
               double utc1, double utc2, double dut1,
@@ -51,17 +52,18 @@ int iauAtoc13(const char *type, double ob1, double ob2,
 **      allowance is made for depression of the horizon.)  This is
 **      related to the observed HA,Dec via the standard rotation, using
 **      the geodetic latitude (corrected for polar motion), while the
-**      observed HA and RA are related simply through the Earth rotation
-**      angle and the site longitude.  "Observed" RA,Dec or HA,Dec thus
-**      means the position that would be seen by a perfect equatorial
-**      with its polar axis aligned to the Earth's axis of rotation.
+**      observed HA and (CIO-based) RA are related simply through the
+**      Earth rotation angle and the site longitude.  "Observed" RA,Dec
+**      or HA,Dec thus means the position that would be seen by a
+**      perfect equatorial with its polar axis aligned to the Earth's
+**      axis of rotation.
 **
 **  2)  Only the first character of the type argument is significant.
 **      "R" or "r" indicates that ob1 and ob2 are the observed right
-**      ascension and declination;  "H" or "h" indicates that they are
-**      hour angle (west +ve) and declination;  anything else ("A" or
-**      "a" is recommended) indicates that ob1 and ob2 are azimuth
-**      (north zero, east 90 deg) and zenith distance.
+**      ascension (CIO-based) and declination;  "H" or "h" indicates
+**      that they are hour angle (west +ve) and declination;  anything
+**      else ("A" or "a" is recommended) indicates that ob1 and ob2 are
+**      azimuth (north zero, east 90 deg) and zenith distance.
 **
 **  3)  utc1+utc2 is quasi Julian Date (see Note 2), apportioned in any
 **      convenient way between the two arguments, for example where utc1
@@ -146,11 +148,11 @@ int iauAtoc13(const char *type, double ob1, double ob2,
 **     iauAtoiq     quick observed to CIRS
 **     iauAticq     quick CIRS to ICRS
 **
-**  This revision:   2013 October 9
+**  This revision:   2022 August 30
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -178,8 +180,8 @@ int iauAtoc13(const char *type, double ob1, double ob2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atoi13.c
+++ b/SOFA/SOFA/src/atoi13.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauAtoi13(const char *type, double ob1, double ob2,
               double utc1, double utc2, double dut1,
@@ -51,10 +52,11 @@ int iauAtoi13(const char *type, double ob1, double ob2,
 **      allowance is made for depression of the horizon.)  This is
 **      related to the observed HA,Dec via the standard rotation, using
 **      the geodetic latitude (corrected for polar motion), while the
-**      observed HA and RA are related simply through the Earth rotation
-**      angle and the site longitude.  "Observed" RA,Dec or HA,Dec thus
-**      means the position that would be seen by a perfect equatorial
-**      with its polar axis aligned to the Earth's axis of rotation.
+**      observed HA and (CIO-based) RA are related simply through the
+**      Earth rotation angle and the site longitude.  "Observed" RA,Dec
+**      or HA,Dec thus means the position that would be seen by a
+**      perfect equatorial with its polar axis aligned to the Earth's
+**      axis of rotation.
 **
 **  2)  Only the first character of the type argument is significant.
 **      "R" or "r" indicates that ob1 and ob2 are the observed right
@@ -145,11 +147,11 @@ int iauAtoi13(const char *type, double ob1, double ob2,
 **     iauApio13    astrometry parameters, CIRS-observed, 2013
 **     iauAtoiq     quick observed to CIRS
 **
-**  This revision:   2013 October 9
+**  This revision:   2022 August 30
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -173,8 +175,8 @@ int iauAtoi13(const char *type, double ob1, double ob2,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/atoiq.c
+++ b/SOFA/SOFA/src/atoiq.c
@@ -46,34 +46,32 @@ void iauAtoiq(const char *type,
 **
 **  Notes:
 **
-**  1) "Observed" Az,El means the position that would be seen by a
+**  1) "Observed" Az,ZD means the position that would be seen by a
 **     perfect geodetically aligned theodolite.  This is related to
 **     the observed HA,Dec via the standard rotation, using the geodetic
 **     latitude (corrected for polar motion), while the observed HA and
-**     RA are related simply through the Earth rotation angle and the
-**     site longitude.  "Observed" RA,Dec or HA,Dec thus means the
-**     position that would be seen by a perfect equatorial with its
-**     polar axis aligned to the Earth's axis of rotation.  By removing
-**     from the observed place the effects of atmospheric refraction and
-**     diurnal aberration, the CIRS RA,Dec is obtained.
+**     (CIO-based) RA are related simply through the Earth rotation
+**     angle and the site longitude.  "Observed" RA,Dec or HA,Dec thus
+**     means the position that would be seen by a perfect equatorial
+**     with its polar axis aligned to the Earth's axis of rotation.
 **
 **  2) Only the first character of the type argument is significant.
 **     "R" or "r" indicates that ob1 and ob2 are the observed right
-**     ascension and declination;  "H" or "h" indicates that they are
-**     hour angle (west +ve) and declination;  anything else ("A" or
-**     "a" is recommended) indicates that ob1 and ob2 are azimuth (north
-**     zero, east 90 deg) and zenith distance.  (Zenith distance is used
-**     rather than altitude in order to reflect the fact that no
-**     allowance is made for depression of the horizon.)
+**     ascension (CIO-based) and declination;  "H" or "h" indicates that
+**     they are hour angle (west +ve) and declination;  anything else
+**     ("A" or "a" is recommended) indicates that ob1 and ob2 are
+**     azimuth (north zero, east 90 deg) and zenith distance.  (Zenith
+**     distance is used rather than altitude in order to reflect the
+**     fact that no allowance is made for depression of the horizon.)
 **
 **  3) The accuracy of the result is limited by the corrections for
 **     refraction, which use a simple A*tan(z) + B*tan^3(z) model.
 **     Providing the meteorological parameters are known accurately and
-**     there are no gross local effects, the predicted observed
+**     there are no gross local effects, the predicted intermediate
 **     coordinates should be within 0.05 arcsec (optical) or 1 arcsec
 **     (radio) for a zenith distance of less than 70 degrees, better
 **     than 30 arcsec (optical or radio) at 85 degrees and better than
-**     20 arcmin (optical) or 30 arcmin (radio) at the horizon.
+**     20 arcmin (optical) or 25 arcmin (radio) at the horizon.
 **
 **     Without refraction, the complementary functions iauAtioq and
 **     iauAtoiq are self-consistent to better than 1 microarcsecond all
@@ -90,18 +88,21 @@ void iauAtoiq(const char *type,
 **     iauC2s       p-vector to spherical
 **     iauAnp       normalize angle into range 0 to 2pi
 **
-**  This revision:   2013 October 9
+**  This revision:   2022 August 30
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
+/* Minimum sin(alt) for refraction purposes */
+   const double SELMIN = 0.05;
+
    int c;
    double c1, c2, sphi, cphi, ce, xaeo, yaeo, zaeo, v[3],
           xmhdo, ymhdo, zmhdo, az, sz, zdo, refa, refb, tz, dref,
           zdt, xaet, yaet, zaet, xmhda, ymhda, zmhda,
-          f, xhd, yhd, zhd, xpl, ypl, w, hma;
+          f, xhd, yhd, zhd, sx, cx, sy, cy, hma;
 
 
 /* Coordinate type. */
@@ -163,7 +164,7 @@ void iauAtoiq(const char *type,
 /* Fast algorithm using two constant model. */
    refa = astrom->refa;
    refb = astrom->refb;
-   tz = sz / zaeo;
+   tz = sz / ( zaeo > SELMIN ? zaeo : SELMIN );
    dref = ( refa + refb*tz*tz ) * tz;
    zdt = zdo + dref;
 
@@ -185,12 +186,13 @@ void iauAtoiq(const char *type,
    zhd = f * zmhda;
 
 /* Polar motion. */
-   xpl = astrom->xpl;
-   ypl = astrom->ypl;
-   w = xpl*xhd - ypl*yhd + zhd;
-   v[0] = xhd - xpl*w;
-   v[1] = yhd + ypl*w;
-   v[2] = w - ( xpl*xpl + ypl*ypl ) * zhd;
+   sx = sin(astrom->xpl);
+   cx = cos(astrom->xpl);
+   sy = sin(astrom->ypl);
+   cy = cos(astrom->ypl);
+   v[0] = cx*xhd + sx*sy*yhd - sx*cy*zhd;
+   v[1] = cy*yhd + sy*zhd;
+   v[2] = sx*xhd - cx*sy*yhd + cx*cy*zhd;
 
 /* To spherical -HA,Dec. */
    iauC2s(v, &hma, di);
@@ -202,8 +204,8 @@ void iauAtoiq(const char *type,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/bi00.c
+++ b/SOFA/SOFA/src/bi00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauBi00(double *dpsibi, double *depsbi, double *dra)
 /*
@@ -6,11 +7,12 @@ void iauBi00(double *dpsibi, double *depsbi, double *dra)
 **   i a u B i 0 0
 **  - - - - - - - -
 **
-**  Frame bias components of IAU 2000 precession-nutation models (part
-**  of MHB2000 with additions).
+**  Frame bias components of IAU 2000 precession-nutation models;  part
+**  of the Mathews-Herring-Buffett (MHB2000) nutation series, with
+**  additions.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -41,16 +43,16 @@ void iauBi00(double *dpsibi, double *depsbi, double *dra)
 **     Astrophys., 387, 700, 2002.
 **
 **     Mathews, P.M., Herring, T.A., Buffet, B.A., "Modeling of nutation
-**     and precession   New nutation series for nonrigid Earth and
+**     and precession:  New nutation series for nonrigid Earth and
 **     insights into the Earth's interior", J.Geophys.Res., 107, B4,
-**     2002.  The MHB2000 code itself was obtained on 9th September 2002
+**     2002.  The MHB2000 code itself was obtained on 2002 September 9
 **     from ftp://maia.usno.navy.mil/conv2000/chapter5/IAU2000A.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* The frame bias corrections in longitude and obliquity */
@@ -66,12 +68,12 @@ void iauBi00(double *dpsibi, double *depsbi, double *dra)
    *depsbi = DEBIAS;
    *dra = DRA0;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/bp00.c
+++ b/SOFA/SOFA/src/bp00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauBp00(double date1, double date2,
              double rb[3][3], double rp[3][3], double rbp[3][3])
@@ -10,7 +11,7 @@ void iauBp00(double date1, double date2,
 **  Frame bias and precession, IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -75,11 +76,11 @@ void iauBp00(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 August 21
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* J2000.0 obliquity (Lieske et al. 1977) */
@@ -122,12 +123,12 @@ void iauBp00(double date1, double date2,
 /* Bias-precession matrix: GCRS to mean of date. */
    iauRxr(rp, rbw, rbp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/bp06.c
+++ b/SOFA/SOFA/src/bp06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauBp06(double date1, double date2,
              double rb[3][3], double rp[3][3], double rbp[3][3])
@@ -10,7 +11,7 @@ void iauBp06(double date1, double date2,
 **  Frame bias and precession, IAU 2006.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -69,11 +70,11 @@ void iauBp06(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 August 21
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gamb, phib, psib, epsa, rbpw[3][3], rbt[3][3];
@@ -93,12 +94,12 @@ void iauBp06(double date1, double date2,
 /* PxB matrix. */
    iauCr(rbpw, rbp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/bpn2xy.c
+++ b/SOFA/SOFA/src/bpn2xy.c
@@ -10,7 +10,7 @@ void iauBpn2xy(double rbpn[3][3], double *x, double *y)
 **  of the Celestial Intermediate Pole.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -39,23 +39,23 @@ void iauBpn2xy(double rbpn[3][3], double *x, double *y)
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Extract the X,Y coordinates. */
    *x = rbpn[2][0];
    *y = rbpn[2][1];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2i00a.c
+++ b/SOFA/SOFA/src/c2i00a.c
@@ -10,7 +10,7 @@ void iauC2i00a(double date1, double date2, double rc2i[3][3])
 **  IAU 2000A precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -53,7 +53,7 @@ void iauC2i00a(double date1, double date2, double rc2i[3][3])
 **     Reference System (see IERS Conventions 2003), ERA is the Earth
 **     Rotation Angle and RPOM is the polar motion matrix.
 **
-**  3) A faster, but slightly less accurate result (about 1 mas), can be
+**  3) A faster, but slightly less accurate, result (about 1 mas) can be
 **     obtained by using instead the iauC2i00b function.
 **
 **  Called:
@@ -73,11 +73,11 @@ void iauC2i00a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3];
@@ -89,12 +89,12 @@ void iauC2i00a(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    iauC2ibpn(date1, date2, rbpn, rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2i00b.c
+++ b/SOFA/SOFA/src/c2i00b.c
@@ -10,7 +10,7 @@ void iauC2i00b(double date1, double date2, double rc2i[3][3])
 **  IAU 2000B precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -73,11 +73,11 @@ void iauC2i00b(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3];
@@ -89,12 +89,12 @@ void iauC2i00b(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    iauC2ibpn(date1, date2, rbpn, rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2i06a.c
+++ b/SOFA/SOFA/src/c2i06a.c
@@ -10,7 +10,7 @@ void iauC2i06a(double date1, double date2, double rc2i[3][3])
 **  IAU 2006 precession and IAU 2000A nutation models.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -64,11 +64,11 @@ void iauC2i06a(double date1, double date2, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3], x, y, s;
@@ -86,12 +86,12 @@ void iauC2i06a(double date1, double date2, double rc2i[3][3])
 /* Form the celestial-to-intermediate matrix. */
    iauC2ixys(x, y, s, rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2ibpn.c
+++ b/SOFA/SOFA/src/c2ibpn.c
@@ -11,7 +11,7 @@ void iauC2ibpn(double date1, double date2, double rbpn[3][3],
 **  the bias-precession-nutation matrix.  IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -76,11 +76,11 @@ void iauC2ibpn(double date1, double date2, double rbpn[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y;
@@ -92,12 +92,12 @@ void iauC2ibpn(double date1, double date2, double rbpn[3][3],
 /* Form the celestial-to-intermediate matrix (n.b. IAU 2000 specific). */
    iauC2ixy(date1, date2, x, y, rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2ixy.c
+++ b/SOFA/SOFA/src/c2ixy.c
@@ -11,7 +11,7 @@ void iauC2ixy(double date1, double date2, double x, double y,
 **  date when the CIP X,Y coordinates are known.  IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -70,23 +70,23 @@ void iauC2ixy(double date1, double date2, double x, double y,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 
 {
 /* Compute s and then the matrix. */
    iauC2ixys(x, y, iauS00(date1, date2, x, y), rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2ixys.c
+++ b/SOFA/SOFA/src/c2ixys.c
@@ -10,7 +10,7 @@ void iauC2ixys(double x, double y, double s, double rc2i[3][3])
 **  X,Y and the CIO locator s.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -52,11 +52,11 @@ void iauC2ixys(double x, double y, double s, double rc2i[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2014 November 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r2, e, d;
@@ -73,12 +73,12 @@ void iauC2ixys(double x, double y, double s, double rc2i[3][3])
    iauRy(d, rc2i);
    iauRz(-(e+s), rc2i);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2s.c
+++ b/SOFA/SOFA/src/c2s.c
@@ -9,7 +9,7 @@ void iauC2s(double p[3], double *theta, double *phi)
 **  P-vector to spherical coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -28,11 +28,11 @@ void iauC2s(double p[3], double *theta, double *phi)
 **
 **  3) At either pole, zero theta is returned.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, d2;
@@ -46,12 +46,12 @@ void iauC2s(double p[3], double *theta, double *phi)
    *theta = (d2 == 0.0) ? 0.0 : atan2(y, x);
    *phi = (z == 0.0) ? 0.0 : atan2(z, sqrt(d2));
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2t00a.c
+++ b/SOFA/SOFA/src/c2t00a.c
@@ -8,17 +8,17 @@ void iauC2t00a(double tta, double ttb, double uta, double utb,
 **  - - - - - - - - - -
 **
 **  Form the celestial to terrestrial matrix given the date, the UT1 and
-**  the polar motion, using the IAU 2000A nutation model.
+**  the polar motion, using the IAU 2000A precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
 **     tta,ttb  double         TT as a 2-part Julian Date (Note 1)
 **     uta,utb  double         UT1 as a 2-part Julian Date (Note 1)
-**     xp,yp    double         coordinates of the pole (radians, Note 2)
+**     xp,yp    double         CIP coordinates (radians, Note 2)
 **
 **  Returned:
 **     rc2t     double[3][3]   celestial-to-terrestrial matrix (Note 3)
@@ -49,7 +49,7 @@ void iauC2t00a(double tta, double ttb, double uta, double utb,
 **  2) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  3) The matrix rc2t transforms from celestial to terrestrial
 **     coordinates:
@@ -64,7 +64,7 @@ void iauC2t00a(double tta, double ttb, double uta, double utb,
 **     celestial-to-intermediate matrix, ERA is the Earth rotation
 **     angle and RPOM is the polar motion matrix.
 **
-**  4) A faster, but slightly less accurate result (about 1 mas), can
+**  4) A faster, but slightly less accurate, result (about 1 mas) can
 **     be obtained by using instead the iauC2t00b function.
 **
 **  Called:
@@ -79,11 +79,11 @@ void iauC2t00a(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
@@ -104,12 +104,12 @@ void iauC2t00a(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    iauC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2t00b.c
+++ b/SOFA/SOFA/src/c2t00b.c
@@ -8,10 +8,10 @@ void iauC2t00b(double tta, double ttb, double uta, double utb,
 **  - - - - - - - - - -
 **
 **  Form the celestial to terrestrial matrix given the date, the UT1 and
-**  the polar motion, using the IAU 2000B nutation model.
+**  the polar motion, using the IAU 2000B precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -49,7 +49,7 @@ void iauC2t00b(double tta, double ttb, double uta, double utb,
 **  2) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  3) The matrix rc2t transforms from celestial to terrestrial
 **     coordinates:
@@ -78,11 +78,11 @@ void iauC2t00b(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rc2i[3][3], era, rpom[3][3];
@@ -100,12 +100,12 @@ void iauC2t00b(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    iauC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2t06a.c
+++ b/SOFA/SOFA/src/c2t06a.c
@@ -8,11 +8,11 @@ void iauC2t06a(double tta, double ttb, double uta, double utb,
 **  - - - - - - - - - -
 **
 **  Form the celestial to terrestrial matrix given the date, the UT1 and
-**  the polar motion, using the IAU 2006 precession and IAU 2000A
-**  nutation models.
+**  the polar motion, using the IAU 2006/2000A precession-nutation
+**  model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -27,8 +27,8 @@ void iauC2t06a(double tta, double ttb, double uta, double utb,
 **  Notes:
 **
 **  1) The TT and UT1 dates tta+ttb and uta+utb are Julian Dates,
-**     apportioned in any convenient way between the arguments uta and
-**     utb.  For example, JD(UT1)=2450123.7 could be expressed in any of
+**     apportioned in any convenient way between the two arguments.  For
+**     example, JD(UT1)=2450123.7 could be expressed in any of
 **     these ways, among others:
 **
 **             uta            utb
@@ -50,7 +50,7 @@ void iauC2t06a(double tta, double ttb, double uta, double utb,
 **  2) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  3) The matrix rc2t transforms from celestial to terrestrial
 **     coordinates:
@@ -77,11 +77,11 @@ void iauC2t06a(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 January 18
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
@@ -102,12 +102,12 @@ void iauC2t06a(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    iauC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2tcio.c
+++ b/SOFA/SOFA/src/c2tcio.c
@@ -12,7 +12,7 @@ void iauC2tcio(double rc2i[3][3], double era, double rpom[3][3],
 **  Angle and the polar motion matrix).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -57,11 +57,11 @@ void iauC2tcio(double rc2i[3][3], double era, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2013 August 24
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r[3][3];
@@ -72,12 +72,12 @@ void iauC2tcio(double rc2i[3][3], double era, double rpom[3][3],
    iauRz(era, r);
    iauRxr(rpom, r, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2teqx.c
+++ b/SOFA/SOFA/src/c2teqx.c
@@ -12,7 +12,7 @@ void iauC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
 **  Sidereal Time and the polar motion matrix).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -57,11 +57,11 @@ void iauC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 August 24
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r[3][3];
@@ -72,12 +72,12 @@ void iauC2teqx(double rbpn[3][3], double gst, double rpom[3][3],
    iauRz(gst, r);
    iauRxr(rpom, r, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2tpe.c
+++ b/SOFA/SOFA/src/c2tpe.c
@@ -12,7 +12,7 @@ void iauC2tpe(double tta, double ttb, double uta, double utb,
 **  the nutation and the polar motion.  IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -57,7 +57,7 @@ void iauC2tpe(double tta, double ttb, double uta, double utb,
 **  3) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  4) The matrix rc2t transforms from celestial to terrestrial
 **     coordinates:
@@ -88,11 +88,11 @@ void iauC2tpe(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3],
@@ -117,12 +117,12 @@ void iauC2tpe(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    iauC2teqx(rbpn, gmst + ee, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/c2txy.c
+++ b/SOFA/SOFA/src/c2txy.c
@@ -12,7 +12,7 @@ void iauC2txy(double tta, double ttb, double uta, double utb,
 **  the CIP coordinates and the polar motion.  IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -55,7 +55,7 @@ void iauC2txy(double tta, double ttb, double uta, double utb,
 **  3) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  4) The matrix rc2t transforms from celestial to terrestrial
 **     coordinates:
@@ -84,11 +84,11 @@ void iauC2txy(double tta, double ttb, double uta, double utb,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rc2i[3][3], era, sp, rpom[3][3];
@@ -109,12 +109,12 @@ void iauC2txy(double tta, double ttb, double uta, double utb,
 /* Combine to form the celestial-to-terrestrial matrix. */
    iauC2tcio(rc2i, era, rpom, rc2t);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/cal2jd.c
+++ b/SOFA/SOFA/src/cal2jd.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauCal2jd(int iy, int im, int id, double *djm0, double *djm)
 /*
@@ -9,7 +10,7 @@ int iauCal2jd(int iy, int im, int id, double *djm0, double *djm)
 **  Gregorian Calendar to Julian Date.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -48,11 +49,11 @@ int iauCal2jd(int iy, int im, int id, double *djm0, double *djm)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j, ly, my;
@@ -91,10 +92,12 @@ int iauCal2jd(int iy, int im, int id, double *djm0, double *djm)
 /* Return status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/cp.c
+++ b/SOFA/SOFA/src/cp.c
@@ -9,7 +9,7 @@ void iauCp(double p[3], double c[3])
 **  Copy a p-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -19,23 +19,23 @@ void iauCp(double p[3], double c[3])
 **  Returned:
 **     c        double[3]     copy
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    c[0] = p[0];
    c[1] = p[1];
    c[2] = p[2];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/cpv.c
+++ b/SOFA/SOFA/src/cpv.c
@@ -9,7 +9,7 @@ void iauCpv(double pv[2][3], double c[2][3])
 **  Copy a position/velocity vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -22,22 +22,22 @@ void iauCpv(double pv[2][3], double c[2][3])
 **  Called:
 **     iauCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauCp(pv[0], c[0]);
    iauCp(pv[1], c[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/cr.c
+++ b/SOFA/SOFA/src/cr.c
@@ -9,7 +9,7 @@ void iauCr(double r[3][3], double c[3][3])
 **  Copy an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -22,23 +22,23 @@ void iauCr(double r[3][3], double c[3][3])
 **  Called:
 **     iauCp        copy p-vector
 **
-**  This revision:  2016 May 19
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauCp(r[0], c[0]);
    iauCp(r[1], c[1]);
    iauCp(r[2], c[2]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/d2dtf.c
+++ b/SOFA/SOFA/src/d2dtf.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 #include <string.h>
 
 int iauD2dtf(const char *scale, int ndp, double d1, double d2,
@@ -76,11 +77,11 @@ int iauD2dtf(const char *scale, int ndp, double d1, double d2,
 **     iauD2tf      decompose days to hms
 **     iauDat       delta(AT) = TAI-UTC
 **
-**  This revision:  2014 February 15
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int leap;
@@ -119,7 +120,7 @@ int iauD2dtf(const char *scale, int ndp, double d1, double d2,
       dleap = dat24 - (2.0*dat12 - dat0);
 
    /* If leap second day, scale the fraction of a day into SI. */
-      leap = (dleap != 0.0);
+      leap = (fabs(dleap) > 0.5);
       if (leap) fd += fd * dleap/DAYSEC;
    }
 
@@ -188,10 +189,12 @@ int iauD2dtf(const char *scale, int ndp, double d1, double d2,
 /* Status. */
    return js;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/d2tf.c
+++ b/SOFA/SOFA/src/d2tf.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauD2tf(int ndp, double days, char *sign, int ihmsf[4])
 /*
@@ -9,7 +10,7 @@ void iauD2tf(int ndp, double days, char *sign, int ihmsf[4])
 **  Decompose days to hours, minutes, seconds, fraction.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -53,11 +54,11 @@ void iauD2tf(int ndp, double days, char *sign, int ihmsf[4])
 **     case where days is very nearly 1.0 and rounds up to 24 hours,
 **     by testing for ihmsf[0]=24 and setting ihmsf[0-3] to zero.
 **
-**  This revision:  2020 April 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int nrs, n;
@@ -110,12 +111,12 @@ void iauD2tf(int ndp, double days, char *sign, int ihmsf[4])
    ihmsf[2] = (int) as;
    ihmsf[3] = (int) af;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/dat.c
+++ b/SOFA/SOFA/src/dat.c
@@ -41,7 +41,7 @@ int iauDat(int iy, int im, int id, double fd, double *deltat)
 **     :__________________________________________:
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  user-replaceable support function.
 **
@@ -120,15 +120,15 @@ int iauDat(int iy, int im, int id, double fd, double *deltat)
 **  Called:
 **     iauCal2jd    Gregorian calendar to JD
 **
-**  This revision:  2020 May 31
+**  This revision:  2023 January 17
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Release year for this version of iauDat */
-   enum { IYV = 2020};
+   enum { IYV = 2023};
 
 /* Reference dates (MJD) and drift rates (s/day), pre leap seconds */
    static const double drift[][2] = {
@@ -249,10 +249,12 @@ int iauDat(int iy, int im, int id, double fd, double *deltat)
 /* Return the status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2018
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================
@@ -348,5 +350,4 @@ int iauDat(int iy, int im, int id, double fd, double *deltat)
 **                 United Kingdom
 **
 **--------------------------------------------------------------------*/
-
 }

--- a/SOFA/SOFA/src/dtdb.c
+++ b/SOFA/SOFA/src/dtdb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauDtdb(double date1, double date2,
                double ut, double elong, double u, double v)
@@ -41,7 +42,7 @@ double iauDtdb(double date1, double date2,
 **  Conventions (McCarthy & Petit 2003).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -162,11 +163,11 @@ double iauDtdb(double date1, double date2,
 **     Simon, J.L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G. & Laskar, J., Astron.Astrophys., 282, 663-683 (1994).
 **
-**  This revision:  2018 January 2
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, tsol, w, elsun, emsun, d, elj, els, wt, w0, w1, w2, w3, w4,
@@ -1165,10 +1166,12 @@ double iauDtdb(double date1, double date2,
 
    return w;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/dtf2d.c
+++ b/SOFA/SOFA/src/dtf2d.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 #include <string.h>
 
 int iauDtf2d(const char *scale, int iy, int im, int id,
@@ -80,11 +81,11 @@ int iauDtf2d(const char *scale, int iy, int im, int id,
 **     iauDat       delta(AT) = TAI-UTC
 **     iauJd2cal    JD to Gregorian calendar
 **
-**  This revision:  2013 July 26
+**  This revision:  2023 May 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int js, iy2, im2, id2;
@@ -130,7 +131,7 @@ int iauDtf2d(const char *scale, int iy, int im, int id,
 /* Validate the time. */
    if ( ihr >= 0 && ihr <= 23 ) {
       if ( imn >= 0 && imn <= 59 ) {
-         if ( sec >= 0 ) {
+         if ( sec >= 0.0 ) {
             if ( sec >= seclim ) {
                js += 2;
             }
@@ -155,10 +156,12 @@ int iauDtf2d(const char *scale, int iy, int im, int id,
 /* Status. */
    return js;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eceq06.c
+++ b/SOFA/SOFA/src/eceq06.c
@@ -58,11 +58,11 @@ void iauEceq06(double date1, double date2, double dl, double db,
 **     iauAnp       normalize angle into range 0 to 2pi
 **     iauAnpm      normalize angle into range +/- pi
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rm[3][3], v1[3], v2[3], a, b;
@@ -84,10 +84,12 @@ void iauEceq06(double date1, double date2, double dl, double db,
    *dr = iauAnp(a);
    *dd = iauAnpm(b);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ecm06.c
+++ b/SOFA/SOFA/src/ecm06.c
@@ -40,7 +40,7 @@ void iauEcm06(double date1, double date2, double rm[3][3])
 **     optimum resolution.  The MJD method and the date & time methods
 **     are both good compromises between resolution and convenience.
 **
-**  1) The matrix is in the sense
+**  2) The matrix is in the sense
 **
 **        E_ep = rm x P_ICRS,
 **
@@ -48,7 +48,7 @@ void iauEcm06(double date1, double date2, double rm[3][3])
 **     and declination axes and E_ep is the same vector with respect to
 **     the (inertial) ecliptic and equinox of date.
 **
-**  2) P_ICRS is a free vector, merely a direction, typically of unit
+**     P_ICRS is a free vector, merely a direction, typically of unit
 **     magnitude, and not bound to any particular spatial origin, such
 **     as the Earth, Sun or SSB.  No assumptions are made about whether
 **     it represents starlight and embodies astrometric effects such as
@@ -64,11 +64,11 @@ void iauEcm06(double date1, double date2, double rm[3][3])
 **     iauRx        rotate around X-axis
 **     iauRxr       product of two r-matrices
 **
-**  This revision:  2015 December 11
+**  This revision:  2023 February 26
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ob, bp[3][3], e[3][3];
@@ -87,10 +87,12 @@ void iauEcm06(double date1, double date2, double rm[3][3])
 /* ICRS to ecliptic coordinates rotation matrix, IAU 2006. */
    iauRxr(e, bp, rm);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ee00.c
+++ b/SOFA/SOFA/src/ee00.c
@@ -10,7 +10,7 @@ double iauEe00(double date1, double date2, double epsa, double dpsi)
 **  given the nutation in longitude and the mean obliquity.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -65,11 +65,11 @@ double iauEe00(double date1, double date2, double epsa, double dpsi)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2008 May 16
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ee;
@@ -80,10 +80,12 @@ double iauEe00(double date1, double date2, double epsa, double dpsi)
 
    return ee;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ee00a.c
+++ b/SOFA/SOFA/src/ee00a.c
@@ -9,7 +9,7 @@ double iauEe00a(double date1, double date2)
 **  Equation of the equinoxes, compatible with IAU 2000 resolutions.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -63,11 +63,11 @@ double iauEe00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004).
 **
-**  This revision:  2008 May 16
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsipr, depspr, epsa, dpsi, deps, ee;
@@ -87,10 +87,12 @@ double iauEe00a(double date1, double date2)
 
    return ee;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ee00b.c
+++ b/SOFA/SOFA/src/ee00b.c
@@ -10,7 +10,7 @@ double iauEe00b(double date1, double date2)
 **  using the truncated nutation model IAU 2000B.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -46,9 +46,9 @@ double iauEe00b(double date1, double date2)
 **        Greenwich apparent ST = GMST + equation of the equinoxes
 **
 **  3) The result is compatible with the IAU 2000 resolutions except
-**     that accuracy has been compromised for the sake of speed.  For
-**     further details, see McCarthy & Luzum (2001), IERS Conventions
-**     2003 and Capitaine et al. (2003).
+**     that accuracy has been compromised (1 mas) for the sake of speed.
+**     For further details, see McCarthy & Luzum (2003), IERS
+**     Conventions 2003 and Capitaine et al. (2003).
 **
 **  Called:
 **     iauPr00      IAU 2000 precession adjustments
@@ -69,11 +69,11 @@ double iauEe00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2008 May 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsipr, depspr, epsa, dpsi, deps, ee;
@@ -93,10 +93,12 @@ double iauEe00b(double date1, double date2)
 
    return ee;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ee06a.c
+++ b/SOFA/SOFA/src/ee06a.c
@@ -10,7 +10,7 @@ double iauEe06a(double date1, double date2)
 **  IAU 2006/2000A precession-nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -55,11 +55,11 @@ double iauEe06a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2008 May 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gst06a, gmst06, ee;
@@ -74,10 +74,12 @@ double iauEe06a(double date1, double date2)
 
    return ee;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eect00.c
+++ b/SOFA/SOFA/src/eect00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauEect00(double date1, double date2)
 /*
@@ -10,7 +11,7 @@ double iauEect00(double date1, double date2)
 **  IAU 2000 resolutions.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -96,11 +97,11 @@ double iauEect00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Time since J2000.0, in Julian centuries */
@@ -234,10 +235,12 @@ double iauEect00(double date1, double date2)
 
    return eect;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eform.c
+++ b/SOFA/SOFA/src/eform.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauEform ( int n, double *a, double *f )
 /*
@@ -60,11 +61,11 @@ int iauEform ( int n, double *a, double *f )
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     p220.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -98,10 +99,12 @@ int iauEform ( int n, double *a, double *f )
 /* OK status. */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eo06a.c
+++ b/SOFA/SOFA/src/eo06a.c
@@ -9,7 +9,7 @@ double iauEo06a(double date1, double date2)
 **  Equation of the origins, IAU 2006 precession and IAU 2000A nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -17,7 +17,7 @@ double iauEo06a(double date1, double date2)
 **     date1,date2  double    TT as a 2-part Julian Date (Note 1)
 **
 **  Returned (function value):
-**                  double    equation of the origins in radians
+**                  double    the equation of the origins in radians
 **
 **  Notes:
 **
@@ -59,11 +59,11 @@ double iauEo06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r[3][3], x, y, s, eo;
@@ -83,10 +83,12 @@ double iauEo06a(double date1, double date2)
 
    return eo;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eors.c
+++ b/SOFA/SOFA/src/eors.c
@@ -10,16 +10,16 @@ double iauEors(double rnpb[3][3], double s)
 **  quantity s.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
 **     rnpb  double[3][3]  classical nutation x precession x bias matrix
-**     s     double        the quantity s (the CIO locator)
+**     s     double        the quantity s (the CIO locator) in radians
 **
 **  Returned (function value):
-**           double        the equation of the origins in radians.
+**           double        the equation of the origins in radians
 **
 **  Notes:
 **
@@ -38,11 +38,11 @@ double iauEors(double rnpb[3][3], double s)
 **
 **     Wallace, P. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 May 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, ax, xs, ys, zs, p, q, eo;
@@ -56,14 +56,16 @@ double iauEors(double rnpb[3][3], double s)
    zs = -x;
    p = rnpb[0][0] * xs + rnpb[0][1] * ys + rnpb[0][2] * zs;
    q = rnpb[1][0] * xs + rnpb[1][1] * ys + rnpb[1][2] * zs;
-   eo = ((p != 0) || (q != 0)) ? s - atan2(q, p) : s;
+   eo = ((p != 0.0) || (q != 0.0)) ? s - atan2(q, p) : s;
 
    return eo;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/epb.c
+++ b/SOFA/SOFA/src/epb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauEpb(double dj1, double dj2)
 /*
@@ -9,19 +10,33 @@ double iauEpb(double dj1, double dj2)
 **  Julian Date to Besselian Epoch.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
-**     dj1,dj2    double     Julian Date (see note)
+**     dj1,dj2    double     Julian Date (Notes 3,4)
 **
 **  Returned (function value):
 **                double     Besselian Epoch.
 **
-**  Note:
+**  Notes:
 **
-**     The Julian Date is supplied in two pieces, in the usual SOFA
+**  1) Besselian Epoch is a method of expressing a moment in time as a
+**     year plus fraction.  It was superseded by Julian Year (see the
+**     function iauEpj).
+**
+**  2) The start of a Besselian year is when the right ascension of
+**     the fictitious mean Sun is 18h 40m, and the unit is the tropical
+**     year.  The conventional definition (see Lieske 1979) is that
+**     Besselian Epoch B1900.0 is JD 2415020.31352 and the length of the
+**     year is 365.242198781 days.
+**
+**  3) The time scale for the JD, originally Ephemeris Time, is TDB,
+**     which for all practical purposes in the present context is
+**     indistinguishable from TT.
+**
+**  4) The Julian Date is supplied in two pieces, in the usual SOFA
 **     manner, which is designed to preserve time resolution.  The
 **     Julian Date is available as a single number by adding dj1 and
 **     dj2.  The maximum resolution is achieved if dj1 is 2451545.0
@@ -31,11 +46,11 @@ double iauEpb(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979. Astron.Astrophys., 73, 282.
 **
-**  This revision:  2013 August 21
+**  This revision:  2023 May 5
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* J2000.0-B1900.0 (2415019.81352) in days */
@@ -43,10 +58,12 @@ double iauEpb(double dj1, double dj2)
 
    return 1900.0 + ((dj1 - DJ00) + (dj2 + D1900)) / DTY;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/epb2jd.c
+++ b/SOFA/SOFA/src/epb2jd.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauEpb2jd(double epb, double *djm0, double *djm)
 /*
@@ -9,7 +10,7 @@ void iauEpb2jd(double epb, double *djm0, double *djm)
 **  Besselian Epoch to Julian Date.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -31,22 +32,22 @@ void iauEpb2jd(double epb, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 13
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    *djm0 = DJM0;
    *djm  =   15019.81352 + (epb - 1900.0) * DTY;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/epj.c
+++ b/SOFA/SOFA/src/epj.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauEpj(double dj1, double dj2)
 /*
@@ -9,19 +10,33 @@ double iauEpj(double dj1, double dj2)
 **  Julian Date to Julian Epoch.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
-**     dj1,dj2    double     Julian Date (see note)
+**     dj1,dj2    double     Julian Date (Note 4)
 **
 **  Returned (function value):
 **                double     Julian Epoch
 **
-**  Note:
+**  Notes:
 **
-**     The Julian Date is supplied in two pieces, in the usual SOFA
+**  1) Julian Epoch is a method of expressing a moment in time as a
+**     year plus fraction.
+**
+**  2) Julian Epoch J2000.0 is 2000 Jan 1.5, and the length of the year
+**     is 365.25 days.
+**
+**  3) For historical reasons, the time scale formally associated with
+**     Julian Epoch is TDB (or TT, near enough).  However, Julian Epoch
+**     can be used more generally as a calendrical convention to
+**     represent other time scales such as TAI and TCB.  This is
+**     analogous to Julian Date, which was originally defined
+**     specifically as a way of representing Universal Times but is now
+**     routinely used for any of the regular time scales.
+**
+**  4) The Julian Date is supplied in two pieces, in the usual SOFA
 **     manner, which is designed to preserve time resolution.  The
 **     Julian Date is available as a single number by adding dj1 and
 **     dj2.  The maximum resolution is achieved if dj1 is 2451545.0
@@ -31,11 +46,11 @@ double iauEpj(double dj1, double dj2)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 7
+**  This revision:  2022 May 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double epj;
@@ -45,10 +60,12 @@ double iauEpj(double dj1, double dj2)
 
    return epj;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/epj2jd.c
+++ b/SOFA/SOFA/src/epj2jd.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauEpj2jd(double epj, double *djm0, double *djm)
 /*
@@ -9,7 +10,7 @@ void iauEpj2jd(double epj, double *djm0, double *djm)
 **  Julian Epoch to Julian Date.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -31,22 +32,22 @@ void iauEpj2jd(double epj, double *djm0, double *djm)
 **
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282.
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    *djm0 = DJM0;
    *djm  = DJM00 + (epj - 2000.0) * 365.25;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/epv00.c
+++ b/SOFA/SOFA/src/epv00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauEpv00(double date1, double date2,
              double pvh[2][3], double pvb[2][3])
@@ -11,7 +12,7 @@ int iauEpv00(double date1, double date2,
 **  respect to the Barycentric Celestial Reference System.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -70,8 +71,8 @@ int iauEpv00(double date1, double date2,
 **        pvb[1][1]  ydot    } barycentric velocity, au/d
 **        pvb[1][2]  zdot    }
 **
-**     The vectors are with respect to the Barycentric Celestial
-**     Reference System.  The time unit is one day in TDB.
+**     The vectors are oriented with respect to the BCRS.  The time unit
+**     is one day in TDB.
 **
 **  3) The function is a SIMPLIFIED SOLUTION from the planetary theory
 **     VSOP2000 (X. Moisson, P. Bretagnon, 2001, Celes. Mechanics &
@@ -99,11 +100,11 @@ int iauEpv00(double date1, double date2,
 **  5) It is permissible to use the same array for pvh and pvb, which
 **     will receive the barycentric values.
 **
-**  This revision:  2019 June 23
+**  This revision:  2023 March 1
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /*
@@ -2541,10 +2542,12 @@ int iauEpv00(double date1, double date2,
 /* Return the status. */
    return jstat;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eqec06.c
+++ b/SOFA/SOFA/src/eqec06.c
@@ -59,11 +59,11 @@ void iauEqec06(double date1, double date2, double dr, double dd,
 **     iauAnp       normalize angle into range 0 to 2pi
 **     iauAnpm      normalize angle into range +/- pi
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rm[3][3], v1[3], v2[3], a, b;
@@ -85,10 +85,12 @@ void iauEqec06(double date1, double date2, double dr, double dd,
    *dl = iauAnp(a);
    *db = iauAnpm(b);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/eqeq94.c
+++ b/SOFA/SOFA/src/eqeq94.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauEqeq94(double date1, double date2)
 /*
@@ -9,7 +10,7 @@ double iauEqeq94(double date1, double date2)
 **  Equation of the equinoxes, IAU 1994 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -56,11 +57,11 @@ double iauEqeq94(double date1, double date2)
 **     Capitaine, N. & Gontier, A.-M., 1993, Astron.Astrophys., 275,
 **     645-650.
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t,  om,  dpsi,  deps,  eps0, ee;
@@ -84,10 +85,12 @@ double iauEqeq94(double date1, double date2)
 
    return ee;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/era00.c
+++ b/SOFA/SOFA/src/era00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauEra00(double dj1, double dj2)
 /*
@@ -9,7 +10,7 @@ double iauEra00(double dj1, double dj2)
 **  Earth rotation angle (IAU 2000 model).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -59,11 +60,11 @@ double iauEra00(double dj1, double dj2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double d1, d2, t, f, theta;
@@ -88,10 +89,12 @@ double iauEra00(double dj1, double dj2)
 
    return theta;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fad03.c
+++ b/SOFA/SOFA/src/fad03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFad03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFad03(double t)
 **  mean elongation of the Moon from the Sun.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -36,11 +37,11 @@ double iauFad03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -55,10 +56,12 @@ double iauFad03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fae03.c
+++ b/SOFA/SOFA/src/fae03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFae03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFae03(double t)
 **  mean longitude of Earth.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFae03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFae03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/faf03.c
+++ b/SOFA/SOFA/src/faf03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFaf03(double t)
 /*
@@ -11,7 +12,7 @@ double iauFaf03(double t)
 **  node.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -37,11 +38,11 @@ double iauFaf03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -57,11 +58,12 @@ double iauFaf03(double t)
 
    return a;
 
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/faju03.c
+++ b/SOFA/SOFA/src/faju03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFaju03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFaju03(double t)
 **  mean longitude of Jupiter.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFaju03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFaju03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fal03.c
+++ b/SOFA/SOFA/src/fal03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFal03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFal03(double t)
 **  mean anomaly of the Moon.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -36,11 +37,11 @@ double iauFal03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -55,10 +56,12 @@ double iauFal03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/falp03.c
+++ b/SOFA/SOFA/src/falp03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFalp03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFalp03(double t)
 **  mean anomaly of the Sun.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -36,11 +37,11 @@ double iauFalp03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -55,10 +56,12 @@ double iauFalp03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fama03.c
+++ b/SOFA/SOFA/src/fama03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFama03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFama03(double t)
 **  mean longitude of Mars.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFama03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFama03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fame03.c
+++ b/SOFA/SOFA/src/fame03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFame03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFame03(double t)
 **  mean longitude of Mercury.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFame03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFame03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fane03.c
+++ b/SOFA/SOFA/src/fane03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFane03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFane03(double t)
 **  mean longitude of Neptune.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -36,11 +37,11 @@ double iauFane03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -51,10 +52,12 @@ double iauFane03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/faom03.c
+++ b/SOFA/SOFA/src/faom03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFaom03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFaom03(double t)
 **  mean longitude of the Moon's ascending node.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -34,13 +35,13 @@ double iauFaom03(double t)
 **     IERS Technical Note No. 32, BKG (2004)
 **
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
-**     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
+**     Francou, G., Laskar, J., 1994, Astron.Astrophys. 282, 663-683.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -56,10 +57,12 @@ double iauFaom03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fapa03.c
+++ b/SOFA/SOFA/src/fapa03.c
@@ -10,7 +10,7 @@ double iauFapa03(double t)
 **  general accumulated precession in longitude.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -40,11 +40,11 @@ double iauFapa03(double t)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -55,10 +55,12 @@ double iauFapa03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fasa03.c
+++ b/SOFA/SOFA/src/fasa03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFasa03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFasa03(double t)
 **  mean longitude of Saturn.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFasa03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFasa03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/faur03.c
+++ b/SOFA/SOFA/src/faur03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFaur03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFaur03(double t)
 **  mean longitude of Uranus.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -36,11 +37,11 @@ double iauFaur03(double t)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J. 1994, Astron.Astrophys. 282, 663-683
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -51,10 +52,12 @@ double iauFaur03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fave03.c
+++ b/SOFA/SOFA/src/fave03.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauFave03(double t)
 /*
@@ -10,7 +11,7 @@ double iauFave03(double t)
 **  mean longitude of Venus.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -39,11 +40,11 @@ double iauFave03(double t)
 **     Souchay, J., Loysel, B., Kinoshita, H., Folgueira, M. 1999,
 **     Astron.Astrophys.Supp.Ser. 135, 111
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double a;
@@ -54,10 +55,12 @@ double iauFave03(double t)
 
    return a;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk425.c
+++ b/SOFA/SOFA/src/fk425.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauFk425(double r1950, double d1950,
               double dr1950, double dd1950,
@@ -19,7 +20,7 @@ void iauFk425(double r1950, double d1950,
 **  Status:  support function.
 **
 **  This function converts a star's catalog data from the old FK4
-** (Bessel-Newcomb) system to the later IAU 1976 FK5 (Fricke) system.
+**  (Bessel-Newcomb) system to the later IAU 1976 FK5 (Fricke) system.
 **
 **  Given: (all B1950.0, FK4)
 **     r1950,d1950    double   B1950.0 RA,Dec (rad)
@@ -115,11 +116,11 @@ void iauFk425(double r1950, double d1950,
 **     from FK4 B1950.0 to FK5 J2000.0 using matrices in 6-space".
 **     Astron.J. 97, 274.
 **
-**  This revision:   2018 December 5
+**  This revision:   2023 March 20
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Radians per year to arcsec per century */
@@ -139,7 +140,7 @@ void iauFk425(double r1950, double d1950,
 ** CANONICAL CONSTANTS (Seidelmann 1992)
 */
 
-/* Km per sec to AU per tropical century */
+/* Km per sec to au per tropical century */
 /* = 86400 * 36524.2198782 / 149597870.7 */
    const double VF = 21.095;
 
@@ -225,8 +226,8 @@ void iauFk425(double r1950, double d1950,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk45z.c
+++ b/SOFA/SOFA/src/fk45z.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauFk45z(double r1950, double d1950, double bepoch,
               double *r2000, double *d2000)
@@ -19,12 +20,12 @@ void iauFk45z(double r1950, double d1950, double bepoch,
 **  (Bessel-Newcomb) system to the later IAU 1976 FK5 (Fricke) system,
 **  in such a way that the FK5 proper motion is zero.  Because such a
 **  star has, in general, a non-zero proper motion in the FK4 system,
-**  the routine requires the epoch at which the position in the FK4
+**  the function requires the epoch at which the position in the FK4
 **  system was determined.
 **
 **  Given:
 **     r1950,d1950    double   B1950.0 FK4 RA,Dec at epoch (rad)
-**     bepoch         double   Besselian epoch (e.g. 1979.3D0)
+**     bepoch         double   Besselian epoch (e.g. 1979.3)
 **
 **  Returned:
 **     r2000,d2000    double   J2000.0 FK5 RA,Dec (rad)
@@ -36,7 +37,7 @@ void iauFk45z(double r1950, double d1950, double bepoch,
 **     negligible extent.
 **
 **  2) The method is from Appendix 2 of Aoki et al. (1983), but using
-**     the constants of Seidelmann (1992).  See the routine iauFk425
+**     the constants of Seidelmann (1992).  See the function iauFk425
 **     for a general introduction to the FK4 to FK5 conversion.
 **
 **  3) Conversion from equinox B1950.0 FK4 to equinox J2000.0 FK5 only
@@ -56,7 +57,7 @@ void iauFk45z(double r1950, double d1950, double bepoch,
 **     in past astrometry, and the undesirability of a discontinuity in
 **     the algorithm, the decision has been made in this SOFA algorithm
 **     to include the effects of differential E-terms on the proper
-**     motions for all stars, whether polar or not.  At epoch 2000.0,
+**     motions for all stars, whether polar or not.  At epoch J2000.0,
 **     and measuring "on the sky" rather than in terms of RA change, the
 **     errors resulting from this simplification are less than
 **     1 milliarcsecond in position and 1 milliarcsecond per century in
@@ -83,11 +84,11 @@ void iauFk45z(double r1950, double d1950, double bepoch,
 **     iauPvu       update a pv-vector
 **     iauS2c       spherical to p-vector
 **
-**  This revision:   2018 December 5
+**  This revision:   2023 March 4
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Radians per year to arcsec per century */
@@ -155,8 +156,8 @@ void iauFk45z(double r1950, double d1950, double bepoch,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk524.c
+++ b/SOFA/SOFA/src/fk524.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauFk524(double r2000, double d2000,
               double dr2000, double dd2000,
@@ -109,11 +110,11 @@ void iauFk524(double r2000, double d2000,
 **     from FK4 B1950.0 to FK5 J2000.0 using matrices in 6-space".
 **     Astron.J. 97, 274.
 **
-**  This revision:   2019 October 3
+**  This revision:   2023 March 20
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Radians per year to arcsec per century */
@@ -133,7 +134,7 @@ void iauFk524(double r2000, double d2000,
 ** CANONICAL CONSTANTS (Seidelmann 1992)
 */
 
-/* Km per sec to AU per tropical century */
+/* Km per sec to au per tropical century */
 /* = 86400 * 36524.2198782 / 149597870.7 */
    const double VF = 21.095;
 
@@ -237,8 +238,8 @@ void iauFk524(double r2000, double d2000,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk52h.c
+++ b/SOFA/SOFA/src/fk52h.c
@@ -12,7 +12,7 @@ void iauFk52h(double r5, double d5,
 **  Transform FK5 (J2000.0) star data into the Hipparcos system.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -58,11 +58,11 @@ void iauFk52h(double r5, double d5,
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -93,12 +93,12 @@ void iauFk52h(double r5, double d5,
 /* Hipparcos pv-vector to spherical. */
    iauPvstar(pvh, rh, dh, drh, ddh, pxh, rvh);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk54z.c
+++ b/SOFA/SOFA/src/fk54z.c
@@ -26,7 +26,7 @@ void iauFk54z(double r2000, double d2000, double bepoch,
 **
 **  Notes:
 **
-**  1) In contrast to the iauFk524  routine, here the FK5 proper
+**  1) In contrast to the iauFk524 function, here the FK5 proper
 **     motions, the parallax and the radial velocity are presumed zero.
 **
 **  2) This function converts a star position from the IAU 1976 FK5
@@ -34,16 +34,16 @@ void iauFk54z(double r2000, double d2000, double bepoch,
 **     cases such as distant radio sources where it is presumed there is
 **     zero parallax and no proper motion.  Because of the E-terms of
 **     aberration, such objects have (in general) non-zero proper motion
-**     in FK4, and the present routine returns those fictitious proper
+**     in FK4, and the present function returns those fictitious proper
 **     motions.
 **
-**  3) Conversion from B1950.0 FK4 to J2000.0 FK5 only is provided for.
+**  3) Conversion from J2000.0 FK5 to B1950.0 FK4 only is provided for.
 **     Conversions involving other equinoxes would require additional
 **     treatment for precession.
 **
-**  4) The position returned by this routine is in the B1950.0 FK4
-**     reference system but at Besselian epoch BEPOCH.  For comparison
-**     with catalogs the BEPOCH argument will frequently be 1950.0. (In
+**  4) The position returned by this function is in the B1950.0 FK4
+**     reference system but at Besselian epoch bepoch.  For comparison
+**     with catalogs the bepoch argument will frequently be 1950.0. (In
 **     this context the distinction between Besselian and Julian epoch
 **     is insignificant.)
 **
@@ -56,11 +56,11 @@ void iauFk54z(double r2000, double d2000, double bepoch,
 **     iauFk524     FK4 to FK5
 **     iauS2c       spherical to p-vector
 **
-**  This revision:   2018 December 5
+**  This revision:   2023 March 5
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r, d, pr, pd, px, rv, p[3], w, v[3];
@@ -97,8 +97,8 @@ void iauFk54z(double r2000, double d2000, double bepoch,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk5hip.c
+++ b/SOFA/SOFA/src/fk5hip.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauFk5hip(double r5h[3][3], double s5h[3])
 /*
@@ -9,7 +10,7 @@ void iauFk5hip(double r5h[3][3], double s5h[3])
 **  FK5 to Hipparcos rotation and spin.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -20,8 +21,8 @@ void iauFk5hip(double r5h[3][3], double s5h[3])
 **  Notes:
 **
 **  1) This function models the FK5 to Hipparcos transformation as a
-**     pure rotation and spin;  zonal errors in the FK5 catalogue are
-**     not taken into account.
+**     pure rotation and spin;  zonal errors in the FK5 catalog are not
+**     taken into account.
 **
 **  2) The r-matrix r5h operates in the sense:
 **
@@ -41,11 +42,11 @@ void iauFk5hip(double r5h[3][3], double s5h[3])
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2023 March 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double v[3];
@@ -76,12 +77,12 @@ void iauFk5hip(double r5h[3][3], double s5h[3])
    s5h[1] = omy;
    s5h[2] = omz;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fk5hz.c
+++ b/SOFA/SOFA/src/fk5hz.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauFk5hz(double r5, double d5, double date1, double date2,
               double *rh, double *dh)
@@ -8,10 +9,10 @@ void iauFk5hz(double r5, double d5, double date1, double date2,
 **  - - - - - - - - -
 **
 **  Transform an FK5 (J2000.0) star position into the system of the
-**  Hipparcos catalogue, assuming zero Hipparcos proper motion.
+**  Hipparcos catalog, assuming zero Hipparcos proper motion.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -52,7 +53,7 @@ void iauFk5hz(double r5, double d5, double date1, double date2,
 **     are both good compromises between resolution and convenience.
 **
 **  3) The FK5 to Hipparcos transformation is modeled as a pure
-**     rotation and spin;  zonal errors in the FK5 catalogue are not
+**     rotation and spin;  zonal errors in the FK5 catalog are not
 **     taken into account.
 **
 **  4) The position returned by this function is in the Hipparcos
@@ -74,11 +75,11 @@ void iauFk5hz(double r5, double d5, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 March 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, p5e[3], r5h[3][3], s5h[3], vst[3], rst[3][3], p5[3],
@@ -110,12 +111,12 @@ void iauFk5hz(double r5, double d5, double date1, double date2,
    iauC2s(ph, &w, dh);
    *rh = iauAnp(w);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fw2m.c
+++ b/SOFA/SOFA/src/fw2m.c
@@ -10,7 +10,7 @@ void iauFw2m(double gamb, double phib, double psi, double eps,
 **  Form rotation matrix given the Fukushima-Williams angles.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -72,13 +72,14 @@ void iauFw2m(double gamb, double phib, double psi, double eps,
 **  References:
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855
+**
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2019 July 26
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Construct the matrix. */
@@ -88,12 +89,12 @@ void iauFw2m(double gamb, double phib, double psi, double eps,
    iauRz(-psi, r);
    iauRx(-eps, r);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/fw2xy.c
+++ b/SOFA/SOFA/src/fw2xy.c
@@ -10,7 +10,7 @@ void iauFw2xy(double gamb, double phib, double psi, double eps,
 **  CIP X,Y given Fukushima-Williams bias-precession-nutation angles.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -55,11 +55,11 @@ void iauFw2xy(double gamb, double phib, double psi, double eps,
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2013 September 2
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r[3][3];
@@ -71,12 +71,12 @@ void iauFw2xy(double gamb, double phib, double psi, double eps,
 /* Extract CIP X,Y. */
    iauBpn2xy(r, x, y);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/g2icrs.c
+++ b/SOFA/SOFA/src/g2icrs.c
@@ -1,3 +1,4 @@
+
 #include "sofa.h"
 
 void iauG2icrs ( double dl, double db, double *dr, double *dd )
@@ -6,7 +7,7 @@ void iauG2icrs ( double dl, double db, double *dr, double *dd )
 **   i a u G 2 i c r s
 **  - - - - - - - - - -
 **
-**  Transformation from Galactic Coordinates to ICRS.
+**  Transformation from Galactic coordinates to ICRS.
 **
 **  This function is part of the International Astronomical Union's
 **  SOFA (Standards of Fundamental Astronomy) software collection.
@@ -14,8 +15,8 @@ void iauG2icrs ( double dl, double db, double *dr, double *dd )
 **  Status:  support function.
 **
 **  Given:
-**     dl     double      galactic longitude (radians)
-**     db     double      galactic latitude (radians)
+**     dl     double      Galactic longitude (radians)
+**     db     double      Galactic latitude (radians)
 **
 **  Returned:
 **     dr     double      ICRS right ascension (radians)
@@ -43,7 +44,7 @@ void iauG2icrs ( double dl, double db, double *dr, double *dd )
 **     coordinates with the above factors taken into account.  The
 **     matrix is derived from three angles, namely the ICRS coordinates
 **     of the Galactic pole and the longitude of the ascending node of
-**     the galactic equator on the ICRS equator.  They are given in
+**     the Galactic equator on the ICRS equator.  They are given in
 **     degrees to five decimal places and for canonical purposes are
 **     regarded as exact.  In the Hipparcos Catalogue the matrix
 **     elements are given to 10 decimal places (about 20 microarcsec).
@@ -66,25 +67,25 @@ void iauG2icrs ( double dl, double db, double *dr, double *dd )
 **     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
 **     Publications Division, Noordwijk, Netherlands.
 **
-**  This revision:   2018 January 2
+**  This revision:   2023 April 16
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double v1[3], v2[3];
 
 /*
-**  L2,B2 system of galactic coordinates in the form presented in the
+**  L2,B2 system of Galactic coordinates in the form presented in the
 **  Hipparcos Catalogue.  In degrees:
 **
 **  P = 192.85948    right ascension of the Galactic north pole in ICRS
 **  Q =  27.12825    declination of the Galactic north pole in ICRS
-**  R =  32.93192    longitude of the ascending node of the Galactic
-**                   plane on the ICRS equator
+**  R =  32.93192    Galactic longitude of the ascending node of
+**                   the Galactic equator on the ICRS equator
 **
-**  ICRS to galactic rotation matrix, obtained by computing
+**  ICRS to Galactic rotation matrix, obtained by computing
 **  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:
 */
    double r[3][3] = { { -0.054875560416215368492398900454,
@@ -115,8 +116,8 @@ void iauG2icrs ( double dl, double db, double *dr, double *dd )
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gc2gd.c
+++ b/SOFA/SOFA/src/gc2gd.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauGc2gd ( int n, double xyz[3],
                double *elong, double *phi, double *height )
@@ -56,11 +57,11 @@ int iauGc2gd ( int n, double xyz[3],
 **     iauEform     Earth reference ellipsoids
 **     iauGc2gde    geocentric to geodetic transformation, general
 **
-**  This revision:  2013 September 1
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -86,10 +87,12 @@ int iauGc2gd ( int n, double xyz[3],
 /* Return the status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gc2gde.c
+++ b/SOFA/SOFA/src/gc2gde.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauGc2gde ( double a, double f, double xyz[3],
                 double *elong, double *phi, double *height )
@@ -61,11 +62,11 @@ int iauGc2gde ( double a, double f, double xyz[3],
 **     coordinates accelerated by Halley's method", J.Geodesy (2006)
 **     79: 689-693
 **
-**  This revision:  2014 November 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double aeps2, e2, e4t, ec2, ec, b, x, y, z, p2, absz, p, s0, pn, zc,
@@ -151,10 +152,12 @@ int iauGc2gde ( double a, double f, double xyz[3],
 /* OK status. */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gd2gc.c
+++ b/SOFA/SOFA/src/gd2gc.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauGd2gc ( int n, double elong, double phi, double height,
                double xyz[3] )
@@ -17,7 +18,7 @@ int iauGd2gc ( int n, double elong, double phi, double height,
 **
 **  Given:
 **     n       int        ellipsoid identifier (Note 1)
-**     elong   double     longitude (radians, east +ve)
+**     elong   double     longitude (radians, east +ve, Note 3)
 **     phi     double     latitude (geodetic, radians, Note 3)
 **     height  double     height above ellipsoid (geodetic, Notes 2,3)
 **
@@ -59,11 +60,11 @@ int iauGd2gc ( int n, double elong, double phi, double height,
 **     iauGd2gce    geodetic to geocentric transformation, general
 **     iauZp        zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 March 9
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j;
@@ -85,10 +86,12 @@ int iauGd2gc ( int n, double elong, double phi, double height,
 /* Return the status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gd2gce.c
+++ b/SOFA/SOFA/src/gd2gce.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauGd2gce ( double a, double f, double elong, double phi,
                 double height, double xyz[3] )
@@ -16,9 +17,9 @@ int iauGd2gce ( double a, double f, double elong, double phi,
 **  Status:  support function.
 **
 **  Given:
-**     a       double     equatorial radius (Notes 1,4)
+**     a       double     equatorial radius (Notes 1,3,4)
 **     f       double     flattening (Notes 2,4)
-**     elong   double     longitude (radians, east +ve)
+**     elong   double     longitude (radians, east +ve, Note 4)
 **     phi     double     latitude (geodetic, radians, Note 4)
 **     height  double     height above ellipsoid (geodetic, Notes 3,4)
 **
@@ -60,11 +61,11 @@ int iauGd2gce ( double a, double f, double elong, double phi,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 4.22, p202.
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 March 10
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double sp, cp, w, d, ac, as, r;
@@ -89,10 +90,12 @@ int iauGd2gce ( double a, double f, double elong, double phi,
 /* Success. */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gmst00.c
+++ b/SOFA/SOFA/src/gmst00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauGmst00(double uta, double utb, double tta, double ttb)
 /*
@@ -10,7 +11,7 @@ double iauGmst00(double uta, double utb, double tta, double ttb)
 **  resolutions).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -25,8 +26,8 @@ double iauGmst00(double uta, double utb, double tta, double ttb)
 **
 **  1) The UT1 and TT dates uta+utb and tta+ttb respectively, are both
 **     Julian Dates, apportioned in any convenient way between the
-**     argument pairs.  For example, JD=2450123.7 could be expressed in
-**     any of these ways, among others:
+**     argument pairs.  For example, JD(UT1)=2450123.7 could be
+**     expressed in any of these ways, among others:
 **
 **            Part A         Part B
 **
@@ -73,11 +74,11 @@ double iauGmst00(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, gmst;
@@ -97,10 +98,12 @@ double iauGmst00(double uta, double utb, double tta, double ttb)
 
    return gmst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gmst06.c
+++ b/SOFA/SOFA/src/gmst06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauGmst06(double uta, double utb, double tta, double ttb)
 /*
@@ -9,7 +10,7 @@ double iauGmst06(double uta, double utb, double tta, double ttb)
 **  Greenwich mean sidereal time (consistent with IAU 2006 precession).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -63,11 +64,11 @@ double iauGmst06(double uta, double utb, double tta, double ttb)
 **     Capitaine, N., Wallace, P.T. & Chapront, J., 2005,
 **     Astron.Astrophys. 432, 355
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, gmst;
@@ -88,10 +89,12 @@ double iauGmst06(double uta, double utb, double tta, double ttb)
 
    return gmst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gmst82.c
+++ b/SOFA/SOFA/src/gmst82.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauGmst82(double dj1, double dj2)
 /*
@@ -9,7 +10,7 @@ double iauGmst82(double dj1, double dj2)
 **  Universal Time to Greenwich mean sidereal time (IAU 1982 model).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -65,11 +66,11 @@ double iauGmst82(double dj1, double dj2)
 **
 **     Aoki et al., Astron.Astrophys., 105, 359-361 (1982).
 **
-**  This revision:  2020 January 12
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Coefficients of IAU 1982 GMST-UT1 model */
@@ -102,10 +103,12 @@ double iauGmst82(double dj1, double dj2)
 
    return gmst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gst00a.c
+++ b/SOFA/SOFA/src/gst00a.c
@@ -10,7 +10,7 @@ double iauGst00a(double uta, double utb, double tta, double ttb)
 **  resolutions).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -25,10 +25,10 @@ double iauGst00a(double uta, double utb, double tta, double ttb)
 **
 **  1) The UT1 and TT dates uta+utb and tta+ttb respectively, are both
 **     Julian Dates, apportioned in any convenient way between the
-**     argument pairs.  For example, JD=2450123.7 could be expressed in
-**     any of these ways, among others:
+**     argument pairs.  For example, JD(UT1)=2450123.7 could be
+**     expressed in any of these ways, among others:
 **
-**            Part A        Part B
+**             uta            utb
 **
 **         2450123.7           0.0       (JD method)
 **         2451545.0       -1421.3       (J2000 method)
@@ -74,11 +74,11 @@ double iauGst00a(double uta, double utb, double tta, double ttb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gmst00, ee00a, gst;
@@ -90,10 +90,12 @@ double iauGst00a(double uta, double utb, double tta, double ttb)
 
    return gst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gst00b.c
+++ b/SOFA/SOFA/src/gst00b.c
@@ -10,7 +10,7 @@ double iauGst00b(double uta, double utb)
 **  resolutions but using the truncated nutation model IAU 2000B).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -24,8 +24,8 @@ double iauGst00b(double uta, double utb)
 **
 **  1) The UT1 date uta+utb is a Julian Date, apportioned in any
 **     convenient way between the argument pair.  For example,
-**     JD=2450123.7 could be expressed in any of these ways, among
-**     others:
+**     JD(UT1)=2450123.7 could be expressed in any of these ways,
+**     among others:
 **
 **             uta            utb
 **
@@ -52,7 +52,7 @@ double iauGst00b(double uta, double utb)
 **       component of GMST and the equation of the equinoxes.  This
 **       results in errors of order 0.1 mas at present.
 **
-**     . The IAU 2000B abridged nutation model (McCarthy & Luzum, 2001)
+**     . The IAU 2000B abridged nutation model (McCarthy & Luzum, 2003)
 **       is used, introducing errors of up to 1 mas.
 **
 **  3) This GAST is compatible with the IAU 2000 resolutions and must be
@@ -82,11 +82,11 @@ double iauGst00b(double uta, double utb)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gmst00, ee00b, gst;
@@ -98,10 +98,12 @@ double iauGst00b(double uta, double utb)
 
    return gst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gst06.c
+++ b/SOFA/SOFA/src/gst06.c
@@ -10,7 +10,7 @@ double iauGst06(double uta, double utb, double tta, double ttb,
 **  Greenwich apparent sidereal time, IAU 2006, given the NPB matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -26,10 +26,10 @@ double iauGst06(double uta, double utb, double tta, double ttb,
 **
 **  1) The UT1 and TT dates uta+utb and tta+ttb respectively, are both
 **     Julian Dates, apportioned in any convenient way between the
-**     argument pairs.  For example, JD=2450123.7 could be expressed in
-**     any of these ways, among others:
+**     argument pairs.  For example, JD(UT1)=2450123.7 could be
+**     expressed in any of these ways, among others:
 **
-**            Part A        Part B
+**             uta            utb
 **
 **         2450123.7           0.0       (JD method)
 **         2451545.0       -1421.3       (J2000 method)
@@ -69,11 +69,11 @@ double iauGst06(double uta, double utb, double tta, double ttb,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, s, era, eors, gst;
@@ -92,10 +92,12 @@ double iauGst06(double uta, double utb, double tta, double ttb,
 
    return gst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gst06a.c
+++ b/SOFA/SOFA/src/gst06a.c
@@ -10,7 +10,7 @@ double iauGst06a(double uta, double utb, double tta, double ttb)
 **  resolutions).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -25,10 +25,10 @@ double iauGst06a(double uta, double utb, double tta, double ttb)
 **
 **  1) The UT1 and TT dates uta+utb and tta+ttb respectively, are both
 **     Julian Dates, apportioned in any convenient way between the
-**     argument pairs.  For example, JD=2450123.7 could be expressed in
-**     any of these ways, among others:
+**     argument pairs.  For example, JD(UT1)=2450123.7 could be
+**     expressed in any of these ways, among others:
 **
-**            Part A        Part B
+**             uta            utb
 **
 **         2450123.7           0.0       (JD method)
 **         2451545.0       -1421.3       (J2000 method)
@@ -65,11 +65,11 @@ double iauGst06a(double uta, double utb, double tta, double ttb)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rnpb[3][3], gst;
@@ -83,10 +83,12 @@ double iauGst06a(double uta, double utb, double tta, double ttb)
 
    return gst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/gst94.c
+++ b/SOFA/SOFA/src/gst94.c
@@ -10,7 +10,7 @@ double iauGst94(double uta, double utb)
 **  resolutions).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -24,7 +24,7 @@ double iauGst94(double uta, double utb)
 **
 **  1) The UT1 date uta+utb is a Julian Date, apportioned in any
 **     convenient way between the argument pair.  For example,
-**     JD=2450123.7 could be expressed in any of these ways, among
+**     JD(UT1)=2450123.7 could be expressed in any of these ways, among
 **     others:
 **
 **             uta            utb
@@ -67,11 +67,11 @@ double iauGst94(double uta, double utb)
 **
 **     IAU Resolution C7, Recommendation 3 (1994)
 **
-**  This revision:  2008 May 16
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gmst82, eqeq94, gst;
@@ -83,10 +83,12 @@ double iauGst94(double uta, double utb)
 
    return gst;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/h2fk5.c
+++ b/SOFA/SOFA/src/h2fk5.c
@@ -12,7 +12,7 @@ void iauH2fk5(double rh, double dh,
 **  Transform Hipparcos star data into the FK5 (J2000.0) system.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -60,11 +60,11 @@ void iauH2fk5(double rh, double dh,
 **
 **     F.Mignard & M.Froeschle, Astron.Astrophys., 354, 732-739 (2000).
 **
-**  This revision:  2017 October 12
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -98,12 +98,12 @@ void iauH2fk5(double rh, double dh,
 /* FK5 pv-vector to spherical. */
    iauPvstar(pv5, r5, d5, dr5, dd5, px5, rv5);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/hd2ae.c
+++ b/SOFA/SOFA/src/hd2ae.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauHd2ae (double ha, double dec, double phi,
                double *az, double *el)
@@ -61,11 +62,11 @@ void iauHd2ae (double ha, double dec, double phi,
 **  7)  Again for efficiency, no range checking of arguments is carried
 **      out.
 **
-**  Last revision:   2017 September 12
+**  Last revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double sh, ch, sd, cd, sp, cp, x, y, z, r, a;
@@ -94,8 +95,8 @@ void iauHd2ae (double ha, double dec, double phi,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/hd2pa.c
+++ b/SOFA/SOFA/src/hd2pa.c
@@ -51,9 +51,9 @@ double iauHd2pa (double ha, double dec, double phi)
 **
 **  Last revision:   2017 September 12
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double cp, cqsz, sqsz;
@@ -68,8 +68,8 @@ double iauHd2pa (double ha, double dec, double phi)
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/hfk5z.c
+++ b/SOFA/SOFA/src/hfk5z.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauHfk5z(double rh, double dh, double date1, double date2,
               double *r5, double *d5, double *dr5, double *dd5)
@@ -11,7 +12,7 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
 **  zero Hipparcos proper motion.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -23,7 +24,7 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
 **  Returned (all FK5, equinox J2000.0, date date1+date2):
 **     r5            double    RA (radians)
 **     d5            double    Dec (radians)
-**     dr5           double    FK5 RA proper motion (rad/year, Note 4)
+**     dr5           double    RA proper motion (rad/year, Note 4)
 **     dd5           double    Dec proper motion (rad/year, Note 4)
 **
 **  Notes:
@@ -50,7 +51,7 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
 **  2) The proper motion in RA is dRA/dt rather than cos(Dec)*dRA/dt.
 **
 **  3) The FK5 to Hipparcos transformation is modeled as a pure rotation
-**     and spin;  zonal errors in the FK5 catalogue are not taken into
+**     and spin;  zonal errors in the FK5 catalog are not taken into
 **     account.
 **
 **  4) It was the intention that Hipparcos should be a close
@@ -62,7 +63,7 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
 **  5) The position returned by this function is in the FK5 J2000.0
 **     reference system but at date date1+date2.
 **
-**  6) See also iauFk52h, iauH2fk5, iauFk5zhz.
+**  6) See also iauFk52h, iauH2fk5, iauFk5hz.
 **
 **  Called:
 **     iauS2c       spherical coordinates to unit vector
@@ -79,11 +80,11 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
 **
 **     F.Mignard & M.Froeschle, 2000, Astron.Astrophys. 354, 732-739.
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 March 7
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, ph[3], r5h[3][3], s5h[3], sh[3], vst[3],
@@ -125,12 +126,12 @@ void iauHfk5z(double rh, double dh, double date1, double date2,
    iauPv2s(pv5e, &w, d5, &r, dr5, dd5, &v);
    *r5 = iauAnp(w);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/icrs2g.c
+++ b/SOFA/SOFA/src/icrs2g.c
@@ -6,7 +6,7 @@ void iauIcrs2g ( double dr, double dd, double *dl, double *db )
 **   i a u I c r s 2 g
 **  - - - - - - - - - -
 **
-**  Transformation from ICRS to Galactic Coordinates.
+**  Transformation from ICRS to Galactic coordinates.
 **
 **  This function is part of the International Astronomical Union's
 **  SOFA (Standards of Fundamental Astronomy) software collection.
@@ -18,8 +18,8 @@ void iauIcrs2g ( double dr, double dd, double *dl, double *db )
 **     dd     double      ICRS declination (radians)
 **
 **  Returned:
-**     dl     double      galactic longitude (radians)
-**     db     double      galactic latitude (radians)
+**     dl     double      Galactic longitude (radians)
+**     db     double      Galactic latitude (radians)
 **
 **  Notes:
 **
@@ -43,7 +43,7 @@ void iauIcrs2g ( double dr, double dd, double *dl, double *db )
 **     coordinates with the above factors taken into account.  The
 **     matrix is derived from three angles, namely the ICRS coordinates
 **     of the Galactic pole and the longitude of the ascending node of
-**     the galactic equator on the ICRS equator.  They are given in
+**     the Galactic equator on the ICRS equator.  They are given in
 **     degrees to five decimal places and for canonical purposes are
 **     regarded as exact.  In the Hipparcos Catalogue the matrix
 **     elements are given to 10 decimal places (about 20 microarcsec).
@@ -66,25 +66,25 @@ void iauIcrs2g ( double dr, double dd, double *dl, double *db )
 **     derived from the ESA Hipparcos Space Astrometry Mission.  ESA
 **     Publications Division, Noordwijk, Netherlands.
 **
-**  This revision:   2018 January 2
+**  This revision:   2023 April 16
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double v1[3], v2[3];
 
 /*
-**  L2,B2 system of galactic coordinates in the form presented in the
+**  L2,B2 system of Galactic coordinates in the form presented in the
 **  Hipparcos Catalogue.  In degrees:
 **
 **  P = 192.85948    right ascension of the Galactic north pole in ICRS
 **  Q =  27.12825    declination of the Galactic north pole in ICRS
-**  R =  32.93192    longitude of the ascending node of the Galactic
-**                   plane on the ICRS equator
+**  R =  32.93192    Galactic longitude of the ascending node of
+**                   the Galactic equator on the ICRS equator
 **
-**  ICRS to galactic rotation matrix, obtained by computing
+**  ICRS to Galactic rotation matrix, obtained by computing
 **  R_3(-R) R_1(pi/2-Q) R_3(pi/2+P) to the full precision shown:
 */
    double r[3][3] = { { -0.054875560416215368492398900454,
@@ -115,8 +115,8 @@ void iauIcrs2g ( double dr, double dd, double *dl, double *db )
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ir.c
+++ b/SOFA/SOFA/src/ir.c
@@ -9,18 +9,18 @@ void iauIr(double r[3][3])
 **  Initialize an r-matrix to the identity matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
 **  Returned:
 **     r       double[3][3]    r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    r[0][0] = 1.0;
@@ -33,12 +33,12 @@ void iauIr(double r[3][3])
    r[2][1] = 0.0;
    r[2][2] = 1.0;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/jdcalf.c
+++ b/SOFA/SOFA/src/jdcalf.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 /*
@@ -10,7 +11,7 @@ int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **  for formatting messages:  rounded to a specified precision.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -26,7 +27,7 @@ int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **               int      status:
 **                          -1 = date out of range
 **                           0 = OK
-**                          +1 = NDP not 0-9 (interpreted as 0)
+**                          +1 = ndp not 0-9 (interpreted as 0)
 **
 **  Notes:
 **
@@ -46,10 +47,11 @@ int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **     the Gregorian Calendar, nor is the AD/BC numbering convention
 **     observed.
 **
-**  3) Refer to the function iauJd2cal.
+**  3) See also the function iauJd2cal.
 **
-**  4) NDP should be 4 or less if internal overflows are to be
-**     avoided on machines which use 16-bit integers.
+**  4) The number of decimal places ndp should be 4 or less if internal
+**     overflows are to be avoided on platforms which use 16-bit
+**     integers.
 **
 **  Called:
 **     iauJd2cal    JD to Gregorian calendar
@@ -60,11 +62,11 @@ int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 12.92 (p604).
 **
-**  This revision:  2020 April 13
+**  This revision:  2023 January 16
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int j, js;
@@ -124,10 +126,12 @@ int iauJdcalf(int ndp, double dj1, double dj2, int iymdf[4])
 /* Return the status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ld.c
+++ b/SOFA/SOFA/src/ld.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLd(double bm, double p[3], double q[3], double e[3],
            double em, double dlim, double p1[3])
@@ -73,11 +74,11 @@ void iauLd(double bm, double p[3], double q[3], double e[3],
 **     iauPdp       scalar product of two p-vectors
 **     iauPxp       vector product of two p-vectors
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -106,8 +107,8 @@ void iauLd(double bm, double p[3], double q[3], double e[3],
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ldn.c
+++ b/SOFA/SOFA/src/ldn.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLdn(int n, iauLDBODY b[], double ob[3], double sc[3],
             double sn[3])
@@ -83,11 +84,11 @@ void iauLdn(int n, iauLDBODY b[], double ob[3], double sc[3],
 **     iauPn        decompose p-vector into modulus and direction
 **     iauLd        light deflection by a solar-system body
 **
-**  This revision:   2017 March 16
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Light time for 1 au (days) */
@@ -128,8 +129,8 @@ void iauLdn(int n, iauLDBODY b[], double ob[3], double sc[3],
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ldsun.c
+++ b/SOFA/SOFA/src/ldsun.c
@@ -40,9 +40,9 @@ void iauLdsun(double p[3], double e[3], double em, double p1[3])
 **
 **  This revision:   2016 June 16
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double em2, dlim;
@@ -60,8 +60,8 @@ void iauLdsun(double p[3], double e[3], double em, double p1[3])
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/lteceq.c
+++ b/SOFA/SOFA/src/lteceq.c
@@ -55,11 +55,11 @@ void iauLteceq(double epj, double dl, double db, double *dr, double *dd)
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rm[3][3], v1[3], v2[3], a, b;
@@ -81,10 +81,12 @@ void iauLteceq(double epj, double dl, double db, double *dr, double *dd)
    *dr = iauAnp(a);
    *dd = iauAnpm(b);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ltecm.c
+++ b/SOFA/SOFA/src/ltecm.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLtecm(double epj, double rm[3][3])
 /*
@@ -61,11 +62,11 @@ void iauLtecm(double epj, double rm[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Frame bias (IERS Conventions 2010, Eqs. 5.21 and 5.33) */
@@ -100,10 +101,12 @@ void iauLtecm(double epj, double rm[3][3])
    rm[2][1] =   z[0]*dr + z[1]    + z[2]*de;
    rm[2][2] = - z[0]*dx - z[1]*de + z[2];
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/lteqec.c
+++ b/SOFA/SOFA/src/lteqec.c
@@ -6,9 +6,8 @@ void iauLteqec(double epj, double dr, double dd, double *dl, double *db)
 **   i a u L t e q e c
 **  - - - - - - - - - -
 **
-**  Transformation from ICRS equatorial coordinates to ecliptic
-**  coordinates (mean equinox and ecliptic of date) using a long-term
-**  precession model.
+**  Transformation from ICRS RA,Dec to ecliptic coordinates (mean equinox
+**  and ecliptic of date), using a long-term precession model.
 **
 **  This function is part of the International Astronomical Union's
 **  SOFA (Standards of Fundamental Astronomy) software collection.
@@ -56,11 +55,11 @@ void iauLteqec(double epj, double dr, double dd, double *dl, double *db)
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2023 March 18
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rm[3][3], v1[3], v2[3], a, b;
@@ -82,10 +81,12 @@ void iauLteqec(double epj, double dr, double dd, double *dl, double *db)
    *dl = iauAnp(a);
    *db = iauAnpm(b);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ltp.c
+++ b/SOFA/SOFA/src/ltp.c
@@ -27,7 +27,7 @@ void iauLtp(double epj, double rp[3][3])
 **
 **     where P_J2000 is a vector with respect to the J2000.0 mean
 **     equator and equinox and P_date is the same vector with respect to
-**     the equator and equinox of epoch epj.
+**     the mean equator and equinox of epoch epj.
 **
 **  2) The Vondrak et al. (2011, 2012) 400 millennia precession model
 **     agrees with the IAU 2006 precession at J2000.0 and stays within
@@ -52,11 +52,11 @@ void iauLtp(double epj, double rp[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2023 March 19
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -83,10 +83,12 @@ void iauLtp(double epj, double rp[3][3])
       rp[2][i] = peqr[i];
    }
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ltpb.c
+++ b/SOFA/SOFA/src/ltpb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLtpb(double epj, double rpb[3][3])
 /*
@@ -17,7 +18,7 @@ void iauLtpb(double epj, double rpb[3][3])
 **     epj     double         Julian epoch (TT)
 **
 **  Returned:
-**     rpb     double[3][3]   precession-bias matrix, J2000.0 to date
+**     rpb     double[3][3]   precession+bias matrix, J2000.0 to date
 **
 **  Notes:
 **
@@ -50,11 +51,11 @@ void iauLtpb(double epj, double rpb[3][3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2015 December 6
+**  This revision:  2023 March 20
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Frame bias (IERS Conventions 2010, Eqs. 5.21 and 5.33) */
@@ -76,10 +77,12 @@ void iauLtpb(double epj, double rpb[3][3])
       rpb[i][2] = -rp[i][0]*dx - rp[i][1]*de + rp[i][2];
    }
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ltpecl.c
+++ b/SOFA/SOFA/src/ltpecl.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLtpecl(double epj, double vec[3])
 /*
@@ -41,11 +42,11 @@ void iauLtpecl(double epj, double vec[3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Obliquity at J2000.0 (radians). */
@@ -120,10 +121,12 @@ void iauLtpecl(double epj, double vec[3])
    vec[1] = - q*c - w*s;
    vec[2] = - q*s + w*c;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ltpequ.c
+++ b/SOFA/SOFA/src/ltpequ.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauLtpequ(double epj, double veq[3])
 /*
@@ -41,11 +42,11 @@ void iauLtpequ(double epj, double veq[3])
 **    expressions, valid for long time intervals (Corrigendum),
 **    Astron.Astrophys. 541, C1
 **
-**  This revision:  2016 February 9
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Polynomial coefficients */
@@ -120,10 +121,12 @@ void iauLtpequ(double epj, double veq[3])
    w = 1.0 - x*x - y*y;
    veq[2] = w < 0.0 ? 0.0 : sqrt(w);
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/makefile
+++ b/SOFA/SOFA/src/makefile
@@ -33,7 +33,7 @@
 #      make distclean     delete all generated binaries
 #      make realclean     same as distclean
 #
-# Last revision:   2019 July 22
+# Last revision:   2021 April 18
 #
 # Copyright International Astronomical Union.  All rights reserved.
 #
@@ -64,8 +64,8 @@ SOFA_INC_DIR = $(INSTALL_DIR)/include/
 # for functions, CFLAGX for executables) here.
 
 CCOMPC = gcc
-CFLAGF = -c -pedantic -Wall -W -O
-CFLAGX = -pedantic -Wall -W -O
+CFLAGF = -c -pedantic -Wall -O
+CFLAGX = -pedantic -Wall -O
 
 #----YOU SHOULDN'T HAVE TO MODIFY ANYTHING BELOW THIS LINE---------
 
@@ -111,6 +111,8 @@ SOFA_OBS = iauA2af.o \
            iauAper13.o \
            iauApio.o \
            iauApio13.o \
+           iauAtcc13.o \
+           iauAtccq.o \
            iauAtci13.o \
            iauAtciq.o \
            iauAtciqn.o \
@@ -223,6 +225,7 @@ SOFA_OBS = iauA2af.o \
            iauLtpb.o \
            iauLtpecl.o \
            iauLtpequ.o \
+           iauMoon98.o \
            iauNum00a.o \
            iauNum00b.o \
            iauNum06a.o \
@@ -361,7 +364,7 @@ uninstall:
 # Test the build.
 check: $(SOFA_TEST_NAME) $(SOFA_INC_NAMES) $(SOFA_LIB_NAME)
 	$(CCOMPC) $(CFLAGX) $(SOFA_TEST_NAME) $(SOFA_LIB_NAME) \
-        -lm -o $(SOFA_TEST)
+        -I. -lm -o $(SOFA_TEST)
 	./$(SOFA_TEST)
 
 # Test the installed library.
@@ -432,6 +435,10 @@ iauApio.o   : apio.c   sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ apio.c
 iauApio13.o : apio13.c sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ apio13.c
+iauAtcc13.o : atcc13.c sofa.h sofam.h
+	$(CCOMPC) $(CFLAGF) -o $@ atcc13.c
+iauAtccq.o  : atccq.c  sofa.h sofam.h
+	$(CCOMPC) $(CFLAGF) -o $@ atccq.c
 iauAtci13.o : atci13.c sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ atci13.c
 iauAtciq.o  : atciq.c  sofa.h sofam.h
@@ -656,6 +663,8 @@ iauLtpecl.o : ltpecl.c sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ ltpecl.c
 iauLtpequ.o : ltpequ.c sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ ltpequ.c
+iauMoon98.o : moon98.c sofa.h sofam.h
+	$(CCOMPC) $(CFLAGF) -o $@ moon98.c
 iauNum00a.o : num00a.c sofa.h sofam.h
 	$(CCOMPC) $(CFLAGF) -o $@ num00a.c
 iauNum00b.o : num00b.c sofa.h sofam.h

--- a/SOFA/SOFA/src/moon98.c
+++ b/SOFA/SOFA/src/moon98.c
@@ -1,0 +1,654 @@
+#include "sofa.h"
+#include "sofam.h"
+#include <stdlib.h>
+
+void iauMoon98 ( double date1, double date2, double pv[2][3] )
+/*
+**  - - - - - - - - - -
+**   i a u M o o n 9 8
+**  - - - - - - - - - -
+**
+**  Approximate geocentric position and velocity of the Moon.
+**
+**  This function is part of the International Astronomical Union's
+**  SOFA (Standards of Fundamental Astronomy) software collection.
+**
+**  Status:  support function.
+**
+**  n.b. Not IAU-endorsed and without canonical status.
+**
+**  Given:
+**     date1  double         TT date part A (Notes 1,4)
+**     date2  double         TT date part B (Notes 1,4)
+**
+**  Returned:
+**     pv     double[2][3]   Moon p,v, GCRS (au, au/d, Note 5)
+**
+**  Notes:
+**
+**  1) The TT date date1+date2 is a Julian Date, apportioned in any
+**     convenient way between the two arguments.  For example,
+**     JD(TT)=2450123.7 could be expressed in any of these ways, among
+**     others:
+**
+**            date1          date2
+**
+**         2450123.7           0.0       (JD method)
+**         2451545.0       -1421.3       (J2000 method)
+**         2400000.5       50123.2       (MJD method)
+**         2450123.5           0.2       (date & time method)
+**
+**     The JD method is the most natural and convenient to use in cases
+**     where the loss of several decimal digits of resolution is
+**     acceptable.  The J2000 method is best matched to the way the
+**     argument is handled internally and will deliver the optimum
+**     resolution.  The MJD method and the date & time methods are both
+**     good compromises between resolution and convenience.  The limited
+**     accuracy of the present algorithm is such that any of the methods
+**     is satisfactory.
+**
+**  2) This function is a full implementation of the algorithm
+**     published by Meeus (see reference) except that the light-time
+**     correction to the Moon's mean longitude has been omitted.
+**
+**  3) Comparisons with ELP/MPP02 over the interval 1950-2100 gave RMS
+**     errors of 2.9 arcsec in geocentric direction, 6.1 km in position
+**     and 36 mm/s in velocity.  The worst case errors were 18.3 arcsec
+**     in geocentric direction, 31.7 km in position and 172 mm/s in
+**     velocity.
+**
+**  4) The original algorithm is expressed in terms of "dynamical time",
+**     which can either be TDB or TT without any significant change in
+**     accuracy.  UT cannot be used without incurring significant errors
+**     (30 arcsec in the present era) due to the Moon's 0.5 arcsec/sec
+**     movement.
+**
+**  5) The result is with respect to the GCRS (the same as J2000.0 mean
+**     equator and equinox to within 23 mas).
+**
+**  6) Velocity is obtained by a complete analytical differentiation
+**     of the Meeus model.
+**
+**  7) The Meeus algorithm generates position and velocity in mean
+**     ecliptic coordinates of date, which the present function then
+**     rotates into GCRS.  Because the ecliptic system is precessing,
+**     there is a coupling between this spin (about 1.4 degrees per
+**     century) and the Moon position that produces a small velocity
+**     contribution.  In the present function this effect is neglected
+**     as it corresponds to a maximum difference of less than 3 mm/s and
+**     increases the RMS error by only 0.4%.
+**
+**  References:
+**
+**     Meeus, J., Astronomical Algorithms, 2nd edition, Willmann-Bell,
+**     1998, p337.
+**
+**     Simon, J.L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
+**     Francou, G. & Laskar, J., Astron.Astrophys., 1994, 282, 663
+**
+**  Defined in sofam.h:
+**     DAU           astronomical unit (m)
+**     DJC           days per Julian century
+**     DJ00          reference epoch (J2000.0), Julian Date
+**     DD2R          degrees to radians
+**
+**  Called:
+**     iauS2pv      spherical coordinates to pv-vector
+**     iauPfw06     bias-precession F-W angles, IAU 2006
+**     iauIr        initialize r-matrix to identity
+**     iauRz        rotate around Z-axis
+**     iauRx        rotate around X-axis
+**     iauRxpv      product of r-matrix and pv-vector
+**
+**  This revision:  2023 March 20
+**
+**  SOFA release 2023-10-11
+**
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
+*/
+{
+/*
+**  Coefficients for fundamental arguments:
+**
+**  . Powers of time in Julian centuries
+**  . Units are degrees.
+*/
+
+/* Moon's mean longitude (wrt mean equinox and ecliptic of date) */
+   static double elp0 = 218.31665436,        /* Simon et al. (1994). */
+                 elp1 = 481267.88123421,
+                 elp2 = -0.0015786,
+                 elp3 = 1.0 / 538841.0,
+                 elp4 = -1.0 / 65194000.0;
+   double elp, delp;
+
+/* Moon's mean elongation */
+   static double d0 = 297.8501921,
+                 d1 = 445267.1114034,
+                 d2 = -0.0018819,
+                 d3 = 1.0 / 545868.0,
+                 d4 = 1.0 / 113065000.0;
+   double d, dd;
+
+/* Sun's mean anomaly */
+   static double em0 = 357.5291092,
+                 em1 = 35999.0502909,
+                 em2 = -0.0001536,
+                 em3 = 1.0 / 24490000.0,
+                 em4 = 0.0;
+   double em, dem;
+
+/* Moon's mean anomaly */
+   static double emp0 = 134.9633964,
+                 emp1 = 477198.8675055,
+                 emp2 = 0.0087414,
+                 emp3 = 1.0 / 69699.0,
+                 emp4 = -1.0 / 14712000.0;
+   double emp, demp;
+
+/* Mean distance of the Moon from its ascending node */
+   static double f0 = 93.2720950,
+                 f1 = 483202.0175233,
+                 f2 = -0.0036539,
+                 f3 = 1.0 / 3526000.0,
+                 f4 = 1.0 / 863310000.0;
+   double f, df;
+
+/*
+** Other arguments
+*/
+
+/* Meeus A_1, due to Venus (deg) */
+   static double a10 = 119.75,
+                 a11 = 131.849;
+   double a1, da1;
+
+/* Meeus A_2, due to Jupiter (deg) */
+   static double a20 = 53.09,
+                 a21 = 479264.290;
+   double a2, da2;
+
+/* Meeus A_3, due to sidereal motion of the Moon in longitude (deg) */
+   static double a30 = 313.45,
+                 a31 = 481266.484;
+   double a3, da3;
+
+/* Coefficients for Meeus "additive terms" (deg) */
+   static double al1 =  0.003958,
+                 al2 =  0.001962,
+                 al3 =  0.000318;
+   static double ab1 = -0.002235,
+                 ab2 =  0.000382,
+                 ab3 =  0.000175,
+                 ab4 =  0.000175,
+                 ab5 =  0.000127,
+                 ab6 = -0.000115;
+
+/* Fixed term in distance (m) */
+   static double r0 = 385000560.0;
+
+/* Coefficients for (dimensionless) E factor */
+   static double e1 = -0.002516,
+                 e2 = -0.0000074;
+   double e, de, esq, desq;
+
+/*
+** Coefficients for Moon longitude and distance series
+*/
+   struct termlr {
+      int nd;           /* multiple of D  in argument           */
+      int nem;          /*     "    "  M   "    "               */
+      int nemp;         /*     "    "  M'  "    "               */
+      int nf;           /*     "    "  F   "    "               */
+      double coefl;     /* coefficient of L sine argument (deg) */
+      double coefr;     /* coefficient of R cosine argument (m) */
+   };
+
+static struct termlr tlr[] = {{0,  0,  1,  0,  6.288774, -20905355.0},
+                              {2,  0, -1,  0,  1.274027,  -3699111.0},
+                              {2,  0,  0,  0,  0.658314,  -2955968.0},
+                              {0,  0,  2,  0,  0.213618,   -569925.0},
+                              {0,  1,  0,  0, -0.185116,     48888.0},
+                              {0,  0,  0,  2, -0.114332,     -3149.0},
+                              {2,  0, -2,  0,  0.058793,    246158.0},
+                              {2, -1, -1,  0,  0.057066,   -152138.0},
+                              {2,  0,  1,  0,  0.053322,   -170733.0},
+                              {2, -1,  0,  0,  0.045758,   -204586.0},
+                              {0,  1, -1,  0, -0.040923,   -129620.0},
+                              {1,  0,  0,  0, -0.034720,    108743.0},
+                              {0,  1,  1,  0, -0.030383,    104755.0},
+                              {2,  0,  0, -2,  0.015327,     10321.0},
+                              {0,  0,  1,  2, -0.012528,         0.0},
+                              {0,  0,  1, -2,  0.010980,     79661.0},
+                              {4,  0, -1,  0,  0.010675,    -34782.0},
+                              {0,  0,  3,  0,  0.010034,    -23210.0},
+                              {4,  0, -2,  0,  0.008548,    -21636.0},
+                              {2,  1, -1,  0, -0.007888,     24208.0},
+                              {2,  1,  0,  0, -0.006766,     30824.0},
+                              {1,  0, -1,  0, -0.005163,     -8379.0},
+                              {1,  1,  0,  0,  0.004987,    -16675.0},
+                              {2, -1,  1,  0,  0.004036,    -12831.0},
+                              {2,  0,  2,  0,  0.003994,    -10445.0},
+                              {4,  0,  0,  0,  0.003861,    -11650.0},
+                              {2,  0, -3,  0,  0.003665,     14403.0},
+                              {0,  1, -2,  0, -0.002689,     -7003.0},
+                              {2,  0, -1,  2, -0.002602,         0.0},
+                              {2, -1, -2,  0,  0.002390,     10056.0},
+                              {1,  0,  1,  0, -0.002348,      6322.0},
+                              {2, -2,  0,  0,  0.002236,     -9884.0},
+                              {0,  1,  2,  0, -0.002120,      5751.0},
+                              {0,  2,  0,  0, -0.002069,         0.0},
+                              {2, -2, -1,  0,  0.002048,     -4950.0},
+                              {2,  0,  1, -2, -0.001773,      4130.0},
+                              {2,  0,  0,  2, -0.001595,         0.0},
+                              {4, -1, -1,  0,  0.001215,     -3958.0},
+                              {0,  0,  2,  2, -0.001110,         0.0},
+                              {3,  0, -1,  0, -0.000892,      3258.0},
+                              {2,  1,  1,  0, -0.000810,      2616.0},
+                              {4, -1, -2,  0,  0.000759,     -1897.0},
+                              {0,  2, -1,  0, -0.000713,     -2117.0},
+                              {2,  2, -1,  0, -0.000700,      2354.0},
+                              {2,  1, -2,  0,  0.000691,         0.0},
+                              {2, -1,  0, -2,  0.000596,         0.0},
+                              {4,  0,  1,  0,  0.000549,     -1423.0},
+                              {0,  0,  4,  0,  0.000537,     -1117.0},
+                              {4, -1,  0,  0,  0.000520,     -1571.0},
+                              {1,  0, -2,  0, -0.000487,     -1739.0},
+                              {2,  1,  0, -2, -0.000399,         0.0},
+                              {0,  0,  2, -2, -0.000381,     -4421.0},
+                              {1,  1,  1,  0,  0.000351,         0.0},
+                              {3,  0, -2,  0, -0.000340,         0.0},
+                              {4,  0, -3,  0,  0.000330,         0.0},
+                              {2, -1,  2,  0,  0.000327,         0.0},
+                              {0,  2,  1,  0, -0.000323,      1165.0},
+                              {1,  1, -1,  0,  0.000299,         0.0},
+                              {2,  0,  3,  0,  0.000294,         0.0},
+                              {2,  0, -1, -2,  0.000000,      8752.0}};
+
+   static int NLR = ( sizeof tlr / sizeof ( struct termlr ) );
+
+/*
+** Coefficients for Moon latitude series
+*/
+   struct termb {
+      int nd;           /* multiple of D  in argument           */
+      int nem;          /*     "    "  M   "    "               */
+      int nemp;         /*     "    "  M'  "    "               */
+      int nf;           /*     "    "  F   "    "               */
+      double coefb;     /* coefficient of B sine argument (deg) */
+   };
+
+static struct termb tb[] = {{0,  0,  0,  1,  5.128122},
+                            {0,  0,  1,  1,  0.280602},
+                            {0,  0,  1, -1,  0.277693},
+                            {2,  0,  0, -1,  0.173237},
+                            {2,  0, -1,  1,  0.055413},
+                            {2,  0, -1, -1,  0.046271},
+                            {2,  0,  0,  1,  0.032573},
+                            {0,  0,  2,  1,  0.017198},
+                            {2,  0,  1, -1,  0.009266},
+                            {0,  0,  2, -1,  0.008822},
+                            {2, -1,  0, -1,  0.008216},
+                            {2,  0, -2, -1,  0.004324},
+                            {2,  0,  1,  1,  0.004200},
+                            {2,  1,  0, -1, -0.003359},
+                            {2, -1, -1,  1,  0.002463},
+                            {2, -1,  0,  1,  0.002211},
+                            {2, -1, -1, -1,  0.002065},
+                            {0,  1, -1, -1, -0.001870},
+                            {4,  0, -1, -1,  0.001828},
+                            {0,  1,  0,  1, -0.001794},
+                            {0,  0,  0,  3, -0.001749},
+                            {0,  1, -1,  1, -0.001565},
+                            {1,  0,  0,  1, -0.001491},
+                            {0,  1,  1,  1, -0.001475},
+                            {0,  1,  1, -1, -0.001410},
+                            {0,  1,  0, -1, -0.001344},
+                            {1,  0,  0, -1, -0.001335},
+                            {0,  0,  3,  1,  0.001107},
+                            {4,  0,  0, -1,  0.001021},
+                            {4,  0, -1,  1,  0.000833},
+                            {0,  0,  1, -3,  0.000777},
+                            {4,  0, -2,  1,  0.000671},
+                            {2,  0,  0, -3,  0.000607},
+                            {2,  0,  2, -1,  0.000596},
+                            {2, -1,  1, -1,  0.000491},
+                            {2,  0, -2,  1, -0.000451},
+                            {0,  0,  3, -1,  0.000439},
+                            {2,  0,  2,  1,  0.000422},
+                            {2,  0, -3, -1,  0.000421},
+                            {2,  1, -1,  1, -0.000366},
+                            {2,  1,  0,  1, -0.000351},
+                            {4,  0,  0,  1,  0.000331},
+                            {2, -1,  1,  1,  0.000315},
+                            {2, -2,  0, -1,  0.000302},
+                            {0,  0,  1,  3, -0.000283},
+                            {2,  1,  1, -1, -0.000229},
+                            {1,  1,  0, -1,  0.000223},
+                            {1,  1,  0,  1,  0.000223},
+                            {0,  1, -2, -1, -0.000220},
+                            {2,  1, -1, -1, -0.000220},
+                            {1,  0,  1,  1, -0.000185},
+                            {2, -1, -2, -1,  0.000181},
+                            {0,  1,  2,  1, -0.000177},
+                            {4,  0, -2, -1,  0.000176},
+                            {4, -1, -1, -1,  0.000166},
+                            {1,  0,  1, -1, -0.000164},
+                            {4,  0,  1, -1,  0.000132},
+                            {1,  0, -1, -1, -0.000119},
+                            {4, -1,  0, -1,  0.000115},
+                            {2, -2,  0,  1,  0.000107}};
+
+   static int NB = ( sizeof tb / sizeof ( struct termb ) );
+
+/* Miscellaneous */
+   int n, i;
+   double t, elpmf, delpmf, vel, vdel, vr, vdr, a1mf, da1mf, a1pf,
+          da1pf, dlpmp, slpmp, vb, vdb, v, dv, emn, empn, dn, fn, en,
+          den, arg, darg, farg, coeff, el, del, r, dr, b, db, gamb,
+          phib, psib, epsa, rm[3][3];
+
+/* ------------------------------------------------------------------ */
+
+/* Centuries since J2000.0 */
+   t = ((date1 - DJ00) + date2) / DJC;
+
+/* --------------------- */
+/* Fundamental arguments */
+/* --------------------- */
+
+/* Arguments (radians) and derivatives (radians per Julian century)
+   for the current date. */
+
+/* Moon's mean longitude. */
+   elp = DD2R * fmod ( elp0
+                   + ( elp1
+                   + ( elp2
+                   + ( elp3
+                   +   elp4 * t ) * t ) * t ) * t, 360.0 );
+   delp = DD2R * (     elp1
+                   + ( elp2 * 2.0
+                   + ( elp3 * 3.0
+                   +   elp4 * 4.0 * t ) * t ) * t );
+
+/* Moon's mean elongation. */
+   d = DD2R * fmod ( d0
+                 + ( d1
+                 + ( d2
+                 + ( d3
+                 +   d4 * t ) * t ) * t ) * t, 360.0 );
+   dd = DD2R * (     d1
+                 + ( d2 * 2.0
+                 + ( d3 * 3.0
+                 +   d4 * 4.0 * t ) * t ) * t );
+
+/* Sun's mean anomaly. */
+   em = DD2R * fmod ( em0
+                  + ( em1
+                  + ( em2
+                  + ( em3
+                  +   em4 * t ) * t ) * t ) * t, 360.0 );
+   dem = DD2R * (     em1
+                  + ( em2 * 2.0
+                  + ( em3 * 3.0
+                  +   em4 * 4.0 * t ) * t ) * t );
+
+/* Moon's mean anomaly. */
+   emp = DD2R * fmod ( emp0
+                   + ( emp1
+                   + ( emp2
+                   + ( emp3
+                   +   emp4 * t ) * t ) * t ) * t, 360.0 );
+   demp = DD2R * (     emp1
+                   + ( emp2 * 2.0
+                   + ( emp3 * 3.0
+                   +   emp4 * 4.0 * t ) * t ) * t );
+
+/* Mean distance of the Moon from its ascending node. */
+   f = DD2R * fmod ( f0
+                 + ( f1
+                 + ( f2
+                 + ( f3
+                 +   f4 * t ) * t ) * t ) * t, 360.0 );
+   df = DD2R * (     f1
+                 + ( f2 * 2.0
+                 + ( f3 * 3.0
+                 +   f4 * 4.0 * t ) * t ) * t );
+
+/* Meeus further arguments. */
+   a1 = DD2R * ( a10 + a11*t );
+   da1 = DD2R * al1;
+   a2 = DD2R * ( a20 + a21*t );
+   da2 = DD2R * a21;
+   a3 = DD2R * ( a30 + a31*t );
+   da3 = DD2R * a31;
+
+/* E-factor, and square. */
+   e = 1.0 + ( e1 + e2*t ) * t;
+   de = e1 + 2.0*e2*t;
+   esq = e*e;
+   desq = 2.0*e*de;
+
+/* Use the Meeus additive terms (deg) to start off the summations. */
+   elpmf = elp - f;
+   delpmf = delp - df;
+   vel = al1 * sin(a1)
+       + al2 * sin(elpmf)
+       + al3 * sin(a2);
+   vdel = al1 * cos(a1) * da1
+        + al2 * cos(elpmf) * delpmf
+        + al3 * cos(a2) * da2;
+
+   vr = 0.0;
+   vdr = 0.0;
+
+   a1mf = a1 - f;
+   da1mf = da1 - df;
+   a1pf = a1 + f;
+   da1pf = da1 + df;
+   dlpmp = elp - emp;
+   slpmp = elp + emp;
+   vb = ab1 * sin(elp)
+      + ab2 * sin(a3)
+      + ab3 * sin(a1mf)
+      + ab4 * sin(a1pf)
+      + ab5 * sin(dlpmp)
+      + ab6 * sin(slpmp);
+   vdb = ab1 * cos(elp) * delp
+       + ab2 * cos(a3) * da3
+       + ab3 * cos(a1mf) * da1mf
+       + ab4 * cos(a1pf) * da1pf
+       + ab5 * cos(dlpmp) * (delp-demp)
+       + ab6 * cos(slpmp) * (delp+demp);
+
+/* ----------------- */
+/* Series expansions */
+/* ----------------- */
+
+/* Longitude and distance plus derivatives. */
+   for ( n = NLR-1; n >= 0; n-- ) {
+      dn = (double) tlr[n].nd;
+      emn = (double) ( i = tlr[n].nem );
+      empn = (double) tlr[n].nemp;
+      fn = (double) tlr[n].nf;
+      switch ( abs(i) ) {
+      case 1:
+         en = e;
+         den = de;
+         break;
+      case 2:
+         en = esq;
+         den = desq;
+         break;
+      default:
+         en = 1.0;
+         den = 0.0;
+      }
+      arg = dn*d + emn*em + empn*emp + fn*f;
+      darg = dn*dd + emn*dem + empn*demp + fn*df;
+      farg = sin(arg);
+      v = farg * en;
+      dv = cos(arg)*darg*en + farg*den;
+      coeff = tlr[n].coefl;
+      vel += coeff * v;
+      vdel += coeff * dv;
+      farg = cos(arg);
+      v = farg * en;
+      dv = -sin(arg)*darg*en + farg*den;
+      coeff = tlr[n].coefr;
+      vr += coeff * v;
+      vdr += coeff * dv;
+   }
+   el = elp + DD2R*vel;
+   del = ( delp + DD2R*vdel ) / DJC;
+   r = ( vr + r0 ) / DAU;
+   dr = vdr / DAU / DJC;
+
+/* Latitude plus derivative. */
+   for ( n = NB-1; n >= 0; n-- ) {
+      dn = (double) tb[n].nd;
+      emn = (double) ( i = tb[n].nem );
+      empn = (double) tb[n].nemp;
+      fn = (double) tb[n].nf;
+      switch ( abs(i) ) {
+      case 1:
+         en = e;
+         den = de;
+         break;
+      case 2:
+         en = esq;
+         den = desq;
+         break;
+      default:
+         en = 1.0;
+         den = 0.0;
+      }
+      arg = dn*d + emn*em + empn*emp + fn*f;
+      darg = dn*dd + emn*dem + empn*demp + fn*df;
+      farg = sin(arg);
+      v = farg * en;
+      dv = cos(arg)*darg*en + farg*den;
+      coeff = tb[n].coefb;
+      vb += coeff * v;
+      vdb += coeff * dv;
+   }
+   b = vb * DD2R;
+   db = vdb * DD2R / DJC;
+
+/* ------------------------------ */
+/* Transformation into final form */
+/* ------------------------------ */
+
+/* Longitude, latitude to x, y, z (au). */
+   iauS2pv ( el, b, r, del, db, dr, pv );
+
+/* IAU 2006 Fukushima-Williams bias+precession angles. */
+   iauPfw06 ( date1, date2, &gamb, &phib, &psib, &epsa );
+
+/* Mean ecliptic coordinates to GCRS rotation matrix. */
+   iauIr ( rm );
+   iauRz ( psib, rm );
+   iauRx ( -phib, rm );
+   iauRz ( -gamb, rm );
+
+/* Rotate the Moon position and velocity into GCRS (Note 6). */
+   iauRxpv ( rm, pv, pv );
+
+/* Finished. */
+
+/*----------------------------------------------------------------------
+**
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
+**  of the International Astronomical Union.
+**
+**  =====================
+**  SOFA Software License
+**  =====================
+**
+**  NOTICE TO USER:
+**
+**  BY USING THIS SOFTWARE YOU ACCEPT THE FOLLOWING SIX TERMS AND
+**  CONDITIONS WHICH APPLY TO ITS USE.
+**
+**  1. The Software is owned by the IAU SOFA Board ("SOFA").
+**
+**  2. Permission is granted to anyone to use the SOFA software for any
+**     purpose, including commercial applications, free of charge and
+**     without payment of royalties, subject to the conditions and
+**     restrictions listed below.
+**
+**  3. You (the user) may copy and distribute SOFA source code to others,
+**     and use and adapt its code and algorithms in your own software,
+**     on a world-wide, royalty-free basis.  That portion of your
+**     distribution that does not consist of intact and unchanged copies
+**     of SOFA source code files is a "derived work" that must comply
+**     with the following requirements:
+**
+**     a) Your work shall be marked or carry a statement that it
+**        (i) uses routines and computations derived by you from
+**        software provided by SOFA under license to you; and
+**        (ii) does not itself constitute software provided by and/or
+**        endorsed by SOFA.
+**
+**     b) The source code of your derived work must contain descriptions
+**        of how the derived work is based upon, contains and/or differs
+**        from the original SOFA software.
+**
+**     c) The names of all routines in your derived work shall not
+**        include the prefix "iau" or "sofa" or trivial modifications
+**        thereof such as changes of case.
+**
+**     d) The origin of the SOFA components of your derived work must
+**        not be misrepresented;  you must not claim that you wrote the
+**        original software, nor file a patent application for SOFA
+**        software or algorithms embedded in the SOFA software.
+**
+**     e) These requirements must be reproduced intact in any source
+**        distribution and shall apply to anyone to whom you have
+**        granted a further right to modify the source code of your
+**        derived work.
+**
+**     Note that, as originally distributed, the SOFA software is
+**     intended to be a definitive implementation of the IAU standards,
+**     and consequently third-party modifications are discouraged.  All
+**     variations, no matter how minor, must be explicitly marked as
+**     such, as explained above.
+**
+**  4. You shall not cause the SOFA software to be brought into
+**     disrepute, either by misuse, or use for inappropriate tasks, or
+**     by inappropriate modification.
+**
+**  5. The SOFA software is provided "as is" and SOFA makes no warranty
+**     as to its use or performance.   SOFA does not and cannot warrant
+**     the performance or results which the user may obtain by using the
+**     SOFA software.  SOFA makes no warranties, express or implied, as
+**     to non-infringement of third party rights, merchantability, or
+**     fitness for any particular purpose.  In no event will SOFA be
+**     liable to the user for any consequential, incidental, or special
+**     damages, including any lost profits or lost savings, even if a
+**     SOFA representative has been advised of such damages, or for any
+**     claim by any third party.
+**
+**  6. The provision of any version of the SOFA software under the terms
+**     and conditions specified herein does not imply that future
+**     versions will also be made available under the same terms and
+**     conditions.
+*
+**  In any published work or commercial product which uses the SOFA
+**  software directly, acknowledgement (see www.iausofa.org) is
+**  appreciated.
+**
+**  Correspondence concerning SOFA software should be addressed as
+**  follows:
+**
+**      By email:  sofa@ukho.gov.uk
+**      By post:   IAU SOFA Center
+**                 HM Nautical Almanac Office
+**                 UK Hydrographic Office
+**                 Admiralty Way, Taunton
+**                 Somerset, TA1 2DN
+**                 United Kingdom
+**
+**--------------------------------------------------------------------*/
+}

--- a/SOFA/SOFA/src/num00a.c
+++ b/SOFA/SOFA/src/num00a.c
@@ -9,7 +9,7 @@ void iauNum00a(double date1, double date2, double rmatn[3][3])
 **  Form the matrix of nutation for a given date, IAU 2000A model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -45,7 +45,7 @@ void iauNum00a(double date1, double date2, double rmatn[3][3])
 **     of date and the p-vector V(mean) is with respect to the mean
 **     equatorial triad of date.
 **
-**  3) A faster, but slightly less accurate result (about 1 mas), can be
+**  3) A faster, but slightly less accurate, result (about 1 mas) can be
 **     obtained by using instead the iauNum00b function.
 **
 **  Called:
@@ -57,11 +57,11 @@ void iauNum00a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rbpn[3][3];
@@ -71,12 +71,12 @@ void iauNum00a(double date1, double date2, double rmatn[3][3])
    iauPn00a(date1, date2,
             &dpsi, &deps, &epsa, rb, rp, rbp, rmatn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/num00b.c
+++ b/SOFA/SOFA/src/num00b.c
@@ -9,7 +9,7 @@ void iauNum00b(double date1, double date2, double rmatn[3][3])
 **  Form the matrix of nutation for a given date, IAU 2000B model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -57,11 +57,11 @@ void iauNum00b(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rbpn[3][3];
@@ -71,12 +71,12 @@ void iauNum00b(double date1, double date2, double rmatn[3][3])
    iauPn00b(date1, date2,
             &dpsi, &deps, &epsa, rb, rp, rbp, rmatn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/num06a.c
+++ b/SOFA/SOFA/src/num06a.c
@@ -9,7 +9,7 @@ void iauNum06a(double date1, double date2, double rmatn[3][3])
 **  Form the matrix of nutation for a given date, IAU 2006/2000A model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -56,11 +56,11 @@ void iauNum06a(double date1, double date2, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double eps, dp, de;
@@ -75,12 +75,12 @@ void iauNum06a(double date1, double date2, double rmatn[3][3])
 /* Nutation matrix. */
    iauNumat(eps, dp, de, rmatn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/numat.c
+++ b/SOFA/SOFA/src/numat.c
@@ -9,7 +9,7 @@ void iauNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 **  Form the matrix of nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -46,11 +46,11 @@ void iauNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222-3 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Build the rotation matrix. */
@@ -59,12 +59,12 @@ void iauNumat(double epsa, double dpsi, double deps, double rmatn[3][3])
    iauRz(-dpsi, rmatn);
    iauRx(-(epsa + deps), rmatn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/nut00a.c
+++ b/SOFA/SOFA/src/nut00a.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauNut00a(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -10,7 +11,7 @@ void iauNut00a(double date1, double date2, double *dpsi, double *deps)
 **  with free core nutation omitted).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -153,11 +154,11 @@ void iauNut00a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 July 20
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i;
@@ -1878,7 +1879,7 @@ void iauNut00a(double date1, double date2, double *dpsi, double *deps)
             t * (-0.00001149)))), TURNAS) * DAS2R;
 
 /* Mean longitude of the Moon minus that of the ascending node */
-/* (IERS 2003. */
+/* (IERS 2003). */
    f = iauFaf03(t);
 
 /* Mean elongation of the Moon from the Sun (MHB2000). */
@@ -1997,12 +1998,12 @@ void iauNut00a(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dpsils + dpsipl;
    *deps = depsls + depspl;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/nut00b.c
+++ b/SOFA/SOFA/src/nut00b.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauNut00b(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -9,7 +10,7 @@ void iauNut00b(double date1, double date2, double *dpsi, double *deps)
 **  Nutation, IAU 2000B model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -121,11 +122,11 @@ void iauNut00b(double date1, double date2, double *dpsi, double *deps)
 **     Simon, J.-L., Bretagnon, P., Chapront, J., Chapront-Touze, M.,
 **     Francou, G., Laskar, J., Astron.Astrophys. 282, 663-683 (1994)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, el, elp, f, d, om, arg, dp, de, sarg, carg,
@@ -322,12 +323,12 @@ void iauNut00b(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dpsils + dpsipl;
    *deps = depsls + depspl;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/nut06a.c
+++ b/SOFA/SOFA/src/nut06a.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauNut06a(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -77,11 +78,11 @@ void iauNut06a(double date1, double date2, double *dpsi, double *deps)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, fj2, dp, de;
@@ -100,12 +101,12 @@ void iauNut06a(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dp + dp * (0.4697e-6 + fj2);
    *deps = de + de * fj2;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/nut80.c
+++ b/SOFA/SOFA/src/nut80.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauNut80(double date1, double date2, double *dpsi, double *deps)
 /*
@@ -9,7 +10,7 @@ void iauNut80(double date1, double date2, double *dpsi, double *deps)
 **  Nutation, IAU 1980 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -53,11 +54,11 @@ void iauNut80(double date1, double date2, double *dpsi, double *deps)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.222 (p111).
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, el, elp, f, d, om, dp, de, arg, s, c;
@@ -275,12 +276,12 @@ void iauNut80(double date1, double date2, double *dpsi, double *deps)
    *dpsi = dp * U2R;
    *deps = de * U2R;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/nutm80.c
+++ b/SOFA/SOFA/src/nutm80.c
@@ -9,7 +9,7 @@ void iauNutm80(double date1, double date2, double rmatn[3][3])
 **  Form the matrix of nutation for a given date, IAU 1980 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -50,11 +50,11 @@ void iauNutm80(double date1, double date2, double rmatn[3][3])
 **     iauObl80     mean obliquity, IAU 1980
 **     iauNumat     form nutation matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsi, deps, epsa;
@@ -67,12 +67,12 @@ void iauNutm80(double date1, double date2, double rmatn[3][3])
 /* Build the rotation matrix. */
    iauNumat(epsa, dpsi, deps, rmatn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/obl06.c
+++ b/SOFA/SOFA/src/obl06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauObl06(double date1, double date2)
 /*
@@ -9,7 +10,7 @@ double iauObl06(double date1, double date2)
 **  Mean obliquity of the ecliptic, IAU 2006 precession model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -47,11 +48,11 @@ double iauObl06(double date1, double date2)
 **
 **     Hilton, J. et al., 2006, Celest.Mech.Dyn.Astron. 94, 351
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, eps0;
@@ -70,10 +71,12 @@ double iauObl06(double date1, double date2)
 
    return eps0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/obl80.c
+++ b/SOFA/SOFA/src/obl80.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauObl80(double date1, double date2)
 /*
@@ -9,7 +10,7 @@ double iauObl80(double date1, double date2)
 **  Mean obliquity of the ecliptic, IAU 1980 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -49,11 +50,11 @@ double iauObl80(double date1, double date2)
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Expression 3.222-1 (p114).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, eps0;
@@ -70,10 +71,12 @@ double iauObl80(double date1, double date2)
 
    return eps0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/p06e.c
+++ b/SOFA/SOFA/src/p06e.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauP06e(double date1, double date2,
              double *eps0, double *psia, double *oma, double *bpa,
@@ -14,7 +15,7 @@ void iauP06e(double date1, double date2,
 **  Precession angles, IAU 2006, equinox based.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical models.
 **
@@ -132,11 +133,11 @@ void iauP06e(double date1, double date2,
 **  Called:
 **     iauObl06     mean obliquity, IAU 2006
 **
-**  This revision:  2020 June 2
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t;
@@ -278,12 +279,12 @@ void iauP06e(double date1, double date2,
           (   -0.0000000148 )
           * t) * t) * t) * t) * t * DAS2R;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/p2pv.c
+++ b/SOFA/SOFA/src/p2pv.c
@@ -9,7 +9,7 @@ void iauP2pv(double p[3], double pv[2][3])
 **  Extend a p-vector to a pv-vector by appending a zero velocity.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -23,22 +23,22 @@ void iauP2pv(double p[3], double pv[2][3])
 **     iauCp        copy p-vector
 **     iauZp        zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauCp(p, pv[0]);
    iauZp(pv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/p2s.c
+++ b/SOFA/SOFA/src/p2s.c
@@ -9,7 +9,7 @@ void iauP2s(double p[3], double *theta, double *phi, double *r)
 **  P-vector to spherical polar coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -31,22 +31,22 @@ void iauP2s(double p[3], double *theta, double *phi, double *r)
 **     iauC2s       p-vector to spherical
 **     iauPm        modulus of p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauC2s(p, theta, phi);
    *r = iauPm(p);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pap.c
+++ b/SOFA/SOFA/src/pap.c
@@ -9,7 +9,7 @@ double iauPap(double a[3], double b[3])
 **  Position-angle from two p-vectors.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -42,11 +42,11 @@ double iauPap(double a[3], double b[3])
 **     iauPmp       p-vector minus p-vector
 **     iauPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double am, au[3], bm, st, ct, xa, ya, za, eta[3], xi[3], a2b[3], pa;
@@ -91,10 +91,12 @@ double iauPap(double a[3], double b[3])
 
    return pa;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pas.c
+++ b/SOFA/SOFA/src/pas.c
@@ -9,7 +9,7 @@ double iauPas(double al, double ap, double bl, double bp)
 **  Position-angle from spherical coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -31,11 +31,11 @@ double iauPas(double al, double ap, double bl, double bp)
 **
 **  2) Zero is returned if the two points are coincident.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dl, x, y, pa;
@@ -48,10 +48,12 @@ double iauPas(double al, double ap, double bl, double bp)
 
    return pa;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pb06.c
+++ b/SOFA/SOFA/src/pb06.c
@@ -12,7 +12,7 @@ void iauPb06(double date1, double date2,
 **  bias (the offset between ICRS and mean J2000.0) is included.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -68,11 +68,11 @@ void iauPb06(double date1, double date2,
 **     iauPmat06    PB matrix, IAU 2006
 **     iauRz        rotate around Z-axis
 **
-**  This revision:  2020 May 27
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double r[3][3], y, x;
@@ -102,10 +102,12 @@ void iauPb06(double date1, double date2,
    x = r[1][1];
    *bzeta = ( x != 0.0 || y != 0.0 ) ? - atan2(y,x) : 0.0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pdp.c
+++ b/SOFA/SOFA/src/pdp.c
@@ -9,7 +9,7 @@ double iauPdp(double a[3], double b[3])
 **  p-vector inner (=scalar=dot) product.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -20,11 +20,11 @@ double iauPdp(double a[3], double b[3])
 **  Returned (function value):
 **            double        a . b
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double w;
@@ -36,10 +36,12 @@ double iauPdp(double a[3], double b[3])
 
    return w;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pfw06.c
+++ b/SOFA/SOFA/src/pfw06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPfw06(double date1, double date2,
               double *gamb, double *phib, double *psib, double *epsa)
@@ -10,7 +11,7 @@ void iauPfw06(double date1, double date2,
 **  Precession angles, IAU 2006 (Fukushima-Williams 4-angle formulation).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -78,11 +79,11 @@ void iauPfw06(double date1, double date2,
 **  Called:
 **     iauObl06     mean obliquity, IAU 2006
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t;
@@ -115,12 +116,12 @@ void iauPfw06(double date1, double date2,
            * t) * t) * t) * t) * t) * DAS2R;
    *epsa =  iauObl06(date1, date2);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/plan94.c
+++ b/SOFA/SOFA/src/plan94.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauPlan94(double date1, double date2, int np, double pv[2][3])
 /*
@@ -6,14 +7,16 @@ int iauPlan94(double date1, double date2, int np, double pv[2][3])
 **   i a u P l a n 9 4
 **  - - - - - - - - - -
 **
+**  Approximate heliocentric position and velocity of a nominated
+**  planet:  Mercury, Venus, EMB, Mars, Jupiter, Saturn, Uranus or
+**  Neptune (but not the Earth itself).
+**
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
-**  Approximate heliocentric position and velocity of a nominated major
-**  planet:  Mercury, Venus, EMB, Mars, Jupiter, Saturn, Uranus or
-**  Neptune (but not the Earth itself).
+**  n.b. Not IAU-endorsed and without canonical status.
 **
 **  Given:
 **     date1  double       TDB date part A (Note 1)
@@ -56,9 +59,9 @@ int iauPlan94(double date1, double date2, int np, double pv[2][3])
 **  2) If an np value outside the range 1-8 is supplied, an error status
 **     (function value -1) is returned and the pv vector set to zeroes.
 **
-**  3) For np=3 the result is for the Earth-Moon Barycenter.  To obtain
-**     the heliocentric position and velocity of the Earth, use instead
-**     the SOFA function iauEpv00.
+**  3) For np=3 the result is for the Earth-Moon barycenter (EMB).  To
+**     obtain the heliocentric position and velocity of the Earth, use
+**     instead the SOFA function iauEpv00.
 **
 **  4) On successful return, the array pv contains the following:
 **
@@ -109,8 +112,8 @@ int iauPlan94(double date1, double date2, int np, double pv[2][3])
 **        Neptune         158000              14.4
 **
 **     Comparisons against DE200 over the interval 1800-2100 gave the
-**     following maximum absolute differences.  (The results using
-**     DE406 were essentially the same.)
+**     following maximum absolute differences (the results using
+**     DE406 were essentially the same):
 **
 **                   L (arcsec)   B (arcsec)     R (km)   Rdot (m/s)
 **
@@ -156,17 +159,17 @@ int iauPlan94(double date1, double date2, int np, double pv[2][3])
 **     which in turn takes precedence over the remote date warning.
 **
 **  Called:
-**     iauAnp       normalize angle into range 0 to 2pi
+**     iauAnpm      normalize angle into range +/- pi
 **
 **  Reference:  Simon, J.L, Bretagnon, P., Chapront, J.,
 **              Chapront-Touze, M., Francou, G., and Laskar, J.,
 **              Astron.Astrophys., 282, 663 (1994).
 **
-**  This revision:  2019 June 23
+**  This revision:  2023 May 5
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Gaussian constant */
@@ -466,10 +469,12 @@ int iauPlan94(double date1, double date2, int np, double pv[2][3])
 /* Return the status. */
    return jstat;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pm.c
+++ b/SOFA/SOFA/src/pm.c
@@ -9,7 +9,7 @@ double iauPm(double p[3])
 **  Modulus of p-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -19,19 +19,21 @@ double iauPm(double p[3])
 **  Returned (function value):
 **            double        modulus
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    return sqrt( p[0]*p[0] + p[1]*p[1] + p[2]*p[2] );
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmat00.c
+++ b/SOFA/SOFA/src/pmat00.c
@@ -10,7 +10,7 @@ void iauPmat00(double date1, double date2, double rbp[3][3])
 **  date, IAU 2000 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -55,11 +55,11 @@ void iauPmat00(double date1, double date2, double rbp[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rb[3][3], rp[3][3];
@@ -68,12 +68,12 @@ void iauPmat00(double date1, double date2, double rbp[3][3])
 /* Obtain the required matrix (discarding others). */
    iauBp00(date1, date2, rb, rp, rbp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmat06.c
+++ b/SOFA/SOFA/src/pmat06.c
@@ -10,7 +10,7 @@ void iauPmat06(double date1, double date2, double rbp[3][3])
 **  date, IAU 2006 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -54,13 +54,17 @@ void iauPmat06(double date1, double date2, double rbp[3][3])
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855
 **
+**     IAU: Trans. International Astronomical Union, Vol. XXIVB;  Proc.
+**     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
+**     (2000)
+**
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gamb, phib, psib, epsa;
@@ -72,12 +76,12 @@ void iauPmat06(double date1, double date2, double rbp[3][3])
 /* Form the matrix. */
    iauFw2m(gamb, phib, psib, epsa, rbp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmat76.c
+++ b/SOFA/SOFA/src/pmat76.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPmat76(double date1, double date2, double rmatp[3][3])
 /*
@@ -9,7 +10,7 @@ void iauPmat76(double date1, double date2, double rmatp[3][3])
 **  Precession matrix from J2000.0 to a specified date, IAU 1976 model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -71,11 +72,11 @@ void iauPmat76(double date1, double date2, double rmatp[3][3])
 **
 **     Kaplan,G.H., 1981. USNO circular no. 163, pA2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double zeta, z, theta, wmat[3][3];
@@ -91,12 +92,12 @@ void iauPmat76(double date1, double date2, double rmatp[3][3])
    iauRz( -z, wmat);
    iauCr( wmat, rmatp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmp.c
+++ b/SOFA/SOFA/src/pmp.c
@@ -9,7 +9,7 @@ void iauPmp(double a[3], double b[3], double amb[3])
 **  P-vector subtraction.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -24,23 +24,23 @@ void iauPmp(double a[3], double b[3], double amb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    amb[0] = a[0] - b[0];
    amb[1] = a[1] - b[1];
    amb[2] = a[2] - b[2];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmpx.c
+++ b/SOFA/SOFA/src/pmpx.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPmpx(double rc, double dc, double pr, double pd,
              double px, double rv, double pmt, double pob[3],
@@ -17,7 +18,7 @@ void iauPmpx(double rc, double dc, double pr, double pd,
 **
 **  Given:
 **     rc,dc  double     ICRS RA,Dec at catalog epoch (radians)
-**     pr     double     RA proper motion (radians/year; Note 1)
+**     pr     double     RA proper motion (radians/year, Note 1)
 **     pd     double     Dec proper motion (radians/year)
 **     px     double     parallax (arcsec)
 **     rv     double     radial velocity (km/s, +ve if receding)
@@ -51,11 +52,11 @@ void iauPmpx(double rc, double dc, double pr, double pd,
 **     iauPdp       scalar product of two p-vectors
 **     iauPn        decompose p-vector into modulus and direction
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 April 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Km/s to au/year */
@@ -98,8 +99,8 @@ void iauPmpx(double rc, double dc, double pr, double pd,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pmsafe.c
+++ b/SOFA/SOFA/src/pmsafe.c
@@ -19,37 +19,37 @@ int iauPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 **  Status:  support function.
 **
 **  Given:
-**     ra1    double      right ascension (radians), before
-**     dec1   double      declination (radians), before
-**     pmr1   double      RA proper motion (radians/year), before
-**     pmd1   double      Dec proper motion (radians/year), before
-**     px1    double      parallax (arcseconds), before
-**     rv1    double      radial velocity (km/s, +ve = receding), before
-**     ep1a   double      "before" epoch, part A (Note 1)
-**     ep1b   double      "before" epoch, part B (Note 1)
-**     ep2a   double      "after" epoch, part A (Note 1)
-**     ep2b   double      "after" epoch, part B (Note 1)
+**     ra1    double     right ascension (radians), before
+**     dec1   double     declination (radians), before
+**     pmr1   double     RA proper motion (radians/year), before
+**     pmd1   double     Dec proper motion (radians/year), before
+**     px1    double     parallax (arcseconds), before
+**     rv1    double     radial velocity (km/s, +ve = receding), before
+**     ep1a   double     "before" epoch, part A (Note 1)
+**     ep1b   double     "before" epoch, part B (Note 1)
+**     ep2a   double     "after" epoch, part A (Note 1)
+**     ep2b   double     "after" epoch, part B (Note 1)
 **
 **  Returned:
-**     ra2    double      right ascension (radians), after
-**     dec2   double      declination (radians), after
-**     pmr2   double      RA proper motion (radians/year), after
-**     pmd2   double      Dec proper motion (radians/year), after
-**     px2    double      parallax (arcseconds), after
-**     rv2    double      radial velocity (km/s, +ve = receding), after
+**     ra2    double     right ascension (radians), after
+**     dec2   double     declination (radians), after
+**     pmr2   double     RA proper motion (radians/year), after
+**     pmd2   double     Dec proper motion (radians/year), after
+**     px2    double     parallax (arcseconds), after
+**     rv2    double     radial velocity (km/s, +ve = receding), after
 **
 **  Returned (function value):
-**            int         status:
-**                         -1 = system error (should not occur)
-**                          0 = no warnings or errors
-**                          1 = distance overridden (Note 6)
-**                          2 = excessive velocity (Note 7)
-**                          4 = solution didn't converge (Note 8)
-**                       else = binary logical OR of the above warnings
+**            int        status:
+**                          -1 = system error (should not occur)
+**                           0 = no warnings or errors
+**                           1 = distance overridden (Note 6)
+**                           2 = excessive velocity (Note 7)
+**                           4 = solution didn't converge (Note 8)
+**                        else = binary logical OR of the above warnings
 **
 **  Notes:
 **
-**  1) The starting and ending TDB epochs ep1a+ep1b and ep2a+ep2b are
+**  1) The starting and ending TDB dates ep1a+ep1b and ep2a+ep2b are
 **     Julian Dates, apportioned in any convenient way between the two
 **     parts (A and B).  For example, JD(TDB)=2450123.7 could be
 **     expressed in any of these ways, among others:
@@ -110,11 +110,11 @@ int iauPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 **     iauSeps      angle between two points
 **     iauStarpm    update star catalog data for space motion
 **
-**  This revision:   2014 July 1
+**  This revision:   2023 April 7
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -151,8 +151,8 @@ int iauPmsafe(double ra1, double dec1, double pmr1, double pmd1,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn.c
+++ b/SOFA/SOFA/src/pn.c
@@ -9,7 +9,7 @@ void iauPn(double p[3], double *r, double u[3])
 **  Convert a p-vector into modulus and unit vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -33,11 +33,11 @@ void iauPn(double p[3], double *r, double u[3])
 **     iauZp        zero p-vector
 **     iauSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double w;
@@ -59,12 +59,12 @@ void iauPn(double p[3], double *r, double u[3])
 /* Return the modulus. */
    *r = w;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn00.c
+++ b/SOFA/SOFA/src/pn00.c
@@ -14,7 +14,7 @@ void iauPn00(double date1, double date2, double dpsi, double deps,
 **  use indirectly.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -100,11 +100,11 @@ void iauPn00(double date1, double date2, double dpsi, double deps,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsipr, depspr, rbpw[3][3], rnw[3][3];
@@ -127,12 +127,12 @@ void iauPn00(double date1, double date2, double dpsi, double deps,
 /* Bias-precession-nutation matrix (classical). */
    iauRxr(rnw, rbpw, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn00a.c
+++ b/SOFA/SOFA/src/pn00a.c
@@ -14,7 +14,7 @@ void iauPn00a(double date1, double date2,
 **  use indirectly.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -54,7 +54,7 @@ void iauPn00a(double date1, double date2,
 **  2)  The nutation components (luni-solar + planetary, IAU 2000A) in
 **      longitude and obliquity are in radians and with respect to the
 **      equinox and ecliptic of date.  Free core nutation is omitted;
-**      for the utmost accuracy, use the iauPn00  function, where the
+**      for the utmost accuracy, use the iauPn00 function, where the
 **      nutation components are caller-specified.  For faster but
 **      slightly less accurate results, use the iauPn00b function.
 **
@@ -84,7 +84,7 @@ void iauPn00a(double date1, double date2,
 **      i.e. rbpn[2][0-2].
 **
 **  10) It is permissible to re-use the same array in the returned
-**      arguments.  The arrays are filled in the order given.
+**      arguments.  The arrays are filled in the stated order.
 **
 **  Called:
 **     iauNut00a    nutation, IAU 2000A
@@ -100,11 +100,11 @@ void iauPn00a(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 November 14
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Nutation. */
@@ -113,12 +113,12 @@ void iauPn00a(double date1, double date2,
 /* Remaining results. */
    iauPn00(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn00b.c
+++ b/SOFA/SOFA/src/pn00b.c
@@ -14,7 +14,7 @@ void iauPn00b(double date1, double date2,
 **  use indirectly.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -55,7 +55,7 @@ void iauPn00b(double date1, double date2,
 **      longitude and obliquity are in radians and with respect to the
 **      equinox and ecliptic of date.  For more accurate results, but
 **      at the cost of increased computation, use the iauPn00a function.
-**      For the utmost accuracy, use the iauPn00  function, where the
+**      For the utmost accuracy, use the iauPn00 function, where the
 **      nutation components are caller-specified.
 **
 **  3)  The mean obliquity is consistent with the IAU 2000 precession.
@@ -100,11 +100,11 @@ void iauPn00b(double date1, double date2,
 **     n.b. The celestial ephemeris origin (CEO) was renamed "celestial
 **          intermediate origin" (CIO) by IAU 2006 Resolution 2.
 **
-**  This revision:  2013 November 13
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Nutation. */
@@ -113,12 +113,12 @@ void iauPn00b(double date1, double date2,
 /* Remaining results. */
    iauPn00(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn06.c
+++ b/SOFA/SOFA/src/pn06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPn06(double date1, double date2, double dpsi, double deps,
              double *epsa,
@@ -14,7 +15,7 @@ void iauPn06(double date1, double date2, double dpsi, double deps,
 **  indirectly.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -28,7 +29,7 @@ void iauPn06(double date1, double date2, double dpsi, double deps,
 **     rp           double[3][3]    precession matrix (Note 5)
 **     rbp          double[3][3]    bias-precession matrix (Note 6)
 **     rn           double[3][3]    nutation matrix (Note 7)
-**     rbpn         double[3][3]    GCRS-to-true matrix (Note 8)
+**     rbpn         double[3][3]    GCRS-to-true matrix (Notes 8,9)
 **
 **  Notes:
 **
@@ -98,11 +99,11 @@ void iauPn06(double date1, double date2, double dpsi, double deps,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 November 14
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gamb, phib, psib, eps, r1[3][3], r2[3][3], rt[3][3];
@@ -137,12 +138,12 @@ void iauPn06(double date1, double date2, double dpsi, double deps,
 /* Obliquity, mean of date. */
    *epsa = eps;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pn06a.c
+++ b/SOFA/SOFA/src/pn06a.c
@@ -14,7 +14,7 @@ void iauPn06a(double date1, double date2,
 **  indirectly.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -90,11 +90,11 @@ void iauPn06a(double date1, double date2,
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855
 **
-**  This revision:  2013 November 13
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Nutation. */
@@ -103,12 +103,12 @@ void iauPn06a(double date1, double date2,
 /* Remaining results. */
    iauPn06(date1, date2, *dpsi, *deps, epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pnm00a.c
+++ b/SOFA/SOFA/src/pnm00a.c
@@ -7,25 +7,25 @@ void iauPnm00a(double date1, double date2, double rbpn[3][3])
 **  - - - - - - - - - -
 **
 **  Form the matrix of precession-nutation for a given date (including
-**  frame bias), equinox-based, IAU 2000A model.
+**  frame bias), equinox based, IAU 2000A model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
-**     date1,date2  double     TT as a 2-part Julian Date (Note 1)
+**     date1,date2 double       TT as a 2-part Julian Date (Note 1)
 **
 **  Returned:
-**     rbpn         double[3][3]    classical NPB matrix (Note 2)
+**     rbpn        double[3][3] bias-precession-nutation matrix (Note 2)
 **
 **  Notes:
 **
 **  1) The TT date date1+date2 is a Julian Date, apportioned in any
 **     convenient way between the two arguments.  For example,
-**     JD(TT)=2450123.7 could be expressed in any of these ways,
-**     among others:
+**     JD(TT)=2450123.7 could be expressed in any of these ways, among
+**     others:
 **
 **            date1          date2
 **
@@ -46,7 +46,7 @@ void iauPnm00a(double date1, double date2, double rbpn[3][3])
 **     of date date1+date2 and the p-vector V(GCRS) is with respect to
 **     the Geocentric Celestial Reference System (IAU, 2000).
 **
-**  3) A faster, but slightly less accurate result (about 1 mas), can be
+**  3) A faster, but slightly less accurate, result (about 1 mas) can be
 **     obtained by using instead the iauPnm00b function.
 **
 **  Called:
@@ -58,11 +58,11 @@ void iauPnm00a(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3];
@@ -71,12 +71,12 @@ void iauPnm00a(double date1, double date2, double rbpn[3][3])
 /* Obtain the required matrix (discarding other results). */
    iauPn00a(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pnm00b.c
+++ b/SOFA/SOFA/src/pnm00b.c
@@ -10,7 +10,7 @@ void iauPnm00b(double date1, double date2, double rbpn[3][3])
 **  frame bias), equinox-based, IAU 2000B model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -24,8 +24,8 @@ void iauPnm00b(double date1, double date2, double rbpn[3][3])
 **
 **  1) The TT date date1+date2 is a Julian Date, apportioned in any
 **     convenient way between the two arguments.  For example,
-**     JD(TT)=2450123.7 could be expressed in any of these ways,
-**     among others:
+**     JD(TT)=2450123.7 could be expressed in any of these ways, among
+**     others:
 **
 **            date1          date2
 **
@@ -58,11 +58,11 @@ void iauPnm00b(double date1, double date2, double rbpn[3][3])
 **     24th General Assembly, Manchester, UK.  Resolutions B1.3, B1.6.
 **     (2000)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dpsi, deps, epsa, rb[3][3], rp[3][3], rbp[3][3], rn[3][3];
@@ -71,12 +71,12 @@ void iauPnm00b(double date1, double date2, double rbpn[3][3])
 /* Obtain the required matrix (discarding other results). */
    iauPn00b(date1, date2, &dpsi, &deps, &epsa, rb, rp, rbp, rn, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pnm06a.c
+++ b/SOFA/SOFA/src/pnm06a.c
@@ -1,16 +1,17 @@
 #include "sofa.h"
 
-void iauPnm06a(double date1, double date2, double rnpb[3][3])
+void iauPnm06a(double date1, double date2, double rbpn[3][3])
 /*
 **  - - - - - - - - - -
 **   i a u P n m 0 6 a
 **  - - - - - - - - - -
 **
 **  Form the matrix of precession-nutation for a given date (including
-**  frame bias), IAU 2006 precession and IAU 2000A nutation models.
+**  frame bias), equinox based, IAU 2006 precession and IAU 2000A
+**  nutation models.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -18,14 +19,14 @@ void iauPnm06a(double date1, double date2, double rnpb[3][3])
 **     date1,date2 double       TT as a 2-part Julian Date (Note 1)
 **
 **  Returned:
-**     rnpb        double[3][3] bias-precession-nutation matrix (Note 2)
+**     rbpn        double[3][3] bias-precession-nutation matrix (Note 2)
 **
 **  Notes:
 **
 **  1) The TT date date1+date2 is a Julian Date, apportioned in any
 **     convenient way between the two arguments.  For example,
-**     JD(TT)=2450123.7 could be expressed in any of these ways,
-**     among others:
+**     JD(TT)=2450123.7 could be expressed in any of these ways, among
+**     others:
 **
 **            date1          date2
 **
@@ -41,7 +42,7 @@ void iauPnm06a(double date1, double date2, double rnpb[3][3])
 **     optimum resolution.  The MJD method and the date & time methods
 **     are both good compromises between resolution and convenience.
 **
-**  2) The matrix operates in the sense V(date) = rnpb * V(GCRS), where
+**  2) The matrix operates in the sense V(date) = rbpn * V(GCRS), where
 **     the p-vector V(date) is with respect to the true equatorial triad
 **     of date date1+date2 and the p-vector V(GCRS) is with respect to
 **     the Geocentric Celestial Reference System (IAU, 2000).
@@ -55,11 +56,11 @@ void iauPnm06a(double date1, double date2, double rnpb[3][3])
 **
 **     Capitaine, N. & Wallace, P.T., 2006, Astron.Astrophys. 450, 855.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double gamb, phib, psib, epsa, dp, de;
@@ -72,14 +73,14 @@ void iauPnm06a(double date1, double date2, double rnpb[3][3])
    iauNut06a(date1, date2, &dp, &de);
 
 /* Equinox based nutation x precession x bias matrix. */
-   iauFw2m(gamb, phib, psib + dp, epsa + de, rnpb);
+   iauFw2m(gamb, phib, psib + dp, epsa + de, rbpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pnm80.c
+++ b/SOFA/SOFA/src/pnm80.c
@@ -10,21 +10,21 @@ void iauPnm80(double date1, double date2, double rmatpn[3][3])
 **  precession model, IAU 1980 nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
 **  Given:
-**     date1,date2    double         TDB date (Note 1)
+**     date1,date2 double       TT as a 2-part Julian Date (Note 1)
 **
 **  Returned:
 **     rmatpn         double[3][3]   combined precession/nutation matrix
 **
 **  Notes:
 **
-**  1) The TDB date date1+date2 is a Julian Date, apportioned in any
+**  1) The TT date date1+date2 is a Julian Date, apportioned in any
 **     convenient way between the two arguments.  For example,
-**     JD(TDB)=2450123.7 could be expressed in any of these ways,
+**     JD(TT)=2450123.7 could be expressed in any of these ways,
 **     among others:
 **
 **            date1          date2
@@ -57,11 +57,11 @@ void iauPnm80(double date1, double date2, double rmatpn[3][3])
 **     P. Kenneth Seidelmann (ed), University Science Books (1992),
 **     Section 3.3 (p145).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rmatp[3][3], rmatn[3][3];
@@ -76,12 +76,12 @@ void iauPnm80(double date1, double date2, double rmatpn[3][3])
 /* Combine the matrices:  PN = N x P. */
    iauRxr(rmatn, rmatp, rmatpn);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pom00.c
+++ b/SOFA/SOFA/src/pom00.c
@@ -9,7 +9,7 @@ void iauPom00(double xp, double yp, double sp, double rpom[3][3])
 **  Form the matrix of polar motion for a given date, IAU 2000.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -25,7 +25,7 @@ void iauPom00(double xp, double yp, double sp, double rpom[3][3])
 **  1) The arguments xp and yp are the coordinates (in radians) of the
 **     Celestial Intermediate Pole with respect to the International
 **     Terrestrial Reference System (see IERS Conventions 2003),
-**     measured along the meridians to 0 and 90 deg west respectively.
+**     measured along the meridians 0 and 90 deg west respectively.
 **
 **  2) The argument sp is the TIO locator s', in radians, which
 **     positions the Terrestrial Intermediate Origin on the equator.  It
@@ -51,11 +51,11 @@ void iauPom00(double xp, double yp, double sp, double rpom[3][3])
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -65,12 +65,12 @@ void iauPom00(double xp, double yp, double sp, double rpom[3][3])
    iauRy(-xp, rpom);
    iauRx(-yp, rpom);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ppp.c
+++ b/SOFA/SOFA/src/ppp.c
@@ -9,7 +9,7 @@ void iauPpp(double a[3], double b[3], double apb[3])
 **  P-vector addition.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -24,23 +24,23 @@ void iauPpp(double a[3], double b[3], double apb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    apb[0] = a[0] + b[0];
    apb[1] = a[1] + b[1];
    apb[2] = a[2] + b[2];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ppsp.c
+++ b/SOFA/SOFA/src/ppsp.c
@@ -9,7 +9,7 @@ void iauPpsp(double a[3], double s, double b[3], double apsb[3])
 **  P-vector plus scaled p-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -28,11 +28,11 @@ void iauPpsp(double a[3], double s, double b[3], double apsb[3])
 **     iauSxp       multiply p-vector by scalar
 **     iauPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double sb[3];
@@ -44,12 +44,12 @@ void iauPpsp(double a[3], double s, double b[3], double apsb[3])
 /* a + s*b. */
    iauPpp(a, sb, apsb);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pr00.c
+++ b/SOFA/SOFA/src/pr00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPr00(double date1, double date2, double *dpsipr, double *depspr)
 /*
@@ -10,7 +11,7 @@ void iauPr00(double date1, double date2, double *dpsipr, double *depspr)
 **  (part of MHB2000).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -71,11 +72,11 @@ void iauPr00(double date1, double date2, double *dpsipr, double *depspr)
 **     Wallace, P.T., "Software for Implementing the IAU 2000
 **     Resolutions", in IERS Workshop 5.1 (2002).
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t;
@@ -92,12 +93,12 @@ void iauPr00(double date1, double date2, double *dpsipr, double *depspr)
    *dpsipr = PRECOR * t;
    *depspr = OBLCOR * t;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/prec76.c
+++ b/SOFA/SOFA/src/prec76.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPrec76(double date01, double date02, double date11, double date12,
                double *zeta, double *z, double *theta)
@@ -14,7 +15,7 @@ void iauPrec76(double date01, double date02, double date11, double date12,
 **  FK5 catalog).
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -71,11 +72,11 @@ void iauPrec76(double date01, double date02, double date11, double date12,
 **     Lieske, J.H., 1979, Astron.Astrophys. 73, 282, equations
 **     (6) & (7), p283.
 **
-**  This revision:  2013 November 19
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t0, t, tas2r, w;
@@ -98,12 +99,12 @@ void iauPrec76(double date01, double date02, double date11, double date12,
    *theta = ((2004.3109 + (-0.85330 - 0.000217 * t0) * t0)
           + ((-0.42665 - 0.000217 * t0) - 0.041833 * t) * t) * tas2r;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pv2p.c
+++ b/SOFA/SOFA/src/pv2p.c
@@ -9,7 +9,7 @@ void iauPv2p(double pv[2][3], double p[3])
 **  Discard velocity component of a pv-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -22,21 +22,21 @@ void iauPv2p(double pv[2][3], double p[3])
 **  Called:
 **     iauCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauCp(pv[0], p);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pv2s.c
+++ b/SOFA/SOFA/src/pv2s.c
@@ -11,7 +11,7 @@ void iauPv2s(double pv[2][3],
 **  Convert position/velocity from Cartesian to spherical coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -39,11 +39,11 @@ void iauPv2s(double pv[2][3],
 **  2) If the position is a pole, theta, td and pd are indeterminate.
 **     In such cases zeroes are returned for all three.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, xd, yd, zd, rxy2, rxy, r2, rtrue, rw, xyp;
@@ -94,12 +94,12 @@ void iauPv2s(double pv[2][3],
    *r = rtrue;
    *rd = (rw != 0.0) ? (xyp + z*zd) / rw : 0.0;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvdpv.c
+++ b/SOFA/SOFA/src/pvdpv.c
@@ -9,7 +9,7 @@ void iauPvdpv(double a[2][3], double b[2][3], double adb[2])
 **  Inner (=scalar=dot) product of two pv-vectors.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -30,11 +30,11 @@ void iauPvdpv(double a[2][3], double b[2][3], double adb[2])
 **  Called:
 **     iauPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double adbd, addb;
@@ -52,12 +52,12 @@ void iauPvdpv(double a[2][3], double b[2][3], double adb[2])
 /* Velocity part of result. */
    adb[1] = adbd + addb;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvm.c
+++ b/SOFA/SOFA/src/pvm.c
@@ -9,7 +9,7 @@ void iauPvm(double pv[2][3], double *r, double *s)
 **  Modulus of pv-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -23,11 +23,11 @@ void iauPvm(double pv[2][3], double *r, double *s)
 **  Called:
 **     iauPm        modulus of p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Distance. */
@@ -36,12 +36,12 @@ void iauPvm(double pv[2][3], double *r, double *s)
 /* Speed. */
    *s = iauPm(pv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvmpv.c
+++ b/SOFA/SOFA/src/pvmpv.c
@@ -9,7 +9,7 @@ void iauPvmpv(double a[2][3], double b[2][3], double amb[2][3])
 **  Subtract one pv-vector from another.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,22 +27,22 @@ void iauPvmpv(double a[2][3], double b[2][3], double amb[2][3])
 **  Called:
 **     iauPmp       p-vector minus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauPmp(a[0], b[0], amb[0]);
    iauPmp(a[1], b[1], amb[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvppv.c
+++ b/SOFA/SOFA/src/pvppv.c
@@ -9,7 +9,7 @@ void iauPvppv(double a[2][3], double b[2][3], double apb[2][3])
 **  Add one pv-vector to another.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,22 +27,22 @@ void iauPvppv(double a[2][3], double b[2][3], double apb[2][3])
 **  Called:
 **     iauPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauPpp(a[0], b[0], apb[0]);
    iauPpp(a[1], b[1], apb[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvstar.c
+++ b/SOFA/SOFA/src/pvstar.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauPvstar(double pv[2][3], double *ra, double *dec,
               double *pmr, double *pmd, double *px, double *rv)
@@ -10,7 +11,7 @@ int iauPvstar(double pv[2][3], double *ra, double *dec,
 **  Convert star position+velocity vector to catalog coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -98,21 +99,21 @@ int iauPvstar(double pv[2][3], double *ra, double *dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  This revision:  2017 March 16
+**  This revision:  2023 May 4
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
-   double r, x[3], vr, ur[3], vt, ut[3], bett, betr, d, w, del,
+   double r, pu[3], vr, ur[3], vt, ut[3], bett, betr, d, w, del,
           usr[3], ust[3], a, rad, decd, rd;
 
 
 /* Isolate the radial component of the velocity (au/day, inertial). */
-   iauPn(pv[0], &r, x);
-   vr = iauPdp(x, pv[1]);
-   iauSxp(vr, x, ur);
+   iauPn(pv[0], &r, pu);
+   vr = iauPdp(pu, pv[1]);
+   iauSxp(vr, pu, ur);
 
 /* Isolate the transverse component of the velocity (au/day, inertial). */
    iauPmp(pv[1], ur, ut);
@@ -122,21 +123,19 @@ int iauPvstar(double pv[2][3], double *ra, double *dec,
    bett = vt / DC;
    betr = vr / DC;
 
-/* The inertial-to-observed correction terms. */
+/* The observed-to-inertial correction terms. */
    d = 1.0 + betr;
    w = betr*betr + bett*bett;
    if (d == 0.0 || w > 1.0) return -1;
    del = - w / (sqrt(1.0-w) + 1.0);
 
-/* Apply relativistic correction factor to radial velocity component. */
-   w = (betr != 0) ? (betr - del) / (betr * d) : 1.0;
-   iauSxp(w, ur, usr);
-
-/* Apply relativistic correction factor to tangential velocity */
-/* component.                                                  */
+/* Scale inertial tangential velocity vector into observed (au/d). */
    iauSxp(1.0/d, ut, ust);
 
-/* Combine the two to obtain the observed velocity vector (au/day). */
+/* Compute observed radial velocity vector (au/d). */
+   iauSxp(DC*(betr-del)/d, pu, usr);
+
+/* Combine the two to obtain the observed velocity vector. */
    iauPpp(usr, ust, pv[1]);
 
 /* Cartesian to spherical. */
@@ -156,13 +155,15 @@ int iauPvstar(double pv[2][3], double *ra, double *dec,
 /* Return radial velocity in km/s. */
    *rv = 1e-3 * rd * DAU / DAYSEC;
 
-/* OK status. */
+/* Success. */
    return 0;
+
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvtob.c
+++ b/SOFA/SOFA/src/pvtob.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauPvtob(double elong, double phi, double hm,
               double xp, double yp, double sp, double theta,
@@ -66,11 +67,11 @@ void iauPvtob(double elong, double phi, double hm,
 **     iauPom00     polar motion matrix
 **     iauTrxp      product of transpose of r-matrix and p-vector
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Earth rotation rate in radians per UT1 second */
@@ -107,8 +108,8 @@ void iauPvtob(double elong, double phi, double hm,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvu.c
+++ b/SOFA/SOFA/src/pvu.c
@@ -9,7 +9,7 @@ void iauPvu(double dt, double pv[2][3], double upv[2][3])
 **  Update a pv-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -33,22 +33,22 @@ void iauPvu(double dt, double pv[2][3], double upv[2][3])
 **     iauPpsp      p-vector plus scaled p-vector
 **     iauCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauPpsp(pv[0], dt, pv[1], upv[0]);
    iauCp(pv[1], upv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvup.c
+++ b/SOFA/SOFA/src/pvup.c
@@ -9,7 +9,7 @@ void iauPvup(double dt, double pv[2][3], double p[3])
 **  Update a pv-vector, discarding the velocity component.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,23 +27,23 @@ void iauPvup(double dt, double pv[2][3], double p[3])
 **
 **  2) The time units of dt must match those of the velocity.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    p[0] = pv[0][0] + dt * pv[1][0];
    p[1] = pv[0][1] + dt * pv[1][1];
    p[2] = pv[0][2] + dt * pv[1][2];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pvxpv.c
+++ b/SOFA/SOFA/src/pvxpv.c
@@ -9,7 +9,7 @@ void iauPvxpv(double a[2][3], double b[2][3], double axb[2][3])
 **  Outer (=vector=cross) product of two pv-vectors.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -35,11 +35,11 @@ void iauPvxpv(double a[2][3], double b[2][3], double axb[2][3])
 **     iauPxp       vector product of two p-vectors
 **     iauPpp       p-vector plus p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double wa[2][3], wb[2][3], axbd[3], adxb[3];
@@ -57,12 +57,12 @@ void iauPvxpv(double a[2][3], double b[2][3], double axb[2][3])
    iauPxp(wa[1], wb[0], adxb);
    iauPpp(axbd, adxb, axb[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/pxp.c
+++ b/SOFA/SOFA/src/pxp.c
@@ -9,7 +9,7 @@ void iauPxp(double a[3], double b[3], double axb[3])
 **  p-vector outer (=vector=cross) product.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -24,11 +24,11 @@ void iauPxp(double a[3], double b[3], double axb[3])
 **     It is permissible to re-use the same array for any of the
 **     arguments.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double xa, ya, za, xb, yb, zb;
@@ -44,12 +44,12 @@ void iauPxp(double a[3], double b[3], double axb[3])
    axb[1] = za*xb - xa*zb;
    axb[2] = xa*yb - ya*xb;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/refco.c
+++ b/SOFA/SOFA/src/refco.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauRefco(double phpa, double tc, double rh, double wl,
               double *refa, double *refb)
@@ -117,6 +118,7 @@ void iauRefco(double phpa, double tc, double rh, double wl,
 **        total pressure, water-vapour pressure and, in the case
 **        of optical/IR, wavelength.  The formulae for the two cases are
 **        developed from Hohenkerk & Sinclair (1985) and Rueger (2002).
+**        The IAG (1999) optical refractivity for dry air is used.
 **
 **     d) The formula for beta, the ratio of the scale height of the
 **        atmosphere to the geocentric distance of the observer, is
@@ -143,6 +145,9 @@ void iauRefco(double phpa, double tc, double rh, double wl,
 **     Hohenkerk, C.Y., & Sinclair, A.T., NAO Technical Note No. 63,
 **     1985.
 **
+**     IAG Resolutions adopted at the XXIIth General Assembly in
+**     Birmingham, 1999, Resolution 3.
+**
 **     Rueger, J.M., "Refractive Index Formulae for Electronic Distance
 **     Measurement with Radio and Millimetre Waves", in Unisurv Report
 **     S-68, School of Surveying and Spatial Information Systems,
@@ -150,11 +155,11 @@ void iauRefco(double phpa, double tc, double rh, double wl,
 **
 **     Stone, Ronald C., P.A.S.P. 108, 1051-1058, 1996.
 **
-**  This revision:   2013 October 9
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int optic;
@@ -207,8 +212,8 @@ void iauRefco(double phpa, double tc, double rh, double wl,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rm2v.c
+++ b/SOFA/SOFA/src/rm2v.c
@@ -9,7 +9,7 @@ void iauRm2v(double r[3][3], double w[3])
 **  Express an r-matrix as an r-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -34,11 +34,11 @@ void iauRm2v(double r[3][3], double w[3])
 **  3) The reference frame rotates clockwise as seen looking along
 **     the rotation vector from the origin.
 **
-**  This revision:  2015 January 30
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, s2, c2, phi, f;
@@ -61,12 +61,12 @@ void iauRm2v(double r[3][3], double w[3])
       w[2] = 0.0;
    }
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rv2m.c
+++ b/SOFA/SOFA/src/rv2m.c
@@ -9,7 +9,7 @@ void iauRv2m(double w[3], double r[3][3])
 **  Form the r-matrix corresponding to a given r-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -26,16 +26,16 @@ void iauRv2m(double w[3], double r[3][3])
 **     supplied to This function has the same direction as the Euler
 **     axis, and its magnitude is the angle in radians.
 **
-**  2) If w is null, the unit matrix is returned.
+**  2) If w is null, the identity matrix is returned.
 **
 **  3) The reference frame rotates clockwise as seen looking along the
 **     rotation vector from the origin.
 **
-**  This revision:  2015 January 30
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, phi, s, c, f;
@@ -68,12 +68,12 @@ void iauRv2m(double w[3], double r[3][3])
    r[2][1] = z*y*f - x*s;
    r[2][2] = z*z*f + c;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rx.c
+++ b/SOFA/SOFA/src/rx.c
@@ -9,7 +9,7 @@ void iauRx(double phi, double r[3][3])
 **  Rotate an r-matrix about the x-axis.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -33,11 +33,11 @@ void iauRx(double phi, double r[3][3])
 **         (                               )
 **         (  0   - sin(phi)   + cos(phi)  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double s, c, a10, a11, a12, a20, a21, a22;
@@ -60,12 +60,12 @@ void iauRx(double phi, double r[3][3])
    r[2][1] = a21;
    r[2][2] = a22;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rxp.c
+++ b/SOFA/SOFA/src/rxp.c
@@ -9,7 +9,7 @@ void iauRxp(double r[3][3], double p[3], double rp[3])
 **  Multiply a p-vector by an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -26,11 +26,11 @@ void iauRxp(double r[3][3], double p[3], double rp[3])
 **  Called:
 **     iauCp        copy p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double w, wrp[3];
@@ -49,12 +49,12 @@ void iauRxp(double r[3][3], double p[3], double rp[3])
 /* Return the result. */
    iauCp(wrp, rp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rxpv.c
+++ b/SOFA/SOFA/src/rxpv.c
@@ -9,7 +9,7 @@ void iauRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
 **  Multiply a pv-vector by an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -20,28 +20,34 @@ void iauRxpv(double r[3][3], double pv[2][3], double rpv[2][3])
 **  Returned:
 **     rpv      double[2][3]    r * pv
 **
-**  Note:
-**     It is permissible for pv and rpv to be the same array.
+**  Notes:
+**
+**  1) The algorithm is for the simple case where the r-matrix r is not
+**     a function of time.  The case where r is a function of time leads
+**     to an additional velocity component equal to the product of the
+**     derivative of r and the position vector.
+**
+**  2) It is permissible for pv and rpv to be the same array.
 **
 **  Called:
 **     iauRxp       product of r-matrix and p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauRxp(r, pv[0], rpv[0]);
    iauRxp(r, pv[1], rpv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rxr.c
+++ b/SOFA/SOFA/src/rxr.c
@@ -9,7 +9,7 @@ void iauRxr(double a[3][3], double b[3][3], double atb[3][3])
 **  Multiply two r-matrices.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,11 +27,11 @@ void iauRxr(double a[3][3], double b[3][3], double atb[3][3])
 **  Called:
 **     iauCr        copy r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int i, j, k;
@@ -49,12 +49,12 @@ void iauRxr(double a[3][3], double b[3][3], double atb[3][3])
    }
    iauCr(wm, atb);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ry.c
+++ b/SOFA/SOFA/src/ry.c
@@ -9,7 +9,7 @@ void iauRy(double theta, double r[3][3])
 **  Rotate an r-matrix about the y-axis.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -33,11 +33,11 @@ void iauRy(double theta, double r[3][3])
 **         (                                        )
 **         (  + sin(theta)     0      + cos(theta)  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double s, c, a00, a01, a02, a20, a21, a22;
@@ -60,12 +60,12 @@ void iauRy(double theta, double r[3][3])
    r[2][1] = a21;
    r[2][2] = a22;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/rz.c
+++ b/SOFA/SOFA/src/rz.c
@@ -9,7 +9,7 @@ void iauRz(double psi, double r[3][3])
 **  Rotate an r-matrix about the z-axis.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -33,11 +33,11 @@ void iauRz(double psi, double r[3][3])
 **         (                                 )
 **         (       0            0         1  )
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double s, c, a00, a01, a02, a10, a11, a12;
@@ -60,12 +60,12 @@ void iauRz(double psi, double r[3][3])
    r[1][1] = a11;
    r[1][2] = a12;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s00.c
+++ b/SOFA/SOFA/src/s00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauS00(double date1, double date2, double x, double y)
 /*
@@ -11,7 +12,7 @@ double iauS00(double date1, double date2, double x, double y)
 **  coordinates.  Compatible with IAU 2000A precession-nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -81,11 +82,11 @@ double iauS00(double date1, double date2, double x, double y)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Time since J2000.0, in Julian centuries */
@@ -275,43 +276,43 @@ double iauS00(double date1, double date2, double x, double y)
    w5 = sp[5];
 
    for (i = NS0-1; i >= 0; i--) {
-   a = 0.0;
-   for (j = 0; j < 8; j++) {
-       a += (double)s0[i].nfa[j] * fa[j];
-   }
-   w0 += s0[i].s * sin(a) + s0[i].c * cos(a);
+      a = 0.0;
+      for (j = 0; j < 8; j++) {
+          a += (double)s0[i].nfa[j] * fa[j];
+      }
+      w0 += s0[i].s * sin(a) + s0[i].c * cos(a);
    }
 
    for (i = NS1-1; i >= 0; i--) {
-   a = 0.0;
-   for (j = 0; j < 8; j++) {
-       a += (double)s1[i].nfa[j] * fa[j];
-   }
-   w1 += s1[i].s * sin(a) + s1[i].c * cos(a);
+      a = 0.0;
+      for (j = 0; j < 8; j++) {
+          a += (double)s1[i].nfa[j] * fa[j];
+      }
+      w1 += s1[i].s * sin(a) + s1[i].c * cos(a);
    }
 
    for (i = NS2-1; i >= 0; i--) {
-   a = 0.0;
-   for (j = 0; j < 8; j++) {
-       a += (double)s2[i].nfa[j] * fa[j];
-   }
-   w2 += s2[i].s * sin(a) + s2[i].c * cos(a);
+      a = 0.0;
+      for (j = 0; j < 8; j++) {
+          a += (double)s2[i].nfa[j] * fa[j];
+      }
+      w2 += s2[i].s * sin(a) + s2[i].c * cos(a);
    }
 
    for (i = NS3-1; i >= 0; i--) {
-   a = 0.0;
-   for (j = 0; j < 8; j++) {
-       a += (double)s3[i].nfa[j] * fa[j];
-   }
-   w3 += s3[i].s * sin(a) + s3[i].c * cos(a);
+      a = 0.0;
+      for (j = 0; j < 8; j++) {
+          a += (double)s3[i].nfa[j] * fa[j];
+      }
+      w3 += s3[i].s * sin(a) + s3[i].c * cos(a);
    }
 
    for (i = NS4-1; i >= 0; i--) {
-   a = 0.0;
-   for (j = 0; j < 8; j++) {
-       a += (double)s4[i].nfa[j] * fa[j];
-   }
-   w4 += s4[i].s * sin(a) + s4[i].c * cos(a);
+      a = 0.0;
+      for (j = 0; j < 8; j++) {
+          a += (double)s4[i].nfa[j] * fa[j];
+      }
+      w4 += s4[i].s * sin(a) + s4[i].c * cos(a);
    }
 
    s = (w0 +
@@ -323,10 +324,12 @@ double iauS00(double date1, double date2, double x, double y)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s00a.c
+++ b/SOFA/SOFA/src/s00a.c
@@ -11,7 +11,7 @@ double iauS00a(double date1, double date2)
 **  precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -74,11 +74,11 @@ double iauS00a(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3], x, y, s;
@@ -95,10 +95,12 @@ double iauS00a(double date1, double date2)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s00b.c
+++ b/SOFA/SOFA/src/s00b.c
@@ -11,7 +11,7 @@ double iauS00b(double date1, double date2)
 **  precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -74,11 +74,11 @@ double iauS00b(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3], x, y, s;
@@ -95,10 +95,12 @@ double iauS00b(double date1, double date2)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s06.c
+++ b/SOFA/SOFA/src/s06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauS06(double date1, double date2, double x, double y)
 /*
@@ -11,7 +12,7 @@ double iauS06(double date1, double date2, double x, double y)
 **  coordinates.  Compatible with IAU 2006/2000A precession-nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -78,11 +79,11 @@ double iauS06(double date1, double date2, double x, double y)
 **     McCarthy, D.D., Petit, G. (eds.) 2004, IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Time since J2000.0, in Julian centuries */
@@ -320,10 +321,12 @@ double iauS06(double date1, double date2, double x, double y)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s06a.c
+++ b/SOFA/SOFA/src/s06a.c
@@ -11,7 +11,7 @@ double iauS06a(double date1, double date2)
 **  precession and IAU 2000A nutation models.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -76,11 +76,11 @@ double iauS06a(double date1, double date2)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rnpb[3][3], x, y, s;
@@ -97,10 +97,12 @@ double iauS06a(double date1, double date2)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s2c.c
+++ b/SOFA/SOFA/src/s2c.c
@@ -9,7 +9,7 @@ void iauS2c(double theta, double phi, double c[3])
 **  Convert spherical coordinates to Cartesian.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -20,11 +20,11 @@ void iauS2c(double theta, double phi, double c[3])
 **  Returned:
 **     c        double[3]    direction cosines
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double cp;
@@ -35,12 +35,12 @@ void iauS2c(double theta, double phi, double c[3])
    c[1] = sin(theta) * cp;
    c[2] = sin(phi);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s2p.c
+++ b/SOFA/SOFA/src/s2p.c
@@ -9,7 +9,7 @@ void iauS2p(double theta, double phi, double r, double p[3])
 **  Convert spherical polar coordinates to p-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -25,11 +25,11 @@ void iauS2p(double theta, double phi, double r, double p[3])
 **     iauS2c       spherical coordinates to unit vector
 **     iauSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double u[3];
@@ -38,12 +38,12 @@ void iauS2p(double theta, double phi, double r, double p[3])
    iauS2c(theta, phi, u);
    iauSxp(r, u, p);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s2pv.c
+++ b/SOFA/SOFA/src/s2pv.c
@@ -11,7 +11,7 @@ void iauS2pv(double theta, double phi, double r,
 **  Convert position/velocity from spherical to Cartesian coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -26,11 +26,11 @@ void iauS2pv(double theta, double phi, double r,
 **  Returned:
 **     pv       double[2][3]    pv-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double st, ct, sp, cp, rcp, x, y, rpd, w;
@@ -53,12 +53,12 @@ void iauS2pv(double theta, double phi, double r,
    pv[1][1] =  x*td - w*st;
    pv[1][2] = rpd*cp + sp*rd;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/s2xpv.c
+++ b/SOFA/SOFA/src/s2xpv.c
@@ -9,7 +9,7 @@ void iauS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
 **  Multiply a pv-vector by two scalars.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,22 +27,22 @@ void iauS2xpv(double s1, double s2, double pv[2][3], double spv[2][3])
 **  Called:
 **     iauSxp       multiply p-vector by scalar
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauSxp(s1, pv[0], spv[0]);
    iauSxp(s2, pv[1], spv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sepp.c
+++ b/SOFA/SOFA/src/sepp.c
@@ -9,7 +9,7 @@ double iauSepp(double a[3], double b[3])
 **  Angular separation between two p-vectors.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -35,11 +35,11 @@ double iauSepp(double a[3], double b[3])
 **     iauPm        modulus of p-vector
 **     iauPdp       scalar product of two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double axb[3], ss, cs, s;
@@ -57,10 +57,12 @@ double iauSepp(double a[3], double b[3])
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/seps.c
+++ b/SOFA/SOFA/src/seps.c
@@ -9,7 +9,7 @@ double iauSeps(double al, double ap, double bl, double bp)
 **  Angular separation between two sets of spherical coordinates.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -26,11 +26,11 @@ double iauSeps(double al, double ap, double bl, double bp)
 **     iauS2c       spherical coordinates to unit vector
 **     iauSepp      angular separation between two p-vectors
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double ac[3], bc[3], s;
@@ -45,10 +45,12 @@ double iauSeps(double al, double ap, double bl, double bp)
 
    return s;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sofa.h
+++ b/SOFA/SOFA/src/sofa.h
@@ -9,16 +9,15 @@
 **  Prototype function declarations for SOFA library.
 **
 **  This file is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
-**  This revision:   2018 December 5
+**  This revision:   2023 April 16
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 
-#include "sofam.h"
 #include "math.h"
 
 #ifdef __cplusplus
@@ -26,6 +25,35 @@ extern "C" {
 #endif
 
 #define EXPORT __declspec(dllexport)
+
+/* Star-independent astrometry parameters */
+EXPORT typedef struct {
+   double pmt;        /* PM time interval (SSB, Julian years) */
+   double eb[3];      /* SSB to observer (vector, au) */
+   double eh[3];      /* Sun to observer (unit vector) */
+   double em;         /* distance from Sun to observer (au) */
+   double v[3];       /* barycentric observer velocity (vector, c) */
+   double bm1;        /* sqrt(1-|v|^2): reciprocal of Lorenz factor */
+   double bpn[3][3];  /* bias-precession-nutation matrix */
+   double along;      /* longitude + s' + dERA(DUT) (radians) */
+   double phi;        /* geodetic latitude (radians) */
+   double xpl;        /* polar motion xp wrt local meridian (radians) */
+   double ypl;        /* polar motion yp wrt local meridian (radians) */
+   double sphi;       /* sine of geodetic latitude */
+   double cphi;       /* cosine of geodetic latitude */
+   double diurab;     /* magnitude of diurnal aberration vector */
+   double eral;       /* "local" Earth rotation angle (radians) */
+   double refa;       /* refraction constant A (radians) */
+   double refb;       /* refraction constant B (radians) */
+} iauASTROM;
+/* (Vectors eb, eh, em and v are all with respect to BCRS axes.) */
+
+/* Body parameters for light deflection */
+EXPORT typedef struct {
+   double bm;         /* mass of the body (solar masses) */
+   double dl;         /* deflection limiter (radians^2/2) */
+   double pv[2][3];   /* barycentric PV of the body (au, au/day) */
+} iauLDBODY;
 
 /* Astronomy/Calendars */
 EXPORT int iauCal2jd(int iy, int im, int id, double *djm0, double *djm);
@@ -76,6 +104,13 @@ EXPORT int iauApio13(double utc1, double utc2, double dut1,
               double elong, double phi, double hm, double xp, double yp,
               double phpa, double tc, double rh, double wl,
               iauASTROM *astrom);
+EXPORT void iauAtcc13(double rc, double dc,
+               double pr, double pd, double px, double rv,
+               double date1, double date2,
+               double *ra, double *da);
+EXPORT void iauAtccq(double rc, double dc,
+              double pr, double pd, double px, double rv,
+              iauASTROM *astrom, double *ra, double *da);
 EXPORT void iauAtci13(double rc, double dc,
                double pr, double pd, double px, double rv,
                double date1, double date2,
@@ -145,6 +180,7 @@ EXPORT void iauRefco(double phpa, double tc, double rh, double wl,
 /* Astronomy/Ephemerides */
 EXPORT int iauEpv00(double date1, double date2,
              double pvh[2][3], double pvb[2][3]);
+EXPORT void iauMoon98(double date1, double date2, double pv[2][3]);
 EXPORT int iauPlan94(double date1, double date2, int np, double pv[2][3]);
 
 /* Astronomy/FundamentalArgs */
@@ -298,7 +334,6 @@ EXPORT int iauStarpv(double ra, double dec,
               double pv[2][3]);
 
 /* Astronomy/StarCatalogs */
-
 EXPORT void iauFk425(double r1950, double d1950,
               double dr1950, double dd1950,
               double p1950, double v1950,
@@ -499,8 +534,8 @@ EXPORT void iauSxpv(double s, double pv[2][3], double spv[2][3]);
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sofam.h
+++ b/SOFA/SOFA/src/sofam.h
@@ -9,47 +9,18 @@
 **  Macros used by SOFA library.
 **
 **  This file is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Please note that the constants defined below are to be used only in
 **  the context of the SOFA software, and have no other official IAU
 **  status.  In addition, self consistency is not guaranteed.
 **
-**  This revision:   2020 June 16
+**  This revision:   2021 February 24
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
-
-/* Star-independent astrometry parameters */
-typedef struct {
-   double pmt;        /* PM time interval (SSB, Julian years) */
-   double eb[3];      /* SSB to observer (vector, au) */
-   double eh[3];      /* Sun to observer (unit vector) */
-   double em;         /* distance from Sun to observer (au) */
-   double v[3];       /* barycentric observer velocity (vector, c) */
-   double bm1;        /* sqrt(1-|v|^2): reciprocal of Lorenz factor */
-   double bpn[3][3];  /* bias-precession-nutation matrix */
-   double along;      /* longitude + s' + dERA(DUT) (radians) */
-   double phi;        /* geodetic latitude (radians) */
-   double xpl;        /* polar motion xp wrt local meridian (radians) */
-   double ypl;        /* polar motion yp wrt local meridian (radians) */
-   double sphi;       /* sine of geodetic latitude */
-   double cphi;       /* cosine of geodetic latitude */
-   double diurab;     /* magnitude of diurnal aberration vector */
-   double eral;       /* "local" Earth rotation angle (radians) */
-   double refa;       /* refraction constant A (radians) */
-   double refb;       /* refraction constant B (radians) */
-} iauASTROM;
-/* (Vectors eb, eh, em and v are all with respect to BCRS axes.) */
-
-/* Body parameters for light deflection */
-typedef struct {
-   double bm;         /* mass of the body (solar masses) */
-   double dl;         /* deflection limiter (radians^2/2) */
-   double pv[2][3];   /* barycentric PV of the body (au, au/day) */
-} iauLDBODY;
 
 /* Pi */
 #define DPI (3.141592653589793238462643)
@@ -156,8 +127,8 @@ typedef struct {
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sp00.c
+++ b/SOFA/SOFA/src/sp00.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 double iauSp00(double date1, double date2)
 /*
@@ -10,7 +11,7 @@ double iauSp00(double date1, double date2)
 **  on the equator of the Celestial Intermediate Pole.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -52,11 +53,11 @@ double iauSp00(double date1, double date2)
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double t, sp;
@@ -70,10 +71,12 @@ double iauSp00(double date1, double date2)
 
    return sp;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/starpm.c
+++ b/SOFA/SOFA/src/starpm.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauStarpm(double ra1, double dec1,
               double pmr1, double pmd1, double px1, double rv1,
@@ -13,7 +14,7 @@ int iauStarpm(double ra1, double dec1,
 **  Star proper motion:  update star catalog data for space motion.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -53,19 +54,19 @@ int iauStarpm(double ra1, double dec1,
 **     parts (A and B).  For example, JD(TDB)=2450123.7 could be
 **     expressed in any of these ways, among others:
 **
-**             epna          epnb
+**            epNa            epNb
 **
 **         2450123.7           0.0       (JD method)
 **         2451545.0       -1421.3       (J2000 method)
 **         2400000.5       50123.2       (MJD method)
 **         2450123.5           0.2       (date & time method)
 **
-**     The JD method is the most natural and convenient to use in
-**     cases where the loss of several decimal digits of resolution
-**     is acceptable.  The J2000 method is best matched to the way
-**     the argument is handled internally and will deliver the
-**     optimum resolution.  The MJD method and the date & time methods
-**     are both good compromises between resolution and convenience.
+**     The JD method is the most natural and convenient to use in cases
+**     where the loss of several decimal digits of resolution is
+**     acceptable.  The J2000 method is best matched to the way the
+**     argument is handled internally and will deliver the optimum
+**     resolution.  The MJD method and the date & time methods are both
+**     good compromises between resolution and convenience.
 **
 **  2) In accordance with normal star-catalog conventions, the object's
 **     right ascension and declination are freed from the effects of
@@ -111,11 +112,11 @@ int iauStarpm(double ra1, double dec1,
 **     iauPdp       scalar product of two p-vectors
 **     iauPvstar    space motion pv-vector to star catalog data
 **
-**  This revision:  2013 June 18
+**  This revision:  2023 May 3
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double pv1[2][3], tl1, dt, pv[2][3], r2, rdv, v2, c2mv2, tl2,
@@ -142,7 +143,7 @@ int iauStarpm(double ra1, double dec1,
    rdv = iauPdp(pv[0], pv[1]);
    v2 = iauPdp(pv[1], pv[1]);
    c2mv2 = DC*DC - v2;
-   if (c2mv2 <=  0) return -1;
+   if (c2mv2 <= 0.0) return -1;
    tl2 = (-rdv + sqrt(rdv*rdv + c2mv2*r2)) / c2mv2;
 
 /* Move the position along track from the observed place at the */
@@ -157,10 +158,12 @@ int iauStarpm(double ra1, double dec1,
 
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/starpv.c
+++ b/SOFA/SOFA/src/starpv.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauStarpv(double ra, double dec,
               double pmr, double pmd, double px, double rv,
@@ -11,7 +12,7 @@ int iauStarpv(double ra, double dec,
 **  Convert star catalog coordinates to position+velocity vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -118,11 +119,11 @@ int iauStarpv(double ra, double dec,
 **
 **     Stumpff, P., 1985, Astron.Astrophys. 144, 232-240.
 **
-**  This revision:  2017 March 16
+**  This revision:  2023 May 4
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 /* Smallest allowed parallax */
@@ -135,7 +136,7 @@ int iauStarpv(double ra, double dec,
    static const int IMAX = 100;
 
    int i, iwarn;
-   double w, r, rd, rad, decd, v, x[3], usr[3], ust[3],
+   double w, r, rd, rad, decd, v, pu[3], usr[3], ust[3],
           vsr, vst, betst, betsr, bett, betr,
           dd, ddel, ur[3], ut[3],
           d = 0.0, del = 0.0,       /* to prevent */
@@ -153,7 +154,7 @@ int iauStarpv(double ra, double dec,
    }
    r = DR2AS / w;
 
-/* Radial velocity (au/day). */
+/* Radial speed (au/day). */
    rd = DAYSEC * rv * 1e3 / DAU;
 
 /* Proper motion (radian/day). */
@@ -171,9 +172,9 @@ int iauStarpv(double ra, double dec,
    }
 
 /* Isolate the radial component of the velocity (au/day). */
-   iauPn(pv[0], &w, x);
-   vsr = iauPdp(x, pv[1]);
-   iauSxp(vsr, x, usr);
+   iauPn(pv[0], &w, pu);
+   vsr = iauPdp(pu, pv[1]);
+   iauSxp(vsr, pu, usr);
 
 /* Isolate the transverse component of the velocity (au/day). */
    iauPmp(pv[1], usr, ust);
@@ -183,7 +184,7 @@ int iauStarpv(double ra, double dec,
    betsr = vsr / DC;
    betst = vst / DC;
 
-/* Determine the inertial-to-observed relativistic correction terms. */
+/* Determine the observed-to-inertial correction terms. */
    bett = betst;
    betr = betsr;
    for (i = 0; i < IMAX; i++) {
@@ -204,23 +205,24 @@ int iauStarpv(double ra, double dec,
    }
    if (i >= IMAX) iwarn += 4;
 
-/* Replace observed radial velocity with inertial value. */
-   w = (betsr != 0.0) ? d + del / betsr : 1.0;
-   iauSxp(w, usr, ur);
-
-/* Replace observed tangential velocity with inertial value. */
+/* Scale observed tangential velocity vector into inertial (au/d). */
    iauSxp(d, ust, ut);
 
-/* Combine the two to obtain the inertial space velocity. */
+/* Compute inertial radial velocity vector (au/d). */
+   iauSxp(DC*(d*betsr+del), pu, ur);
+
+/* Combine the two to obtain the inertial space velocity vector. */
    iauPpp(ur, ut, pv[1]);
 
 /* Return the status. */
    return iwarn;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sxp.c
+++ b/SOFA/SOFA/src/sxp.c
@@ -9,7 +9,7 @@ void iauSxp(double s, double p[3], double sp[3])
 **  Multiply a p-vector by a scalar.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -23,23 +23,23 @@ void iauSxp(double s, double p[3], double sp[3])
 **  Note:
 **     It is permissible for p and sp to be the same array.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    sp[0] = s * p[0];
    sp[1] = s * p[1];
    sp[2] = s * p[2];
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/sxpv.c
+++ b/SOFA/SOFA/src/sxpv.c
@@ -9,7 +9,7 @@ void iauSxpv(double s, double pv[2][3], double spv[2][3])
 **  Multiply a pv-vector by a scalar.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -21,26 +21,26 @@ void iauSxpv(double s, double pv[2][3], double spv[2][3])
 **     spv     double[2][3]    s * pv
 **
 **  Note:
-**     It is permissible for pv and spv to be the same array
+**     It is permissible for pv and spv to be the same array.
 **
 **  Called:
 **     iauS2xpv     multiply pv-vector by two scalars
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauS2xpv(s, s, pv, spv);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/t_sofa_c.c
+++ b/SOFA/SOFA/src/t_sofa_c.c
@@ -1,5 +1,6 @@
-#include <stdio.h>
 #include <sofa.h>
+#include "sofam.h"
+#include <stdio.h>
 
 static int verbose = 0;
 
@@ -17,11 +18,11 @@ static int verbose = 0;
 **
 **  All messages go to stdout.
 **
-**  This revision:  2020 May 30
+**  This revision:  2021 July 29
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 
 static void viv(int ival, int ivalok,
@@ -607,7 +608,7 @@ static void t_apco(int *status)
 **
 **  Called:  iauApco, vvd
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double date1, date2, ebpv[2][3], ehp[3], x, y, s,
@@ -685,11 +686,11 @@ static void t_apco(int *status)
                          "iauApco", "bpn(2,3)", status);
    vvd(astrom.bpn[2][2], 0.9999991386008323373, 1e-12,
                          "iauApco", "bpn(3,3)", status);
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995734, 1e-12,
                      "iauApco", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApco", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApco", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApco", "sphi", status);
@@ -697,7 +698,7 @@ static void t_apco(int *status)
                     "iauApco", "cphi", status);
    vvd(astrom.diurab, 0, 0,
                       "iauApco", "diurab", status);
-   vvd(astrom.eral, 2.617608903969802566, 1e-12,
+   vvd(astrom.eral, 2.617608903970400427, 1e-12,
                     "iauApco", "eral", status);
    vvd(astrom.refa, 0.2014187790000000000e-3, 1e-15,
                     "iauApco", "refa", status);
@@ -719,7 +720,7 @@ static void t_apco13(int *status)
 **
 **  Called:  iauApco13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -786,11 +787,11 @@ static void t_apco13(int *status)
                          "iauApco13", "bpn(2,3)", status);
    vvd(astrom.bpn[2][2], 0.9999991386008312212, 1e-12,
                          "iauApco13", "bpn(3,3)", status);
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995733, 1e-12,
                      "iauApco13", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApco13", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApco13", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApco13", "sphi", status);
@@ -798,7 +799,7 @@ static void t_apco13(int *status)
                     "iauApco13", "cphi", status);
    vvd(astrom.diurab, 0, 0,
                       "iauApco13", "diurab", status);
-   vvd(astrom.eral, 2.617608909189066140, 1e-12,
+   vvd(astrom.eral, 2.617608909189664000, 1e-12,
                     "iauApco13", "eral", status);
    vvd(astrom.refa, 0.2014187785940396921e-3, 1e-15,
                     "iauApco13", "refa", status);
@@ -1045,7 +1046,7 @@ static void t_apio(int *status)
 **
 **  Called:  iauApio, vvd
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double sp, theta, elong, phi, hm, xp, yp, refa, refb;
@@ -1064,11 +1065,11 @@ static void t_apio(int *status)
 
    iauApio(sp, theta, elong, phi, hm, xp, yp, refa, refb, &astrom);
 
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995734, 1e-12,
                      "iauApio", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApio", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApio", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApio", "sphi", status);
@@ -1076,7 +1077,7 @@ static void t_apio(int *status)
                     "iauApio", "cphi", status);
    vvd(astrom.diurab, 0.5135843661699913529e-6, 1e-12,
                       "iauApio", "diurab", status);
-   vvd(astrom.eral, 2.617608903969802566, 1e-12,
+   vvd(astrom.eral, 2.617608903970400427, 1e-12,
                     "iauApio", "eral", status);
    vvd(astrom.refa, 0.2014187790000000000e-3, 1e-15,
                     "iauApio", "refa", status);
@@ -1098,7 +1099,7 @@ static void t_apio13(int *status)
 **
 **  Called:  iauApio13, vvd, viv
 **
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl;
@@ -1122,11 +1123,11 @@ static void t_apio13(int *status)
    j = iauApio13(utc1, utc2, dut1, elong, phi, hm, xp, yp,
                  phpa, tc, rh, wl, &astrom);
 
-   vvd(astrom.along, -0.5278008060301974337, 1e-12,
+   vvd(astrom.along, -0.5278008060295995733, 1e-12,
                      "iauApio13", "along", status);
-   vvd(astrom.xpl, 0.1133427418174939329e-5, 1e-17,
+   vvd(astrom.xpl, 0.1133427418130752958e-5, 1e-17,
                    "iauApio13", "xpl", status);
-   vvd(astrom.ypl, 0.1453347595745898629e-5, 1e-17,
+   vvd(astrom.ypl, 0.1453347595780646207e-5, 1e-17,
                    "iauApio13", "ypl", status);
    vvd(astrom.sphi, -0.9440115679003211329, 1e-12,
                     "iauApio13", "sphi", status);
@@ -1134,13 +1135,86 @@ static void t_apio13(int *status)
                     "iauApio13", "cphi", status);
    vvd(astrom.diurab, 0.5135843661699913529e-6, 1e-12,
                       "iauApio13", "diurab", status);
-   vvd(astrom.eral, 2.617608909189066140, 1e-12,
+   vvd(astrom.eral, 2.617608909189664000, 1e-12,
                     "iauApio13", "eral", status);
    vvd(astrom.refa, 0.2014187785940396921e-3, 1e-15,
                     "iauApio13", "refa", status);
    vvd(astrom.refb, -0.2361408314943696227e-6, 1e-18,
                     "iauApio13", "refb", status);
    viv(j, 0, "iauApio13", "j", status);
+
+}
+
+static void t_atcc13(int *status)
+/*
+**  - - - - - - - - -
+**   t _ a t c c 1 3
+**  - - - - - - - - -
+**
+**  Test iauAtcc13 function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  iauAtcc13, vvd
+**
+**  This revision:  2021 April 18
+*/
+{
+   double rc, dc, pr, pd, px, rv, date1, date2, ra, da;
+
+
+   rc = 2.71;
+   dc = 0.174;
+   pr = 1e-5;
+   pd = 5e-6;
+   px = 0.1;
+   rv = 55.0;
+   date1 = 2456165.5;
+   date2 = 0.401182685;
+
+   iauAtcc13(rc, dc, pr, pd, px, rv, date1, date2, &ra, &da);
+
+   vvd(ra,  2.710126504531372384, 1e-12,
+           "iauAtcc13", "ra", status);
+   vvd(da, 0.1740632537628350152, 1e-12,
+           "iauAtcc13", "da", status);
+
+}
+
+static void t_atccq(int *status)
+/*
+**  - - - - - - - -
+**   t _ a t c c q
+**  - - - - - - - -
+**
+**  Test iauAtccq function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  iauApci13, iauAtccq, vvd
+**
+**  This revision:  2021 July 29
+*/
+{
+   double date1, date2, eo, rc, dc, pr, pd, px, rv, ra, da;
+   iauASTROM astrom;
+
+   date1 = 2456165.5;
+   date2 = 0.401182685;
+   iauApci13(date1, date2, &astrom, &eo);
+   rc = 2.71;
+   dc = 0.174;
+   pr = 1e-5;
+   pd = 5e-6;
+   px = 0.1;
+   rv = 55.0;
+
+   iauAtccq(rc, dc, pr, pd, px, rv, &astrom, &ra, &da);
+
+   vvd(ra, 2.710126504531372384, 1e-12, "iauAtccq", "ra", status);
+   vvd(da, 0.1740632537628350152, 1e-12, "iauAtccq", "da", status);
 
 }
 
@@ -1326,7 +1400,7 @@ static void t_atco13(int *status)
 **
 **  Called:  iauAtco13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double rc, dc, pr, pd, px, rv, utc1, utc2, dut1,
@@ -1359,11 +1433,11 @@ static void t_atco13(int *status)
                  phpa, tc, rh, wl,
                  &aob, &zob, &hob, &dob, &rob, &eo);
 
-   vvd(aob, 0.09251774485385390973, 1e-12, "iauAtco13", "aob", status);
-   vvd(zob, 1.407661405256671703, 1e-12, "iauAtco13", "zob", status);
-   vvd(hob, -0.09265154431430045141, 1e-12, "iauAtco13", "hob", status);
-   vvd(dob, 0.1716626560074556029, 1e-12, "iauAtco13", "dob", status);
-   vvd(rob, 2.710260453503366591, 1e-12, "iauAtco13", "rob", status);
+   vvd(aob, 0.9251774485485515207e-1, 1e-12, "iauAtco13", "aob", status);
+   vvd(zob, 1.407661405256499357, 1e-12, "iauAtco13", "zob", status);
+   vvd(hob, -0.9265154431529724692e-1, 1e-12, "iauAtco13", "hob", status);
+   vvd(dob, 0.1716626560072526200, 1e-12, "iauAtco13", "dob", status);
+   vvd(rob, 2.710260453504961012, 1e-12, "iauAtco13", "rob", status);
    vvd(eo, -0.003020548354802412839, 1e-14, "iauAtco13", "eo", status);
    viv(j, 0, "iauAtco13", "j", status);
 
@@ -1505,7 +1579,7 @@ static void t_atio13(int *status)
 **
 **  Called:  iauAtio13, vvd, viv
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double ri, di, utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -1532,11 +1606,11 @@ static void t_atio13(int *status)
                  xp, yp, phpa, tc, rh, wl,
                  &aob, &zob, &hob, &dob, &rob);
 
-   vvd(aob, 0.09233952224794989993, 1e-12, "iauAtio13", "aob", status);
-   vvd(zob, 1.407758704513722461, 1e-12, "iauAtio13", "zob", status);
-   vvd(hob, -0.09247619879782006106, 1e-12, "iauAtio13", "hob", status);
-   vvd(dob, 0.1717653435758265198, 1e-12, "iauAtio13", "dob", status);
-   vvd(rob, 2.710085107986886201, 1e-12, "iauAtio13", "rob", status);
+   vvd(aob, 0.9233952224895122499e-1, 1e-12, "iauAtio13", "aob", status);
+   vvd(zob, 1.407758704513549991, 1e-12, "iauAtio13", "zob", status);
+   vvd(hob, -0.9247619879881698140e-1, 1e-12, "iauAtio13", "hob", status);
+   vvd(dob, 0.1717653435756234676, 1e-12, "iauAtio13", "dob", status);
+   vvd(rob, 2.710085107988480746, 1e-12, "iauAtio13", "rob", status);
    viv(j, 0, "iauAtio13", "j", status);
 
 }
@@ -1554,7 +1628,7 @@ static void t_atioq(int *status)
 **
 **  Called:  iauApio13, iauAtioq, vvd, viv
 **
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp,
@@ -1581,11 +1655,11 @@ static void t_atioq(int *status)
 
    iauAtioq(ri, di, &astrom, &aob, &zob, &hob, &dob, &rob);
 
-   vvd(aob, 0.09233952224794989993, 1e-12, "iauAtioq", "aob", status);
-   vvd(zob, 1.407758704513722461, 1e-12, "iauAtioq", "zob", status);
-   vvd(hob, -0.09247619879782006106, 1e-12, "iauAtioq", "hob", status);
-   vvd(dob, 0.1717653435758265198, 1e-12, "iauAtioq", "dob", status);
-   vvd(rob, 2.710085107986886201, 1e-12, "iauAtioq", "rob", status);
+   vvd(aob, 0.9233952224895122499e-1, 1e-12, "iauAtioq", "aob", status);
+   vvd(zob, 1.407758704513549991, 1e-12, "iauAtioq", "zob", status);
+   vvd(hob, -0.9247619879881698140e-1, 1e-12, "iauAtioq", "hob", status);
+   vvd(dob, 0.1717653435756234676, 1e-12, "iauAtioq", "dob", status);
+   vvd(rob, 2.710085107988480746, 1e-12, "iauAtioq", "rob", status);
 
 }
 
@@ -1602,7 +1676,7 @@ static void t_atoc13(int *status)
 **
 **  Called:  iauAtoc13, vvd, viv
 **
-**  This revision:  2017 March 15
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1,
@@ -1629,8 +1703,8 @@ static void t_atoc13(int *status)
    j = iauAtoc13 ( "R", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "R/rc", status);
-   vvd(dc, 0.1741696500896438967, 1e-12, "iauAtoc13", "R/dc", status);
+   vvd(rc, 2.709956744659136129, 1e-12, "iauAtoc13", "R/rc", status);
+   vvd(dc, 0.1741696500898471362, 1e-12, "iauAtoc13", "R/dc", status);
    viv(j, 0, "iauAtoc13", "R/j", status);
 
    ob1 = -0.09247619879782006106;
@@ -1638,8 +1712,8 @@ static void t_atoc13(int *status)
    j = iauAtoc13 ( "H", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "H/rc", status);
-   vvd(dc, 0.1741696500896438967, 1e-12, "iauAtoc13", "H/dc", status);
+   vvd(rc, 2.709956744659734086, 1e-12, "iauAtoc13", "H/rc", status);
+   vvd(dc, 0.1741696500898471362, 1e-12, "iauAtoc13", "H/dc", status);
    viv(j, 0, "iauAtoc13", "H/j", status);
 
    ob1 = 0.09233952224794989993;
@@ -1647,8 +1721,8 @@ static void t_atoc13(int *status)
    j = iauAtoc13 ( "A", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &rc, &dc);
-   vvd(rc, 2.709956744660731630, 1e-12, "iauAtoc13", "A/rc", status);
-   vvd(dc, 0.1741696500896438970, 1e-12, "iauAtoc13", "A/dc", status);
+   vvd(rc, 2.709956744659734086, 1e-12, "iauAtoc13", "A/rc", status);
+   vvd(dc, 0.1741696500898471366, 1e-12, "iauAtoc13", "A/dc", status);
    viv(j, 0, "iauAtoc13", "A/j", status);
 
 }
@@ -1666,7 +1740,7 @@ static void t_atoi13(int *status)
 **
 **  Called:  iauAtoi13, vvd, viv
 **
-**  This revision:  2013 October 3
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl,
@@ -1692,8 +1766,8 @@ static void t_atoi13(int *status)
    j = iauAtoi13 ( "R", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "R/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12, "iauAtoi13", "R/di", status);
+   vvd(ri, 2.710121574447540810, 1e-12, "iauAtoi13", "R/ri", status);
+   vvd(di, 0.1729371839116608778, 1e-12, "iauAtoi13", "R/di", status);
    viv(j, 0, "iauAtoi13", "R/J", status);
 
    ob1 = -0.09247619879782006106;
@@ -1701,8 +1775,8 @@ static void t_atoi13(int *status)
    j = iauAtoi13 ( "H", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "H/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12, "iauAtoi13", "H/di", status);
+   vvd(ri, 2.710121574448138676, 1e-12, "iauAtoi13", "H/ri", status);
+   vvd(di, 0.1729371839116608778, 1e-12, "iauAtoi13", "H/di", status);
    viv(j, 0, "iauAtoi13", "H/J", status);
 
    ob1 = 0.09233952224794989993;
@@ -1710,8 +1784,8 @@ static void t_atoi13(int *status)
    j = iauAtoi13 ( "A", ob1, ob2, utc1, utc2, dut1,
                    elong, phi, hm, xp, yp, phpa, tc, rh, wl,
                    &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12, "iauAtoi13", "A/ri", status);
-   vvd(di, 0.1729371839114567728, 1e-12, "iauAtoi13", "A/di", status);
+   vvd(ri, 2.710121574448138676, 1e-12, "iauAtoi13", "A/ri", status);
+   vvd(di, 0.1729371839116608781, 1e-12, "iauAtoi13", "A/di", status);
    viv(j, 0, "iauAtoi13", "A/J", status);
 
 }
@@ -1729,7 +1803,7 @@ static void t_atoiq(int *status)
 *
 **  Called:  iauApio13, iauAtoiq, vvd
 *
-**  This revision:  2013 October 4
+**  This revision:  2021 January 5
 */
 {
    double utc1, utc2, dut1, elong, phi, hm, xp, yp, phpa, tc, rh, wl,
@@ -1755,25 +1829,25 @@ static void t_atoiq(int *status)
    ob1 = 2.710085107986886201;
    ob2 = 0.1717653435758265198;
    iauAtoiq("R", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574447540810, 1e-12,
            "iauAtoiq", "R/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12,
+   vvd(di, 0.17293718391166087785, 1e-12,
            "iauAtoiq", "R/di", status);
 
    ob1 = -0.09247619879782006106;
    ob2 = 0.1717653435758265198;
    iauAtoiq("H", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574448138676, 1e-12,
            "iauAtoiq", "H/ri", status);
-   vvd(di, 0.1729371839114567725, 1e-12,
+   vvd(di, 0.1729371839116608778, 1e-12,
            "iauAtoiq", "H/di", status);
 
    ob1 = 0.09233952224794989993;
    ob2 = 1.407758704513722461;
    iauAtoiq("A", ob1, ob2, &astrom, &ri, &di);
-   vvd(ri, 2.710121574449135955, 1e-12,
+   vvd(ri, 2.710121574448138676, 1e-12,
            "iauAtoiq", "A/ri", status);
-   vvd(di, 0.1729371839114567728, 1e-12,
+   vvd(di, 0.1729371839116608781, 1e-12,
            "iauAtoiq", "A/di", status);
 
 }
@@ -3976,7 +4050,7 @@ static void t_fk52h(int *status)
 **
 **  Called:  iauFk52h, vvd
 **
-**  This revision:  2017 January 3
+**  This revision:  2021 January 5
 */
 {
    double r5, d5, dr5, dd5, px5, rv5, rh, dh, drh, ddh, pxh, rvh;
@@ -3996,7 +4070,7 @@ static void t_fk52h(int *status)
        "iauFk52h", "ra", status);
    vvd(dh,  -0.2917516070530391757, 1e-14,
        "iauFk52h", "dec", status);
-   vvd(drh, -0.19618741256057224e-6,1e-19,
+   vvd(drh, -0.1961874125605721270e-6,1e-19,
        "iauFk52h", "dr5", status);
    vvd(ddh, -0.58459905176693911e-5, 1e-19,
        "iauFk52h", "dd5", status);
@@ -5272,6 +5346,43 @@ static void t_ltpequ(int *status)
        "iauLtpequ", "veq2", status);
    vvd(veq[2], 0.9118552442250819624, 1e-14,
        "iauLtpequ", "veq3", status);
+
+}
+
+static void t_moon98(int *status)
+/*
+**  - - - - - - - - -
+**   t _ m o o n 9 8
+**  - - - - - - - - -
+**
+**  Test iauMoon98 function.
+**
+**  Returned:
+**     status    int         FALSE = success, TRUE = fail
+**
+**  Called:  iauMoon98, vvd, viv
+**
+**  This revision:  2021 April 12
+*/
+{
+   double pv[2][3];
+
+
+   iauMoon98(2400000.5, 43999.9, pv);
+
+   vvd(pv[0][0], -0.2601295959971044180e-2, 1e-11,
+       "iauMoon98", "x 4", status);
+   vvd(pv[0][1], 0.6139750944302742189e-3, 1e-11,
+       "iauMoon98", "y 4", status);
+   vvd(pv[0][2], 0.2640794528229828909e-3, 1e-11,
+       "iauMoon98", "z 4", status);
+
+   vvd(pv[1][0], -0.1244321506649895021e-3, 1e-11,
+       "iauMoon98", "xd 4", status);
+   vvd(pv[1][1], -0.5219076942678119398e-3, 1e-11,
+       "iauMoon98", "yd 4", status);
+   vvd(pv[1][2], -0.1716132214378462047e-3, 1e-11,
+       "iauMoon98", "zd 4", status);
 
 }
 
@@ -7718,7 +7829,7 @@ static void t_pvu(int *status)
 **
 **  Called:  iauPvu, vvd
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 January 5
 */
 {
    double pv[2][3], upv[2][3];
@@ -7734,11 +7845,11 @@ static void t_pvu(int *status)
 
    iauPvu(2920.0, pv, upv);
 
-   vvd(upv[0][0], 126656.7598605317105, 1e-12,
+   vvd(upv[0][0], 126656.7598605317105, 1e-6,
        "iauPvu", "p1", status);
-   vvd(upv[0][1], 2118.531271155726332, 1e-12,
+   vvd(upv[0][1], 2118.531271155726332, 1e-8,
        "iauPvu", "p2", status);
-   vvd(upv[0][2], -245216.5048590656190, 1e-12,
+   vvd(upv[0][2], -245216.5048590656190, 1e-6,
        "iauPvu", "p3", status);
 
    vvd(upv[1][0], -0.4051854035740713039e-2, 1e-12,
@@ -7763,7 +7874,7 @@ static void t_pvup(int *status)
 **
 **  Called:  iauPvup, vvd
 **
-**  This revision:  2013 August 7
+**  This revision:  2021 January 5
 */
 {
    double pv[2][3], p[3];
@@ -7779,9 +7890,9 @@ static void t_pvup(int *status)
 
    iauPvup(2920.0, pv, p);
 
-   vvd(p[0],  126656.7598605317105,   1e-12, "iauPvup", "1", status);
-   vvd(p[1],    2118.531271155726332, 1e-12, "iauPvup", "2", status);
-   vvd(p[2], -245216.5048590656190,   1e-12, "iauPvup", "3", status);
+   vvd(p[0],  126656.7598605317105,   1e-6, "iauPvup", "1", status);
+   vvd(p[1],    2118.531271155726332, 1e-8, "iauPvup", "2", status);
+   vvd(p[2], -245216.5048590656190,   1e-6, "iauPvup", "3", status);
 
 }
 
@@ -9886,7 +9997,7 @@ int main(int argc, char *argv[])
 **   m a i n
 **  - - - - -
 **
-**  This revision:  2017 October 21
+**  This revision:  2021 April 18
 */
 {
    int status;
@@ -9921,6 +10032,8 @@ int main(int argc, char *argv[])
    t_aper13(&status);
    t_apio(&status);
    t_apio13(&status);
+   t_atcc13(&status);
+   t_atccq(&status);
    t_atci13(&status);
    t_atciq(&status);
    t_atciqn(&status);
@@ -10033,6 +10146,7 @@ int main(int argc, char *argv[])
    t_ltpb(&status);
    t_ltpecl(&status);
    t_ltpequ(&status);
+   t_moon98(&status);
    t_num00a(&status);
    t_num00b(&status);
    t_num06a(&status);
@@ -10154,11 +10268,11 @@ int main(int argc, char *argv[])
       printf("t_sofa_c validation successful\n");
    }
    return status;
-}
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================
@@ -10250,3 +10364,4 @@ int main(int argc, char *argv[])
 **                 United Kingdom
 **
 **--------------------------------------------------------------------*/
+}

--- a/SOFA/SOFA/src/taitt.c
+++ b/SOFA/SOFA/src/taitt.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTaitt(double tai1, double tai2, double *tt1, double *tt2)
 /*
@@ -38,11 +39,11 @@ int iauTaitt(double tai1, double tai2, double *tt1, double *tt2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -62,10 +63,12 @@ int iauTaitt(double tai1, double tai2, double *tt1, double *tt2)
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/taiut1.c
+++ b/SOFA/SOFA/src/taiut1.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTaiut1(double tai1, double tai2, double dta,
               double *ut11, double *ut12)
@@ -40,11 +41,11 @@ int iauTaiut1(double tai1, double tai2, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 **
 */
 {
@@ -64,10 +65,12 @@ int iauTaiut1(double tai1, double tai2, double dta,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/taiutc.c
+++ b/SOFA/SOFA/src/taiutc.c
@@ -61,11 +61,11 @@ int iauTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int big1;
@@ -111,10 +111,12 @@ int iauTaiutc(double tai1, double tai2, double *utc1, double *utc2)
 /* Status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tcbtdb.c
+++ b/SOFA/SOFA/src/tcbtdb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 /*
@@ -52,11 +53,11 @@ int iauTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -84,10 +85,12 @@ int iauTcbtdb(double tcb1, double tcb2, double *tdb1, double *tdb2)
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tcgtt.c
+++ b/SOFA/SOFA/src/tcgtt.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 /*
@@ -32,16 +33,16 @@ int iauTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 **
 **  References:
 **
-**     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),.
+**     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -61,10 +62,12 @@ int iauTcgtt(double tcg1, double tcg2, double *tt1, double *tt2)
 /* OK status. */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tdbtcb.c
+++ b/SOFA/SOFA/src/tdbtcb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 /*
@@ -52,11 +53,11 @@ int iauTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 **
 **     IAU 2006 Resolution B3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -89,10 +90,12 @@ int iauTdbtcb(double tdb1, double tdb2, double *tcb1, double *tcb2)
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tdbtt.c
+++ b/SOFA/SOFA/src/tdbtt.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTdbtt(double tdb1, double tdb2, double dtr,
              double *tt1, double *tt2 )
@@ -50,11 +51,11 @@ int iauTdbtt(double tdb1, double tdb2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 **
 */
 {
@@ -74,10 +75,12 @@ int iauTdbtt(double tdb1, double tdb2, double dtr,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tf2a.c
+++ b/SOFA/SOFA/src/tf2a.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 #include <stdlib.h>
 
 int iauTf2a(char s, int ihour, int imin, double sec, double *rad)
@@ -39,11 +40,11 @@ int iauTf2a(char s, int ihour, int imin, double sec, double *rad)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -59,10 +60,12 @@ int iauTf2a(char s, int ihour, int imin, double sec, double *rad)
    if ( sec < 0.0 || sec >= 60.0 ) return 3;
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tf2d.c
+++ b/SOFA/SOFA/src/tf2d.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 #include <stdlib.h>
 
 int iauTf2d(char s, int ihour, int imin, double sec, double *days)
@@ -39,11 +40,11 @@ int iauTf2d(char s, int ihour, int imin, double sec, double *days)
 **  3)  If there are multiple errors, the status value reflects only the
 **      first, the smallest taking precedence.
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -59,10 +60,12 @@ int iauTf2d(char s, int ihour, int imin, double sec, double *days)
    if ( sec < 0.0 || sec >= 60.0 ) return 3;
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tpors.c
+++ b/SOFA/SOFA/src/tpors.c
@@ -90,9 +90,9 @@ int iauTpors(double xi, double eta, double a, double b,
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double xi2, r, sb, cb, rsb, rcb, w2, w, s, c;
@@ -126,8 +126,8 @@ int iauTpors(double xi, double eta, double a, double b,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tporv.c
+++ b/SOFA/SOFA/src/tporv.c
@@ -85,9 +85,9 @@ int iauTporv(double xi, double eta, double v[3],
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, rxy2, xi2, eta2p1, r, rsb, rcb, w2, w, c;
@@ -123,8 +123,8 @@ int iauTporv(double xi, double eta, double v[3],
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tpsts.c
+++ b/SOFA/SOFA/src/tpsts.c
@@ -57,9 +57,9 @@ void iauTpsts(double xi, double eta, double a0, double b0,
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double sb0, cb0, d;
@@ -74,8 +74,8 @@ void iauTpsts(double xi, double eta, double a0, double b0,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tpstv.c
+++ b/SOFA/SOFA/src/tpstv.c
@@ -66,9 +66,9 @@ void iauTpstv(double xi, double eta, double v0[3], double v[3])
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double x, y, z, f, r;
@@ -98,8 +98,8 @@ void iauTpstv(double xi, double eta, double v0[3], double v[3])
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tpxes.c
+++ b/SOFA/SOFA/src/tpxes.c
@@ -61,9 +61,9 @@ int iauTpxes(double a, double b, double a0, double b0,
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    const double TINY = 1e-6;
@@ -107,8 +107,8 @@ int iauTpxes(double a, double b, double a0, double b0,
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tpxev.c
+++ b/SOFA/SOFA/src/tpxev.c
@@ -72,9 +72,9 @@ int iauTpxev(double v[3], double v0[3], double *xi, double *eta)
 **
 **  This revision:   2018 January 2
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    const double TINY = 1e-6;
@@ -127,8 +127,8 @@ int iauTpxev(double v[3], double v0[3], double *xi, double *eta)
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tr.c
+++ b/SOFA/SOFA/src/tr.c
@@ -9,7 +9,7 @@ void iauTr(double r[3][3], double rt[3][3])
 **  Transpose an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -25,11 +25,11 @@ void iauTr(double r[3][3], double rt[3][3])
 **  Called:
 **     iauCr        copy r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double wm[3][3];
@@ -43,12 +43,12 @@ void iauTr(double r[3][3], double rt[3][3])
    }
    iauCr(wm, rt);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/trxp.c
+++ b/SOFA/SOFA/src/trxp.c
@@ -9,7 +9,7 @@ void iauTrxp(double r[3][3], double p[3], double trp[3])
 **  Multiply a p-vector by the transpose of an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -27,11 +27,11 @@ void iauTrxp(double r[3][3], double p[3], double trp[3])
 **     iauTr        transpose r-matrix
 **     iauRxp       product of r-matrix and p-vector
 **
-**  This revision:  2020 May 24
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double tr[3][3];
@@ -43,12 +43,12 @@ void iauTrxp(double r[3][3], double p[3], double trp[3])
 /* Matrix tr * vector p -> vector trp. */
    iauRxp(tr, p, trp);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/trxpv.c
+++ b/SOFA/SOFA/src/trxpv.c
@@ -9,7 +9,7 @@ void iauTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 **  Multiply a pv-vector by the transpose of an r-matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
@@ -18,20 +18,26 @@ void iauTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 **     pv       double[2][3]    pv-vector
 **
 **  Returned:
-**     trpv     double[2][3]    r * pv
+**     trpv     double[2][3]    r^T * pv
 **
-**  Note:
-**     It is permissible for pv and trpv to be the same array.
+**  Notes:
+**
+**  1) The algorithm is for the simple case where the r-matrix r is not
+**     a function of time.  The case where r is a function of time leads
+**     to an additional velocity component equal to the product of the
+**     derivative of the transpose of r and the position vector.
+**
+**  2) It is permissible for pv and rpv to be the same array.
 **
 **  Called:
 **     iauTr        transpose r-matrix
 **     iauRxpv      product of r-matrix and pv-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double tr[3][3];
@@ -43,12 +49,12 @@ void iauTrxpv(double r[3][3], double pv[2][3], double trpv[2][3])
 /* Matrix tr * vector pv -> vector trpv. */
    iauRxpv(tr, pv, trpv);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tttai.c
+++ b/SOFA/SOFA/src/tttai.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTttai(double tt1, double tt2, double *tai1, double *tai2)
 /*
@@ -38,11 +39,11 @@ int iauTttai(double tt1, double tt2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -62,10 +63,12 @@ int iauTttai(double tt1, double tt2, double *tai1, double *tai2)
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tttcg.c
+++ b/SOFA/SOFA/src/tttcg.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 /*
@@ -37,11 +38,11 @@ int iauTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 **
 **     IAU 2000 Resolution B1.9
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -64,10 +65,12 @@ int iauTttcg(double tt1, double tt2, double *tcg1, double *tcg2)
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/tttdb.c
+++ b/SOFA/SOFA/src/tttdb.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTttdb(double tt1, double tt2, double dtr,
              double *tdb1, double *tdb2)
@@ -50,11 +51,11 @@ int iauTttdb(double tt1, double tt2, double dtr,
 **
 **     IAU 2006 Resolution 3
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dtrd;
@@ -73,10 +74,12 @@ int iauTttdb(double tt1, double tt2, double dtr,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ttut1.c
+++ b/SOFA/SOFA/src/ttut1.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauTtut1(double tt1, double tt2, double dt,
              double *ut11, double *ut12)
@@ -39,11 +40,11 @@ int iauTtut1(double tt1, double tt2, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dtd;
@@ -62,10 +63,12 @@ int iauTtut1(double tt1, double tt2, double dt,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ut1tai.c
+++ b/SOFA/SOFA/src/ut1tai.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauUt1tai(double ut11, double ut12, double dta,
               double *tai1, double *tai2)
@@ -40,11 +41,11 @@ int iauUt1tai(double ut11, double ut12, double dta,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dtad;
@@ -63,10 +64,12 @@ int iauUt1tai(double ut11, double ut12, double dta,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ut1tt.c
+++ b/SOFA/SOFA/src/ut1tt.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauUt1tt(double ut11, double ut12, double dt,
              double *tt1, double *tt2)
@@ -39,11 +40,11 @@ int iauUt1tt(double ut11, double ut12, double dt,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double dtd;
@@ -62,10 +63,12 @@ int iauUt1tt(double ut11, double ut12, double dt,
 /* Status (always OK). */
    return 0;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/ut1utc.c
+++ b/SOFA/SOFA/src/ut1utc.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauUt1utc(double ut11, double ut12, double dut1,
               double *utc1, double *utc2)
@@ -43,8 +44,8 @@ int iauUt1utc(double ut11, double ut12, double dut1,
 **
 **  3) JD cannot unambiguously represent UTC during a leap second unless
 **     special measures are taken.  The convention in the present
-**     function is that the returned quasi JD day UTC1+UTC2 represents
-**     UTC days whether the length is 86399, 86400 or 86401 SI seconds.
+**     function is that the returned quasi-JD UTC1+UTC2 represents UTC
+**     days whether the length is 86399, 86400 or 86401 SI seconds.
 **
 **  4) The function iauD2dtf can be used to transform the UTC quasi-JD
 **     into calendar date and clock time, including UTC leap second
@@ -67,11 +68,11 @@ int iauUt1utc(double ut11, double ut12, double dut1,
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2023 May 6
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int big1;
@@ -105,7 +106,7 @@ int iauUt1utc(double ut11, double ut12, double dut1,
       if ( fabs(ddats) >= 0.5 ) {
 
       /* Yes, leap second nearby: ensure UT1-UTC is "before" value. */
-         if ( ddats * duts >= 0 ) duts -= ddats;
+         if ( ddats*duts >= 0.0 ) duts -= ddats;
 
       /* UT1 for the start of the UTC day that ends in a leap. */
          if ( iauCal2jd(iy, im, id, &d1, &d2) ) return -1;
@@ -115,7 +116,7 @@ int iauUt1utc(double ut11, double ut12, double dut1,
       /* Is the UT1 after this point? */
          du = u1 - us1;
          du += u2 - us2;
-         if ( du > 0 ) {
+         if ( du > 0.0 ) {
 
          /* Yes:  fraction of the current UTC day that has elapsed. */
             fd = du * DAYSEC / ( DAYSEC + ddats );
@@ -145,10 +146,12 @@ int iauUt1utc(double ut11, double ut12, double dut1,
 /* Status. */
    return js;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/utctai.c
+++ b/SOFA/SOFA/src/utctai.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 int iauUtctai(double utc1, double utc2, double *tai1, double *tai2)
 /*
@@ -63,11 +64,11 @@ int iauUtctai(double utc1, double utc2, double *tai1, double *tai2)
 **     Explanatory Supplement to the Astronomical Almanac,
 **     P. Kenneth Seidelmann (ed), University Science Books (1992)
 **
-**  This revision:  2019 June 20
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 **
 */
 {
@@ -130,10 +131,12 @@ int iauUtctai(double utc1, double utc2, double *tai1, double *tai2)
 /* Status. */
    return j;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/utcut1.c
+++ b/SOFA/SOFA/src/utcut1.c
@@ -68,11 +68,11 @@ int iauUtcut1(double utc1, double utc2, double dut1,
 **     iauUtctai    UTC to TAI
 **     iauTaiut1    TAI to UT1
 **
-**  This revision:  2013 August 12
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    int iy, im, id, js, jw;
@@ -99,10 +99,12 @@ int iauUtcut1(double utc1, double utc2, double dut1,
 /* Status. */
    return js;
 
+/* Finished. */
+
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/xy06.c
+++ b/SOFA/SOFA/src/xy06.c
@@ -1,4 +1,5 @@
 #include "sofa.h"
+#include "sofam.h"
 
 void iauXy06(double date1, double date2, double *x, double *y)
 /*
@@ -10,7 +11,7 @@ void iauXy06(double date1, double date2, double *x, double *y)
 **  on IAU 2006 precession and IAU 2000A nutation.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  canonical model.
 **
@@ -90,11 +91,11 @@ void iauXy06(double date1, double date2, double *x, double *y)
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2019 June 23
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
 
@@ -2708,12 +2709,12 @@ void iauXy06(double date1, double date2, double *x, double *y)
    *x = DAS2R * (xypr[0] + (xyls[0] + xypl[0]) / 1e6);
    *y = DAS2R * (xypr[1] + (xyls[1] + xypl[1]) / 1e6);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/xys00a.c
+++ b/SOFA/SOFA/src/xys00a.c
@@ -12,7 +12,7 @@ void iauXys00a(double date1, double date2,
 **  precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -64,11 +64,11 @@ void iauXys00a(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2019 November 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3];
@@ -83,12 +83,12 @@ void iauXys00a(double date1, double date2,
 /* Obtain s. */
    *s = iauS00(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/xys00b.c
+++ b/SOFA/SOFA/src/xys00b.c
@@ -12,7 +12,7 @@ void iauXys00b(double date1, double date2,
 **  precession-nutation model.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -21,7 +21,7 @@ void iauXys00b(double date1, double date2,
 **
 **  Returned:
 **     x,y          double   Celestial Intermediate Pole (Note 2)
-**     s            double   the CIO locator s (Note 2)
+**     s            double   the CIO locator s (Note 3)
 **
 **  Notes:
 **
@@ -64,11 +64,11 @@ void iauXys00b(double date1, double date2,
 **     McCarthy, D. D., Petit, G. (eds.), IERS Conventions (2003),
 **     IERS Technical Note No. 32, BKG (2004)
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3];
@@ -83,12 +83,12 @@ void iauXys00b(double date1, double date2,
 /* Obtain s. */
    *s = iauS00(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/xys06a.c
+++ b/SOFA/SOFA/src/xys06a.c
@@ -12,7 +12,7 @@ void iauXys06a(double date1, double date2,
 **  precession and IAU 2000A nutation models.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  support function.
 **
@@ -21,7 +21,7 @@ void iauXys06a(double date1, double date2,
 **
 **  Returned:
 **     x,y          double  Celestial Intermediate Pole (Note 2)
-**     s            double  the CIO locator s (Note 2)
+**     s            double  the CIO locator s (Note 3)
 **
 **  Notes:
 **
@@ -64,11 +64,11 @@ void iauXys06a(double date1, double date2,
 **
 **     Wallace, P.T. & Capitaine, N., 2006, Astron.Astrophys. 459, 981
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    double rbpn[3][3];
@@ -83,12 +83,12 @@ void iauXys06a(double date1, double date2,
 /* Obtain s. */
    *s = iauS06(date1, date2, *x, *y);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/zp.c
+++ b/SOFA/SOFA/src/zp.c
@@ -9,30 +9,30 @@ void iauZp(double p[3])
 **  Zero a p-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
 **  Returned:
-**     p        double[3]      p-vector
+**     p        double[3]      zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    p[0] = 0.0;
    p[1] = 0.0;
    p[2] = 0.0;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/zpv.c
+++ b/SOFA/SOFA/src/zpv.c
@@ -9,32 +9,32 @@ void iauZpv(double pv[2][3])
 **  Zero a pv-vector.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
 **  Returned:
-**     pv       double[2][3]      pv-vector
+**     pv       double[2][3]      zero pv-vector
 **
 **  Called:
 **     iauZp        zero p-vector
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    iauZp(pv[0]);
    iauZp(pv[1]);
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================

--- a/SOFA/SOFA/src/zr.c
+++ b/SOFA/SOFA/src/zr.c
@@ -9,18 +9,18 @@ void iauZr(double r[3][3])
 **  Initialize an r-matrix to the null matrix.
 **
 **  This function is part of the International Astronomical Union's
-**  SOFA (Standards Of Fundamental Astronomy) software collection.
+**  SOFA (Standards of Fundamental Astronomy) software collection.
 **
 **  Status:  vector/matrix support function.
 **
 **  Returned:
 **     r        double[3][3]    r-matrix
 **
-**  This revision:  2013 June 18
+**  This revision:  2021 May 11
 **
-**  SOFA release 2020-07-21
+**  SOFA release 2023-10-11
 **
-**  Copyright (C) 2020 IAU SOFA Board.  See notes at end.
+**  Copyright (C) 2023 IAU SOFA Board.  See notes at end.
 */
 {
    r[0][0] = 0.0;
@@ -33,12 +33,12 @@ void iauZr(double r[3][3])
    r[2][1] = 0.0;
    r[2][2] = 0.0;
 
-   return;
+/* Finished. */
 
 /*----------------------------------------------------------------------
 **
-**  Copyright (C) 2020
-**  Standards Of Fundamental Astronomy Board
+**  Copyright (C) 2023
+**  Standards of Fundamental Astronomy Board
 **  of the International Astronomical Union.
 **
 **  =====================


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
- Pass two part dates into SOFAs api for improved precision
- Add additional methods for JulianDateTT and JulianDateUT1 to AstroUtil
- DeltaUT cache to use nullable types
- Log NOVAS.Place failures as warnings
- Adjust BasicBody and RiseAndSetEvent to calculate synchronously as they are cpu bound anyways
- Improve robustness of RiseAndSetEvent Calculate method
- Refreshed SOFA library to latest Issue from 2023-10-11

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [-] No breaking changes to interfaces  -- Potential breaking changes in RiseAndSet class
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
