### PR TITLE
Discontinue use of StringBuilder in QhySdk, improve locking a little, and some general cleanups

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -261,13 +261,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
             get {
                 if (internalReconnect) { return tempCoolerPower; }
 
-                double rv = double.NaN;                
+                double rv = double.NaN;
                 if (Connected && CanSetTemperature) {
                     if ((rv = Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_CURPWM)) != QhySdk.QHYCCD_ERROR) {
                         /*
                          * This needs to be returned as a percentage of Info.CoolerPwmMax.
                          */
-                        return (rv / Info.CoolerPwmMax) * 100;
+                        return rv / Info.CoolerPwmMax * 100;
                     }
                 }
 
@@ -290,7 +290,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public IList<string> SupportedActions => [];
 
-        public double ElectronsPerADU => double.NaN;        
+        public double ElectronsPerADU => double.NaN;
 
         /// <summary>
         // We store the camera's exposure times in microseconds
@@ -300,7 +300,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public int Gain {
             get {
-                if(internalReconnect) { return tempGain; }
+                if (internalReconnect) { return tempGain; }
 
                 if (Connected && CanGetGain) {
                     double rv;
@@ -514,7 +514,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             get {
                 if (internalReconnect) { return tempTemperature; }
 
-                double rv = double.NaN;                
+                double rv = double.NaN;
                 if (Connected && Info.HasChipTemp) {
                     if ((rv = Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_CURTEMP)) != QhySdk.QHYCCD_ERROR)
                         return rv;
@@ -706,7 +706,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             } catch (Exception ex) {
                 Logger.Error($"QHYCCD: Cooling thread failed to terminate within {COOLING_TIMEOUT}", ex);
             } finally {
-                try { cts?.Dispose(); } finally { }                
+                try { cts?.Dispose(); } finally { }
                 coolerWorkerCts = null;
                 coolerTask = null;
             }
@@ -931,7 +931,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     /*
                      * Initialize cooler's target temperature to 0C
                      */
-                    if (!internalReconnect) { 
+                    if (!internalReconnect) {
                         Info.CoolerTargetTemp = 0;
                     }
 
@@ -961,7 +961,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                  * it manually using QHYCCD_CAMERA_INFO.CurBin. We initialize the
                  * camera with 1x1 binning.
                  */
-                if (!internalReconnect) { 
+                if (!internalReconnect) {
                     Info.CurBin = 1;
                 }
                 SetBinning(Info.CurBin, Info.CurBin);
@@ -996,14 +996,14 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 QhyHasSensorAirPressure = Sdk.IsControl(QhySdk.CONTROL_ID.CAM_PRESSURE);
                 QhyHasSensorHumidity = Sdk.IsControl(QhySdk.CONTROL_ID.CAM_HUMIDITY);
 
-                if(!internalReconnect) {
+                if (!internalReconnect) {
                     if (QhyHasSensorAirPressure || QhyHasSensorHumidity) {
                         Logger.Debug("QHYCCD: Starting SensorStatsWorker task");
 
                         sensorStatsCts = new CancellationTokenSource();
                         sensorStatsTask = SensorStatsWorker(sensorStatsCts.Token);
                     }
-                }                
+                }
 
                 QhyFirmwareVersion = GetFirmwareVersion();
                 QhyFPGAVersion = GetFPGAVersion();
@@ -1049,7 +1049,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
 
             try {
-                if(!internalReconnect) {
+                if (!internalReconnect) {
                     Connected = false;
                     CancelCoolingSync();
                     CancelSensorStatsSync();
@@ -1117,7 +1117,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     }
                 }
                 if (rv != QhySdk.QHYCCD_SUCCESS) {
-                    Logger.Warning($"QHYCCD: Failed to download image from camera! rv = {rv }");
+                    Logger.Warning($"QHYCCD: Failed to download image from camera! rv = {rv}");
                     throw new CameraDownloadFailedException(Loc.Instance["LblASIImageDownloadError"]);
                 }
 
@@ -1138,7 +1138,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     width: (int)width,
                     height: (int)height,
                     bitDepth: BitDepth,
-                    isBayered: SensorType != SensorType.Monochrome && (BinX == 1 && BinY == 1),
+                    isBayered: SensorType != SensorType.Monochrome && BinX == 1 && BinY == 1,
                     metaData: metaData);
             }, ct);
         }
@@ -1178,8 +1178,8 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 starty = (StartPixelY + (uint)SubSampleY) / (uint)BinY;
                 uint subWidth = Math.Min((uint)SubSampleX + (uint)SubSampleWidth, QhyIncludeOverscan ? (uint)CameraXSize : Info.EffectiveArea.SizeX) - (uint)SubSampleX;
                 uint subHeight = Math.Min((uint)SubSampleY + (uint)SubSampleHeight, QhyIncludeOverscan ? (uint)CameraYSize : Info.EffectiveArea.SizeY) - (uint)SubSampleY;
-                sizex = (uint)subWidth / (uint)BinX;
-                sizey = (uint)subHeight / (uint)BinY;
+                sizex = subWidth / (uint)BinX;
+                sizey = subHeight / (uint)BinY;
             } else {
                 startx = StartPixelX / (uint)BinX;
                 starty = StartPixelY / (uint)BinY;
@@ -1187,8 +1187,8 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     sizex = (uint)CameraXSize / (uint)BinX;
                     sizey = (uint)CameraYSize / (uint)BinY;
                 } else {
-                    sizex = (uint)Info.EffectiveArea.SizeX / (uint)BinX;
-                    sizey = (uint)Info.EffectiveArea.SizeY / (uint)BinY;
+                    sizex = Info.EffectiveArea.SizeX / (uint)BinX;
+                    sizey = Info.EffectiveArea.SizeY / (uint)BinY;
                 }
             }
 
