### PR TITLE
Increase the decimal places for displaying SkyBrightness/lux values

### DIFF
--- a/NINA/View/Equipment/WeatherData/WeatherDataView.xaml
+++ b/NINA/View/Equipment/WeatherData/WeatherDataView.xaml
@@ -253,7 +253,7 @@
                                 <TextBlock Text="{ns:Loc LblSkyBrightness}" />
                                 <TextBlock
                                     Margin="5,0,0,0"
-                                    Text="{Binding WeatherDataInfo.SkyBrightness, StringFormat=\{0:0.00\} lx}"
+                                    Text="{Binding WeatherDataInfo.SkyBrightness, StringFormat=\{0:0.00000\} lx}"
                                     TextWrapping="WrapWithOverflow" />
                             </UniformGrid>
                         </UniformGrid>

--- a/NINA/View/Imaging/AnchorableWeatherDataView.xaml
+++ b/NINA/View/Imaging/AnchorableWeatherDataView.xaml
@@ -140,7 +140,7 @@
                         Visibility="{Binding WeatherDataInfo.SkyBrightness, Converter={StaticResource NaNToVisibilityCollapsedConverter}}">
                         <UniformGrid VerticalAlignment="Center" Columns="2">
                             <TextBlock Text="{ns:Loc LblSkyBrightness}" />
-                            <TextBlock Margin="5,0,0,0" Text="{Binding WeatherDataInfo.SkyBrightness, StringFormat=\{0:0.00\} lx}" />
+                            <TextBlock Margin="5,0,0,0" Text="{Binding WeatherDataInfo.SkyBrightness, StringFormat=\{0:0.00000\} lx}" />
                         </UniformGrid>
                     </Border>
                     <Border

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@ This allows you to safely return to a stable release if needed.
 - Clicking on slew Alt/Az in the Mount equipment page with Mount drivers that do not support slewing to Alt/Az, will now fallback to slewing to RA/Dec coordinates instead of doing nothing.
 - The manual focuser step buttons now use configurable multipliers. Users can adjust the small step (default 0.5x) and large step (default 5.0x) multipliers in Options > Imaging > Autofocus.
 - Debayer algorithm has been optimized to work fast even on older CPUs
+- Sky brightness readings in the Weather device windows have been increased from 2 decimal places to 5 so that measurements obtained in low light conditions are adequately displayed.
 
 ## Behavioral Changes
 - Unparking the mount no longer automatically starts sidereal tracking. Tracking will begin automatically during a slew to a target, as usual.


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

User on the ASCOM-Dev list reported that NINA's display of `SkyBrightness`, which is measured in lux, cuts off the displayed value at the usual 2 decimal places. However lux readings can be in the thousandths of lx, necessitating the display of additional decimal places so that it does not display as "0.00 lx". This change increases the display from 2 decimal places to 5.

## 🧪 How Was It Tested?

ObservingConditions simulator

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
