### PR TITLE
SBIGCamera: Set ElectronsPerADU so that the EGAIN header populates with valid data

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
@@ -231,6 +231,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             PixelSizeY = unbinnedMode.Value.PixelHeightMicrons;
             CameraXSize = unbinnedMode.Value.Width;
             CameraYSize = unbinnedMode.Value.Height;
+            ElectronsPerADU = unbinnedMode.Value.ElectronsPerAdu;
 
             // For simplicity, only support on chip 2x2 and 3x3 binning modes
             // If there's user demand we could enable off chip, non-square, and greater than 3 binning modes
@@ -440,7 +441,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
         }
 
-        private double _electronsPerADU;
+        private double _electronsPerADU = double.NaN;
 
         public double ElectronsPerADU {
             get => _electronsPerADU;

--- a/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/SBIGCamera.cs
@@ -27,11 +27,8 @@ using NINA.Image.ImageData;
 using NINA.Image.Interfaces;
 using NINA.Profile.Interfaces;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -48,7 +45,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public SBIGCamera(ISbigSdk sdk, SBIG.CCD exposureCcd, DeviceQueryInfo queriedCameraInfo, IProfileService profileService, IExposureDataFactory exposureDataFactory) {
             this.sdk = sdk;
             this.exposureCcd = exposureCcd;
-            this.BinningModes = new AsyncObservableCollection<BinningMode>();
+            this.BinningModes = [];
             this.queriedCameraInfo = queriedCameraInfo;
             this.profileService = profileService;
             this.exposureDataFactory = exposureDataFactory;
@@ -399,7 +396,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public bool HasDewHeater => false;
 
-        public IList<string> SupportedActions => new List<string>();
+        public IList<string> SupportedActions => [];
 
         private SBIGCameraStatus _cameraStatus = SBIGCameraStatus.IDLE;
 
@@ -414,39 +411,14 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
         }
 
-        public CameraStates CameraState {
-            get {
-                CameraStates cameraState;
-
-                switch (CameraStatus) {
-                    case SBIGCameraStatus.EXPOSING:
-                        cameraState = CameraStates.Exposing;
-                        break;
-
-                    case SBIGCameraStatus.DOWNLOAD:
-                        cameraState = CameraStates.Download;
-                        break;
-
-                    case SBIGCameraStatus.WAITING:
-                        cameraState = CameraStates.Waiting;
-                        break;
-
-                    case SBIGCameraStatus.ERROR:
-                        cameraState = CameraStates.Error;
-                        break;
-
-                    case SBIGCameraStatus.IDLE:
-                        cameraState = CameraStates.Idle;
-                        break;
-
-                    default:
-                        cameraState = CameraStates.NoState;
-                        break;
-                }
-
-                return cameraState;
-            }
-        }
+        public CameraStates CameraState => CameraStatus switch {
+            SBIGCameraStatus.EXPOSING => CameraStates.Exposing,
+            SBIGCameraStatus.DOWNLOAD => CameraStates.Download,
+            SBIGCameraStatus.WAITING => CameraStates.Waiting,
+            SBIGCameraStatus.ERROR => CameraStates.Error,
+            SBIGCameraStatus.IDLE => CameraStates.Idle,
+            _ => CameraStates.NoState,
+        };
 
         public bool CanSubSample => true;
         public bool EnableSubSample { get; set; }
@@ -481,7 +453,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
         }
 
-        public IList<string> ReadoutModes => new List<string>() { "Default" };
+        public IList<string> ReadoutModes => ["Default"];
 
         public short ReadoutMode {
             get => 0;
@@ -839,7 +811,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public int Gain { get => -1; set => throw new InvalidOperationException(); }
 
-        public IList<int> Gains => new List<int>() { };
+        public IList<int> Gains => [];
 
         public bool DewHeaterOn { get => false; set => throw new InvalidOperationException(); }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,7 +25,7 @@ This allows you to safely return to a stable release if needed.
 - Autofocus after HFR Increase HFRTrendPercentage is now calculated correctly and will no longer underestimate the change on large HFR drift
 - ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
 - When updating the application, the color schema upgrades now properly apply updated or added colors
-- The native driver for SBIG cameras now provides the proper electrons/ADU value in for the `EGAIN` keyword in image metadata
+- The native driver for SBIG cameras now provides the proper electrons/ADU value for the `EGAIN` keyword in image metadata
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ This allows you to safely return to a stable release if needed.
 - Autofocus after HFR Increase HFRTrendPercentage is now calculated correctly and will no longer underestimate the change on large HFR drift
 - ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
 - When updating the application, the color schema upgrades now properly apply updated or added colors
+- The native driver for SBIG cameras now provides the proper electrons/ADU value in for the `EGAIN` keyword in image metadata
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

User reported that the SBIGCamera driver didn't set its `ElectronsPerADU` property with info from the SBIG SDK. The backing variable for `ElectronsPerADU` was also uninitialized, leading to a an erroneous `EGAIN` value of `0` being inserted into image metadata. This PR updates some code patterns and fixes this issue by getting the e/ADU value from the SDK's ReadoutMode struct and setting the `ElectronsPerADU` property with it.

## 🧪 How Was It Tested?

With an ST-8300M camera

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [X] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
