### PR TITLE
Remove disused switch connecto notification with unresolved label

### DIFF
--- a/NINA.WPF.Base/ViewModel/Equipment/Switch/SwitchVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Switch/SwitchVM.cs
@@ -265,7 +265,6 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Switch {
 
                             return true;
                         } else {
-                            Notification.ShowError(String.Format(Loc.Instance["LblUnableToconnectTo"], DeviceChooserVM.SelectedDevice.Name));
                             SwitchInfo.Connected = false;
                             this.SwitchHub = null;
                             return false;


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

SwitchVM has a connection failure notification that uses a label that doesn't exist, resulting in the following error notification

<img width="200" height="150" alt="image" src="https://github.com/user-attachments/assets/35e9017c-e8ba-4825-9312-7617fa37939b" />

This brings  SwitchVM's connect failure code in line with other devices.
## 🧪 How Was It Tested?

Failure to connect didn't produce the old notification

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
