### PR TITLE
Add PLUGINS to ApplicationTab enum

### DIFF
--- a/NINA.Core/Enum/ApplicationTab.cs
+++ b/NINA.Core/Enum/ApplicationTab.cs
@@ -21,6 +21,7 @@ namespace NINA.Core.Enum {
         FLATWIZARD,
         SEQUENCE,
         IMAGING,
-        OPTIONS
+        OPTIONS,
+        PLUGINS
     }
 }


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

This PR adds the `PLUGINS` entry to the `ApplicationTab` enum, allowing plugins to switch to the plugins tab via the `ApplicationMediator`

## 🧪 How Was It Tested?

I counted the amount of items in the `ApplicationTab` enum and the amount of tabs in NINA: Both 7

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [ ] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues
Closes #186
