### PR TITLE
Fix excessive debug logging after disconnecting the OpenMeteo client

### DIFF
--- a/NINA.Equipment/Equipment/MyWeatherData/OpenMeteo.cs
+++ b/NINA.Equipment/Equipment/MyWeatherData/OpenMeteo.cs
@@ -169,31 +169,20 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
         }
 
         private async Task UpdateWorker(CancellationToken ct) {
-            try 
-            {
-                while (true) 
-                {
-                    try 
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(_queryPeriod), ct);
-                        await QueryWeather();
-                    }
-                    catch (Exception e) 
-                    {
-                        Logger.Debug($"OpenMeteo: Exception during update: {e.ToString()}");
-                    }
+            try {
+                while (true) {
+                    await Task.Delay(TimeSpan.FromSeconds(_queryPeriod), ct);
+                    await QueryWeather();
                 }
-                
-            } 
-            catch (OperationCanceledException)
-            {
+            } catch (OperationCanceledException) {
                 Logger.Debug("OpenMeteo: Update task cancelled");
                 throw;
-            } 
+            } catch (Exception e) {
+                Logger.Debug($"OpenMeteo: Exception during update: {e.ToString()}");
+            }
         }
 
-        private async Task QueryWeather()
-        {
+        private async Task QueryWeather() {
             var latitude = profileService.ActiveProfile.AstrometrySettings.Latitude;
             var longitude = profileService.ActiveProfile.AstrometrySettings.Longitude;
 
@@ -209,7 +198,7 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
             Temperature = data.Current.Temperature;
             Pressure = data.Current.SurfacePressure;
             Humidity = data.Current.Humidity;
-            
+
             WindDirection = data.Current.WindDirection;
             WindSpeed = ConvertKilometerPerHourToMeterPerSecond(data.Current.WindSpeed);
             WindGust = ConvertKilometerPerHourToMeterPerSecond(data.Current.WindGusts);
@@ -219,8 +208,7 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
             RainRate = data.Current.Precipitation;
         }
 
-        private double ConvertKilometerPerHourToMeterPerSecond(double kmh)
-        {
+        private double ConvertKilometerPerHourToMeterPerSecond(double kmh) {
             return kmh * 0.277778;
         }
 
@@ -270,7 +258,7 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
         public void SendCommandBlind(string command, bool raw) {
             throw new NotImplementedException();
         }
-        
+
         public class OpenMeteoDataResponse {
 
             [JsonProperty(PropertyName = "current")]
@@ -280,10 +268,10 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
 
                 [JsonProperty(PropertyName = "temperature_2m")]
                 public double Temperature { get; set; } //degree celcius
-                
+
                 [JsonProperty(PropertyName = "surface_pressure")]
                 public double SurfacePressure { get; set; } //hPa
-                
+
                 [JsonProperty(PropertyName = "relative_humidity_2m")]
                 public double Humidity { get; set; } //percentage
 
@@ -292,13 +280,13 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
 
                 [JsonProperty(PropertyName = "cloud_cover")]
                 public double CloudCover { get; set; } //percentage
-                                
+
                 [JsonProperty(PropertyName = "wind_direction_10m")]
                 public double WindDirection { get; set; } // degree
 
                 [JsonProperty(PropertyName = "wind_speed_10m")]
                 public double WindSpeed { get; set; } // km/h
-                
+
                 [JsonProperty(PropertyName = "wind_gusts_10m")]
                 public double WindGusts { get; set; } // km/h
             }

--- a/NINA.Equipment/Equipment/MyWeatherData/OpenMeteo.cs
+++ b/NINA.Equipment/Equipment/MyWeatherData/OpenMeteo.cs
@@ -169,20 +169,27 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
         }
 
         private async Task UpdateWorker(CancellationToken ct) {
-            try {
-                while (true) {
+            while (true) 
+            {
+                try 
+                {
                     await Task.Delay(TimeSpan.FromSeconds(_queryPeriod), ct);
                     await QueryWeather();
+                } 
+                catch (OperationCanceledException) 
+                {
+                    Logger.Debug("OpenMeteo: Update task cancelled");
+                    throw;
+                } 
+                catch (Exception e) 
+                {
+                    Logger.Debug($"OpenMeteo: Exception during update: {e.ToString()}");
                 }
-            } catch (OperationCanceledException) {
-                Logger.Debug("OpenMeteo: Update task cancelled");
-                throw;
-            } catch (Exception e) {
-                Logger.Debug($"OpenMeteo: Exception during update: {e.ToString()}");
             }
         }
 
-        private async Task QueryWeather() {
+        private async Task QueryWeather()
+        {
             var latitude = profileService.ActiveProfile.AstrometrySettings.Latitude;
             var longitude = profileService.ActiveProfile.AstrometrySettings.Longitude;
 
@@ -198,7 +205,7 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
             Temperature = data.Current.Temperature;
             Pressure = data.Current.SurfacePressure;
             Humidity = data.Current.Humidity;
-
+            
             WindDirection = data.Current.WindDirection;
             WindSpeed = ConvertKilometerPerHourToMeterPerSecond(data.Current.WindSpeed);
             WindGust = ConvertKilometerPerHourToMeterPerSecond(data.Current.WindGusts);
@@ -208,7 +215,8 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
             RainRate = data.Current.Precipitation;
         }
 
-        private double ConvertKilometerPerHourToMeterPerSecond(double kmh) {
+        private double ConvertKilometerPerHourToMeterPerSecond(double kmh)
+        {
             return kmh * 0.277778;
         }
 
@@ -258,7 +266,7 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
         public void SendCommandBlind(string command, bool raw) {
             throw new NotImplementedException();
         }
-
+        
         public class OpenMeteoDataResponse {
 
             [JsonProperty(PropertyName = "current")]
@@ -268,10 +276,10 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
 
                 [JsonProperty(PropertyName = "temperature_2m")]
                 public double Temperature { get; set; } //degree celcius
-
+                
                 [JsonProperty(PropertyName = "surface_pressure")]
                 public double SurfacePressure { get; set; } //hPa
-
+                
                 [JsonProperty(PropertyName = "relative_humidity_2m")]
                 public double Humidity { get; set; } //percentage
 
@@ -280,13 +288,13 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
 
                 [JsonProperty(PropertyName = "cloud_cover")]
                 public double CloudCover { get; set; } //percentage
-
+                                
                 [JsonProperty(PropertyName = "wind_direction_10m")]
                 public double WindDirection { get; set; } // degree
 
                 [JsonProperty(PropertyName = "wind_speed_10m")]
                 public double WindSpeed { get; set; } // km/h
-
+                
                 [JsonProperty(PropertyName = "wind_gusts_10m")]
                 public double WindGusts { get; set; } // km/h
             }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ This allows you to safely return to a stable release if needed.
 - ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
 - When updating the application, the color schema upgrades now properly apply updated or added colors
 - The native driver for SBIG cameras now provides the proper electrons/ADU value for the `EGAIN` keyword in image metadata
+- Fixed excessive debug logging after disconnecting the OpenMeteo weather client
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

I noticed that after disconnecting the OpenMeteo client, the log file would rapidly grow in size. That was because the worker contained to try catch blocks and the inner block stopped the OperationCancelledException from propagating to the outer try catch. The inner try catch also didn't throw so it just kept logging the same debug message without a delay.

As my solution, I decided to move the OperationCancelledException handler into the inner block.

## 🧪 How Was It Tested?

I connected and disconnected the openMeteo client and there were no unnecessary logs

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues
None