@@ -1209,7 +1209,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public void StartExposure(CaptureSequence sequence) {
             RaiseIfNotConnected();
             uint rv;
-            uint startx, starty, sizex, sizey;
             bool isSnap;
             short readoutMode;
 
@@ -1266,7 +1265,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 }
             }
 
-            if (!SetResolution(out startx, out starty, out sizex, out sizey)) {
+            if (!SetResolution(out _, out _, out uint sizex, out uint sizey)) {
                 return;
             }
 
@@ -1345,7 +1344,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 return;
             }
 
-            if (Sdk.SetBitsMode((uint)16) != QhySdk.QHYCCD_SUCCESS) {
+            if (Sdk.SetBitsMode(16) != QhySdk.QHYCCD_SUCCESS) {
                 CameraState = CameraStates.Error;
                 return;
             }
@@ -1364,8 +1363,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 }
             }
 
-            uint startx, starty, sizex, sizey;
-            if (!SetResolution(out startx, out starty, out sizex, out sizey)) {
+            if (!SetResolution(out _, out _, out uint sizex, out uint sizey)) {
                 Logger.Warning("QHYCCD: Failed to set resolution for video mode");
                 CameraState = CameraStates.Error;
                 return;
@@ -1509,39 +1507,39 @@ namespace NINA.Equipment.Equipment.MyCamera {
             TimeSpan utc_diff = DateTime.UtcNow - now_utc;
             if (Math.Abs(utc_diff.TotalMinutes) > 1) {
                 Logger.Warning("GPS is on, but extracted data is bad.");
-                return; 
+                return;
             }
 
             //PPS count
-            var pps = 256 * 256 * imgData[41] + 256 * imgData[42] + imgData[43];
+            var pps = (256 * 256 * imgData[41]) + (256 * imgData[42]) + imgData[43];
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_PPS", pps, "QHY pps"));
             //Frame number
-            var seqNumber = 256 * 256 * 256 * imgData[0] + 256 * 256 * imgData[1] + 256 * imgData[2] + imgData[3];
+            var seqNumber = (256 * 256 * 256 * imgData[0]) + (256 * 256 * imgData[1]) + (256 * imgData[2]) + imgData[3];
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_SEQ", seqNumber, "QHY sequence nr"));
             //The width of the image
-            var width = 256 * imgData[5] + imgData[6];
+            var width = (256 * imgData[5]) + imgData[6];
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_W", width, "QHY width"));
             //Height of the image
-            var height = 256 * imgData[7] + imgData[8];
+            var height = (256 * imgData[7]) + imgData[8];
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_H", height, "QHY height"));
             //latitude
-            var temp = 256 * 256 * 256 * imgData[9] + 256 * 256 * imgData[10] + 256 * imgData[11] + imgData[12];
+            var temp = (256 * 256 * 256 * imgData[9]) + (256 * 256 * imgData[10]) + (256 * imgData[11]) + imgData[12];
             var south = temp > 1000000000;
-            var deg = (temp % 1000000000) / 10000000;
-            var min = (temp % 10000000) / 100000;
-            var fractMin = (temp % 100000) / 100000.0;
-            var latitude = (deg + (min + fractMin) / 60.0) * (south ? -1 : 1);
+            var deg = temp % 1000000000 / 10000000;
+            var min = temp % 10000000 / 100000;
+            var fractMin = temp % 100000 / 100000.0;
+            var latitude = (deg + ((min + fractMin) / 60.0)) * (south ? -1 : 1);
             metaData.GenericHeaders.Add(new DoubleMetaDataHeader("GPS_LAT", latitude, "latitude"));
             //longitude
-            temp = 256 * 256 * 256 * imgData[13] + 256 * 256 * imgData[14] + 256 * imgData[15] + imgData[16];
+            temp = (256 * 256 * 256 * imgData[13]) + (256 * 256 * imgData[14]) + (256 * imgData[15]) + imgData[16];
             var west = temp > 1000000000;
-            deg = (temp % 1000000000) / 1000000;
-            min = (temp % 1000000) / 10000;
-            fractMin = (temp % 10000) / 10000.0;
-            var longitude = (deg + (min + fractMin) / 60.0) * (west ? -1 : 1);
+            deg = temp % 1000000000 / 1000000;
+            min = temp % 1000000 / 10000;
+            fractMin = temp % 10000 / 10000.0;
+            var longitude = (deg + ((min + fractMin) / 60.0)) * (west ? -1 : 1);
             metaData.GenericHeaders.Add(new DoubleMetaDataHeader("GPS_LON", longitude, "longitude"));
             //Shutter start time
-            var start_flag = (imgData[17] / 16) % 4;
+            var start_flag = imgData[17] / 16 % 4;
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_SFLG", start_flag, "QHY start_flag"));
             metaData.GenericHeaders.Add(new StringMetaDataHeader("GPS_SST", ReceiverStatus(start_flag), "QHY start_flag status"));
             var start_sec = (256 * 256 * 256 * imgData[18]) + (256 * 256 * imgData[19]) + (256 * imgData[20]) + imgData[21];
@@ -1550,7 +1548,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_SUS", start_us, "[us] QHY start"));
             metaData.GenericHeaders.Add(new DateTimeMetaDataHeader("GPS_SUTC", JulianSecToDateTime(start_sec, start_us).ToUniversalTime(), "QHY start_time"));
             //Shutter end time
-            var end_flag = (imgData[25] / 16) % 4;
+            var end_flag = imgData[25] / 16 % 4;
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_EFLG", end_flag, "QHY end_flag"));
             metaData.GenericHeaders.Add(new StringMetaDataHeader("GPS_EST", ReceiverStatus(end_flag), "QHY end_flag status"));
             var end_sec = (256 * 256 * 256 * imgData[26]) + (256 * 256 * imgData[27]) + (256 * imgData[28]) + imgData[29];
@@ -1559,7 +1557,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_EUS", end_us, "[us] QHY end"));
             metaData.GenericHeaders.Add(new DateTimeMetaDataHeader("GPS_EUTC", JulianSecToDateTime(end_sec, end_us).ToUniversalTime(), "QHY end_time"));
             //The current time
-            var now_flag = (imgData[33] / 16) % 4;
+            var now_flag = imgData[33] / 16 % 4;
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_NFLG", now_flag, "QHY now_flag"));
             metaData.GenericHeaders.Add(new StringMetaDataHeader("GPS_NST", ReceiverStatus(now_flag), "QHY now_flag status"));
             metaData.GenericHeaders.Add(new IntMetaDataHeader("GPS_NSEC", now_sec, "[s] QHY now"));

--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -31,7 +31,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,30 +52,31 @@ namespace NINA.Equipment.Equipment.MyCamera {
         private readonly IExposureDataFactory exposureDataFactory;
         private CancellationTokenSource downloadExposureTaskCTS;
         private Task<IExposureData> downloadExposureTask;
+
         public IQhySdk Sdk { get; set; } = QhySdk.Instance;
 
         public QHYCamera(uint cameraIdx, IProfileService profileService, IExposureDataFactory exposureDataFactory) {
             this.profileService = profileService;
             this.exposureDataFactory = exposureDataFactory;
 
-            var cameraId = new StringBuilder(QhySdk.QHYCCD_ID_LEN);
-            var cameraModel = new StringBuilder(0);
+            var cameraId = string.Empty;
+            var cameraModel = string.Empty;
 
             /*
              * Camera model long form, eg: "QHY183C-c915484fa76ea7552"
              * The QHY SDK uses this to internally identify connected cameras
              * and this we need this to create a handle for our camera.
              */
-            Sdk.GetId(cameraIdx, cameraId);
+            Sdk.GetId(cameraIdx, out cameraId);
 
             /*
              * Camera model short form, eg: "QHY183C"
              * We use this to put in the camera equipment selection menu
              * rather than the long form above.
              */
-            Sdk.GetModel(cameraId, cameraModel);
+            Sdk.GetModel(cameraId, out cameraModel);
 
-            Name = cameraModel.ToString();
+            Name = cameraModel;
             Info.Index = cameraIdx;
             Info.Id = cameraId;
 
@@ -275,7 +275,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
         }
 
-        public string Description => Info.Id.ToString();
+        public string Description => Info.Id;
 
         public bool DewHeaterOn {
             get => false;
@@ -350,9 +350,9 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public short MaxBinY => MaxBinX;
 
         public string Name {
-            get => Info.Model.ToString();
+            get => Info.Model;
             set {
-                Info.Model = new StringBuilder(value);
+                Info.Model = value;
                 RaiseAllPropertiesChanged();
             }
         }
@@ -754,8 +754,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             var success = false;
             double min = 0, max = 0, step = 0;
             var modeList = new List<string>();
-            var cameraID = new StringBuilder(QhySdk.QHYCCD_ID_LEN);
-            var modeName = new StringBuilder(0);
+            var cameraID = string.Empty;
             uint num_modes = 0;
             Info.HasReadoutSpeed = false;
 
@@ -769,7 +768,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 /*
                  * Get our selected camera's ID from the SDK
                  */
-                Sdk.GetId(Info.Index, cameraID);
+                Sdk.GetId(Info.Index, out cameraID);
 
                 /*
                  * CameraP is the handle we use to reference this camera
@@ -837,9 +836,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
                      */
                     if (num_modes > 1) {
                         for (uint i = 0; i < num_modes; i++) {
-                            ThrowOnFailure("GetQHYCCDReadModeName", Sdk.GetReadModeName(i, modeName));
+                            string modeName = string.Empty;
+                            ThrowOnFailure("GetQHYCCDReadModeName", Sdk.GetReadModeName(i, out modeName));
                             Logger.Debug($"QHYCCD: Found readout mode \"{modeName}\"");
-                            modeList.Add(modeName.ToString());
+                            modeList.Add(modeName);
                         }
                     }
                 }

--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -125,7 +125,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public AsyncObservableCollection<BinningMode> BinningModes {
             get {
                 if (_binningModes == null) {
-                    _binningModes = new AsyncObservableCollection<BinningMode>();
+                    _binningModes = [];
                     foreach (int f in SupportedBinFactors) {
                         /*
                          * QHY cameras are known to support only symmetrical bin modes
@@ -288,7 +288,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public bool EnableSubSample { get; set; }
         public double ExposureMax => Info.ExpMax / 1e6;
 
-        public IList<string> SupportedActions => new List<string>();
+        public IList<string> SupportedActions => [];
 
         public double ElectronsPerADU => double.NaN;        
 
@@ -327,7 +327,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public int GainMax => Info.GainMax;
         public int GainMin => Info.GainMin;
-        public IList<int> Gains => new List<int>();
+        public IList<int> Gains => [];
         public bool HasBattery => false;
         public bool HasDewHeater => false;
         public bool HasSetupDialog => false;

--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -1116,7 +1116,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                         ImgData[i] = ImgDataBytes[i];
                     }
                 }
-                if (rv != QhySdk.QHYCCD_SUCCESS) {
+                if (rv != QhySdk.QHYCCD_SUCCESS && !ct.IsCancellationRequested) {
                     Logger.Warning($"QHYCCD: Failed to download image from camera! rv = {rv}");
                     throw new CameraDownloadFailedException(Loc.Instance["LblASIImageDownloadError"]);
                 }

--- a/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
@@ -38,11 +38,11 @@ namespace NINA.Equipment.Equipment.MyFilterWheel {
         public QHYFilterWheel(string fwheel, IProfileService profileService) {
             this.profileService = profileService;
 
-            StringBuilder FWheelId = new StringBuilder(32);
-            StringBuilder cameraModel = new StringBuilder(0);
+            string FWheelId;
+            var cameraModel = string.Empty;
 
-            FWheelId.Append(fwheel);
-            Sdk.GetModel(FWheelId, cameraModel);
+            FWheelId = fwheel;
+            Sdk.GetModel(FWheelId, out cameraModel);
 
             Info.Id = FWheelId;
             Sdk.Open(Info.Id);
@@ -91,14 +91,13 @@ namespace NINA.Equipment.Equipment.MyFilterWheel {
             }
         }
 
-        public string Id => Info.Id.ToString();
+        public string Id => Info.Id;
         public string Name => Info.Name;
         public string DisplayName => Name;
         public string Category => "QHYCCD";
         public string Description => string.Format($"Integrated or 4-pin Filter Wheel on {Info.Id}");
         public string DriverInfo => "Native driver for QHY integrated or 4-pin filter wheels";
         public string DriverVersion => "1.0";
-        public short InterfaceVersion => 1;
 
         public int[] FocusOffsets => this.Filters.Select((x) => x.FocusOffset).ToArray();
 

--- a/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
@@ -12,25 +12,25 @@
 
 #endregion "copyright"
 
-using NINA.Profile.Interfaces;
+using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Utility;
+using NINA.Profile.Interfaces;
 using QHYCCD;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NINA.Core.Model.Equipment;
-using NINA.Equipment.Interfaces;
-using System.Collections.Generic;
-using System;
-using NINA.Equipment.Utility;
 
 namespace NINA.Equipment.Equipment.MyFilterWheel {
 
     public class QHYFilterWheel : BaseINPC, IFilterWheel {
         private QhySdk.QHYCCD_FILTER_WHEEL_INFO Info;
         private bool _connected = false;
-        private IProfileService profileService;
+        private readonly IProfileService profileService;
         private bool moveRequested = false;
         private string destinationPostition = string.Empty;
         public IQhySdk Sdk { get; set; } = QhySdk.Instance;
@@ -164,7 +164,7 @@ namespace NINA.Equipment.Equipment.MyFilterWheel {
             Sdk.ReleaseSdk();
         }
 
-        private object lockObj = new object();
+        private readonly object lockObj = new object();
         public AsyncObservableCollection<FilterInfo> Filters {
             get {
                 lock (lockObj) {

--- a/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/QHYFilterWheel.cs
@@ -154,7 +154,7 @@ namespace NINA.Equipment.Equipment.MyFilterWheel {
             }
         }
 
-        public IList<string> SupportedActions => new List<string>();
+        public IList<string> SupportedActions => [];
 
         public void Disconnect() {
             Logger.Debug($"QHYCFW: Closing filter wheel {Name}");

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/IQhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/IQhyccdSdk.cs
@@ -121,7 +121,7 @@ namespace QHYCCD {
         void SetQHYCCDGPSPOSB(uint pos, byte width);
 
         uint GetQHYCCDPreciseExposureInfo(ref uint pixelPeriod, ref uint linePeriod, ref uint framePeriod, ref uint clocksPerLine, ref uint linesPerFrame, ref uint actualExposureTime, ref byte isLongExposureMode);
-        
+
         uint GetQHYCCDRollingShutterEndOffset(uint row, ref double offset);
     }
 }

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/IQhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/IQhyccdSdk.cs
@@ -12,9 +12,7 @@
 
 #endregion "copyright"
 
-using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace QHYCCD {
 
@@ -24,7 +22,7 @@ namespace QHYCCD {
 
         void ReleaseSdk();
 
-        void Open(StringBuilder id);
+        void Open(string id);
 
         void Close();
 
@@ -46,15 +44,15 @@ namespace QHYCCD {
 
         uint GetNumberOfReadModes(ref uint numModes);
 
-        uint GetReadModeName(uint mode, StringBuilder modeName);
+        uint GetReadModeName(uint mode, out string modeName);
 
         uint ControlTemp(double targetTemp);
 
         uint ControlShutter(byte shutterState);
 
-        void GetId(uint index, StringBuilder id);
+        void GetId(uint index, out string id);
 
-        void GetModel(StringBuilder id, StringBuilder model);
+        void GetModel(string id, out string model);
 
         uint GetParamMinMaxStep(QhySdk.CONTROL_ID controlId, ref double min, ref double max, ref double step);
 

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QHYFilterWheels.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QHYFilterWheels.cs
@@ -14,7 +14,6 @@
 
 using NINA.Core.Utility;
 using System.Collections.Generic;
-using System.Text;
 
 namespace QHYCCD {
 
@@ -22,9 +21,8 @@ namespace QHYCCD {
         public IQhySdk Sdk { get; set; } = QhySdk.Instance;
 
         public List<string> GetFilterWheels() {
-            StringBuilder cameraId = new StringBuilder(QhySdk.QHYCCD_ID_LEN);
-            StringBuilder cameraModel = new StringBuilder(0);
-            List<string> FWheels = new List<string>();
+            var cameraId = string.Empty;
+            var FWheels = new List<string>();
             uint positions;
             uint num;
 
@@ -36,9 +34,7 @@ namespace QHYCCD {
 
             if ((num = Sdk.Scan()) > 0) {
                 for (uint i = 0; i < num; i++) {
-                    Sdk.GetId(i, cameraId);
-                    Sdk.GetModel(cameraId, cameraModel);
-
+                    Sdk.GetId(i, out cameraId);
                     Sdk.Open(cameraId);
 
                     if (Sdk.IsCfwPlugged()) {

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -593,7 +593,7 @@ namespace QHYCCD {
             CONTROL_SPEED,
 
             /// <summary>
-            /// Bit depth of the image retreieved from the camera
+            /// Bit depth of the image retreived from the camera
             /// </summary>
             CONTROL_TRANSFERBIT,
 

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -68,7 +68,7 @@ namespace QHYCCD {
             }
         }
 
-        public void Open(StringBuilder id) {
+        public void Open(string id) {
             lock (lockobj) {
                 Logger.Trace($"QhyccdSdk: Opening {id}, refCount={refCount}");
 
@@ -153,9 +153,17 @@ namespace QHYCCD {
             }
         }
 
-        public uint GetReadModeName(uint mode, StringBuilder modeName) {
+        public uint GetReadModeName(uint mode, out string modeName) {
             lock (lockobj) {
-                return GetQHYCCDReadModeName(handle, mode, modeName);
+                modeName = string.Empty;
+                byte[] buffer = new byte[QHYCCD_READMODE_NAME_LEN];
+                uint result = GetQHYCCDReadModeName(handle, mode, buffer);
+
+                if (result == QHYCCD_SUCCESS) {
+                    modeName = NullTerminatedBytesToString(buffer);
+                }
+
+                return result;
             }
         }
 
@@ -171,15 +179,27 @@ namespace QHYCCD {
             }
         }
 
-        public void GetId(uint index, StringBuilder id) {
+        public void GetId(uint index, out string id) {
             lock (lockobj) {
-                CheckReturn(GetQHYCCDId(index, id), MethodBase.GetCurrentMethod(), index, new object[] { id });
+                id = string.Empty;
+                byte[] buffer = new byte[QHYCCD_ID_LEN];
+
+                uint result = GetQHYCCDId(index, buffer);
+                CheckReturn(result, MethodBase.GetCurrentMethod(), index, new object[] { id });
+
+                id = NullTerminatedBytesToString(buffer);
             }
         }
 
-        public void GetModel(StringBuilder id, StringBuilder model) {
+        public void GetModel(string id, out string model) {
             lock (lockobj) {
-                CheckReturn(GetQHYCCDModel(id, model), MethodBase.GetCurrentMethod(), new object[] { model });
+                model = string.Empty;
+                byte[] modelBuffer = new byte[QHYCCD_MODEL_LEN];
+
+                uint result = GetQHYCCDModel(id, modelBuffer);
+                CheckReturn(result, MethodBase.GetCurrentMethod(), new object[] { model });
+
+                model = NullTerminatedBytesToString(modelBuffer);
             }
         }
 
@@ -442,6 +462,12 @@ namespace QHYCCD {
             lock (lockobj) {
                 return GetQHYCCDRollingShutterEndOffset(handle, row, ref offset);
             }
+        }
+
+        private static string NullTerminatedBytesToString(byte[] buffer) {
+            int length = Array.IndexOf(buffer, (byte)0);
+            if (length < 0) length = buffer.Length;
+            return Encoding.ASCII.GetString(buffer, 0, length);
         }
 
         #endregion Utility Methods
@@ -1063,10 +1089,10 @@ namespace QHYCCD {
         private static extern unsafe uint GetQHYCCDFWVersion(IntPtr handle, [Out] byte[] verBuf);
 
         [DllImport(DLLNAME, EntryPoint = "GetQHYCCDId", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private static extern unsafe uint GetQHYCCDId(uint index, StringBuilder id);
+        private static extern unsafe uint GetQHYCCDId(uint index, [Out] byte[] idBuf);
 
         [DllImport(DLLNAME, EntryPoint = "GetQHYCCDModel", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private static extern unsafe uint GetQHYCCDModel(StringBuilder id, StringBuilder model);
+        private static extern unsafe uint GetQHYCCDModel(string id, [Out] byte[] modelBuf);
 
         [DllImport(DLLNAME, EntryPoint = "GetQHYCCDParam", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
         private static extern unsafe double GetQHYCCDParam(IntPtr handle, CONTROL_ID controlid);
@@ -1081,7 +1107,7 @@ namespace QHYCCD {
         private static extern unsafe uint GetQHYCCDReadModeResolution(IntPtr handle, uint mode, ref uint width, ref uint height);
 
         [DllImport(DLLNAME, EntryPoint = "GetQHYCCDReadModeName", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private static extern unsafe uint GetQHYCCDReadModeName(IntPtr handle, uint mode, StringBuilder mode_name);
+        private static extern unsafe uint GetQHYCCDReadModeName(IntPtr handle, uint mode, [Out] byte[] nameBuf);
 
         [DllImport(DLLNAME, EntryPoint = "GetQHYCCDReadMode", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
         private static extern unsafe uint GetQHYCCDReadMode(IntPtr handle, ref uint mode);
@@ -1106,7 +1132,7 @@ namespace QHYCCD {
         private static extern unsafe uint IsQHYCCDControlAvailable(IntPtr handle, CONTROL_ID controlid);
 
         [DllImport(DLLNAME, EntryPoint = "OpenQHYCCD", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private static extern unsafe IntPtr OpenQHYCCD(StringBuilder id);
+        private static extern IntPtr OpenQHYCCD(string id);
 
         [DllImport(DLLNAME, EntryPoint = "ReleaseQHYCCDResource", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
         private static extern unsafe uint ReleaseQHYCCDResource();
@@ -1205,6 +1231,16 @@ namespace QHYCCD {
         /// model number and serial number, currently not to exceed 32 characters in length.
         /// </summary>
         public const int QHYCCD_ID_LEN = 32;
+
+        /// <summary>
+        /// Specifies the maximum length, in characters, for a QHYCCD model name.
+        /// </summary>
+        public const int QHYCCD_MODEL_LEN = 256;
+
+        /// <summary>
+        /// Specifies the maximum length, in characters, for a QHYCCD readout mode name.
+        /// </summary>
+        public const int QHYCCD_READMODE_NAME_LEN = 256;
 
         /// <summary>
         /// Values for tracking the current camera state within NINA
@@ -1377,7 +1413,7 @@ namespace QHYCCD {
             /// <summary>
             /// The camera's model name, including unique identifier
             /// </summary>
-            public StringBuilder Id;
+            public string Id;
 
             /// <summary>
             /// Image array size (bytes)
@@ -1403,7 +1439,7 @@ namespace QHYCCD {
             /// <summary>
             /// The camera's model name
             /// </summary>
-            public StringBuilder Model;
+            public string Model;
 
             /// <summary>
             /// Maximum sensor offset
@@ -1553,7 +1589,7 @@ namespace QHYCCD {
             /// <summary>
             /// The filter wheel's unique name
             /// </summary>
-            public StringBuilder Id;
+            public string Id;
 
             /// <summary>
             /// The filter wheel's full name, including camera model name

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -137,9 +137,7 @@ namespace QHYCCD {
         }
 
         public uint GetReadMode(ref uint mode) {
-            lock (lockobj) {
-                return GetQHYCCDReadMode(handle, ref mode);
-            }
+            return GetQHYCCDReadMode(handle, ref mode);
         }
 
         public uint SetReadMode(uint mode) {
@@ -149,23 +147,19 @@ namespace QHYCCD {
         }
 
         public uint GetNumberOfReadModes(ref uint numModes) {
-            lock (lockobj) {
-                return GetQHYCCDNumberOfReadModes(handle, ref numModes);
-            }
+            return GetQHYCCDNumberOfReadModes(handle, ref numModes);
         }
 
         public uint GetReadModeName(uint mode, out string modeName) {
-            lock (lockobj) {
-                modeName = string.Empty;
-                byte[] buffer = new byte[QHYCCD_READMODE_NAME_LEN];
-                uint result = GetQHYCCDReadModeName(handle, mode, buffer);
+            modeName = string.Empty;
+            byte[] buffer = new byte[QHYCCD_READMODE_NAME_LEN];
+            uint result = GetQHYCCDReadModeName(handle, mode, buffer);
 
-                if (result == QHYCCD_SUCCESS) {
-                    modeName = NullTerminatedBytesToString(buffer);
-                }
-
-                return result;
+            if (result == QHYCCD_SUCCESS) {
+                modeName = NullTerminatedBytesToString(buffer);
             }
+
+            return result;
         }
 
         public uint ControlTemp(double targetTemp) {
@@ -181,27 +175,23 @@ namespace QHYCCD {
         }
 
         public void GetId(uint index, out string id) {
-            lock (lockobj) {
-                id = string.Empty;
-                byte[] buffer = new byte[QHYCCD_ID_LEN];
+            id = string.Empty;
+            byte[] buffer = new byte[QHYCCD_ID_LEN];
 
-                uint result = GetQHYCCDId(index, buffer);
-                CheckReturn(result, MethodBase.GetCurrentMethod(), index, new object[] { id });
+            uint result = GetQHYCCDId(index, buffer);
+            CheckReturn(result, MethodBase.GetCurrentMethod(), index, new object[] { id });
 
-                id = NullTerminatedBytesToString(buffer);
-            }
+            id = NullTerminatedBytesToString(buffer);
         }
 
         public void GetModel(string id, out string model) {
-            lock (lockobj) {
-                model = string.Empty;
-                byte[] modelBuffer = new byte[QHYCCD_MODEL_LEN];
+            model = string.Empty;
+            byte[] modelBuffer = new byte[QHYCCD_MODEL_LEN];
 
-                uint result = GetQHYCCDModel(id, modelBuffer);
-                CheckReturn(result, MethodBase.GetCurrentMethod(), new object[] { model });
+            uint result = GetQHYCCDModel(id, modelBuffer);
+            CheckReturn(result, MethodBase.GetCurrentMethod(), new object[] { model });
 
-                model = NullTerminatedBytesToString(modelBuffer);
-            }
+            model = NullTerminatedBytesToString(modelBuffer);
         }
 
         public uint GetParamMinMaxStep(CONTROL_ID controlId, ref double min, ref double max, ref double step) {
@@ -211,15 +201,11 @@ namespace QHYCCD {
         }
 
         public uint GetChipInfo(ref double chipW, ref double chipH, ref uint imageX, ref uint imageY, ref double pixelX, ref double pixelY, ref uint bpp) {
-            lock (lockobj) {
-                return GetQHYCCDChipInfo(handle, ref chipW, ref chipH, ref imageX, ref imageY, ref pixelX, ref pixelY, ref bpp);
-            }
+            return GetQHYCCDChipInfo(handle, ref chipW, ref chipH, ref imageX, ref imageY, ref pixelX, ref pixelY, ref bpp);
         }
 
         public uint GetEffectiveArea(ref uint startX, ref uint startY, ref uint imageX, ref uint imageY) {
-            lock (lockobj) {
-                return GetQHYCCDEffectiveArea(handle, ref startX, ref startY, ref imageX, ref imageY);
-            }
+            return GetQHYCCDEffectiveArea(handle, ref startX, ref startY, ref imageX, ref imageY);
         }
 
         public uint SetResolution(uint x, uint y, uint xSize, uint ySize) {
@@ -253,15 +239,11 @@ namespace QHYCCD {
         }
 
         public uint GetExposureRemaining() {
-            lock (lockobj) {
-                return GetQHYCCDExposureRemaining(handle);
-            }
+            return GetQHYCCDExposureRemaining(handle);
         }
 
         public uint GetPressure(ref double hpa) {
-            lock (lockobj) {
-                return GetQHYCCDPressure(handle, ref hpa);
-            }
+            return GetQHYCCDPressure(handle, ref hpa);
         }
 
         public uint GetHumidity(ref double rh) {
@@ -271,19 +253,15 @@ namespace QHYCCD {
         }
 
         public bool IsCfwPlugged() {
-            lock (lockobj) {
-                if (IsQHYCCDCFWPlugged(handle) == QHYCCD_SUCCESS) {
-                    return true;
-                }
-
-                return false;
+            if (IsQHYCCDCFWPlugged(handle) == QHYCCD_SUCCESS) {
+                return true;
             }
+
+            return false;
         }
 
         public uint GetCfwStatus(byte[] status) {
-            lock (lockobj) {
-                return GetQHYCCDCFWStatus(handle, status);
-            }
+            return GetQHYCCDCFWStatus(handle, status);
         }
 
         public uint SendOrderToCfw(string order, int length) {

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -21,13 +21,14 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 namespace QHYCCD {
 
     public class QhySdk : IQhySdk {
         private const string DLLNAME = "qhyccd.dll";
 
-        private readonly object lockobj = new object();
+        private readonly Lock lockobj = new();
         private IntPtr handle = IntPtr.Zero;
 
         private bool sdkIsInitialized = false;


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

Reports and direct experience of a hard crash in NINA when connecting to a QH600 camera with 3.3 nightly build 12. This crash did not happen when connecting to a QHY268M or QHY183M. It did happen with a QHY600M-Pro and QHY600M-PH. Looking at the dmp file, the crashing thread was getting the readout mode names from the SDK. My suspicions turned to StringBuilder, which is involved in all string-related exchanges with the SDK. For some reason, one of the readout mode names specific to the QHY600 was causing .NET 10 to crash NINA with:

```
Faulting application name: NINA.exe, version: 3.3.0.1012, time stamp: 0x69760000
Faulting module name: coreclr.dll, version: 10.0.326.7603, time stamp: 0x69764c44
Exception code: 0xc0000409
Fault offset: 0x000000000014b4ad
```

Realizing that `StringBuilder` could be a problem here for a variety of reasons, I tested a fix that replaced it with `byte[]` and the crash no longer happened. I expanded this replacement to remove all uses of `StringBuilder` in the native driver. 

While doing this work, I performed some code cleanups for formatting and casts, and switched locking to use the new(er) `System.Threading.Lock` facility. 

In addition to that, I quelled a feral image download error that could appear during high-rate imaging.

## 🧪 How Was It Tested?

QHY600M-Pro, QHY600M-PH, QHY268M-PH, and QHY183M

## ✅ PR Checklist

- [ ] All unit tests pass

Unrelated failure:
```
ExternalScript_Execute_SetsExitCodeSymbol_OnNonZeroExit
   Source: ExternalScriptTest.cs line 180
   Duration: 8.4 sec

  Message: 
Expected capturedExitCode to be 42, but found -1073741502 (difference of -1073741544).

  Stack Trace: 
LateBoundTestFramework.Throw(String message)
TestFrameworkProvider.Throw(String message)
DefaultAssertionStrategy.HandleFailure(String message)
NumericAssertions`2.Be(T expected, String because, Object[] becauseArgs)
ExternalScriptTest.ExternalScript_Execute_SetsExitCodeSymbol_OnNonZeroExit() line 207
AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
TestMethodCommand.Execute(TestExecutionContext context)
DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)

  Standard Output: 
2026-03-02T22:58:12.7572|INFO|ExternalScript.cs|Execute|141|External Script, script = C:\WINDOWS\System32\cmd.exe /c exit 42, processed script = C:\WINDOWS\System32\cmd.exe /c exit 42
2026-03-02T22:58:12.7575|INFO|ExternalScript.cs|RunCommand|208|Running - 'C:\WINDOWS\System32\cmd.exe' with args '/c exit 42'

```
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
