### PR TITLE
Fix SlewScopeToAltAz to use SlewToTopocentricCoordinates

### DIFF
--- a/NINA.Sequencer/SequenceItem/Telescope/Datatemplates.xaml
+++ b/NINA.Sequencer/SequenceItem/Telescope/Datatemplates.xaml
@@ -132,6 +132,17 @@
                         Exp="{Binding AzExpression, Mode=TwoWay}"
                         Label="(Decimal "
                         Unit=")" />
+                    <TextBlock
+                        Margin="20,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="{ns:Loc LblTracking}" />
+                     <CheckBox
+                        MinWidth="40"
+                        Margin="5,0,8,0"
+                        VerticalAlignment="Center"
+                        IsChecked="{Binding Mode=TwoWay, 
+                            RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type view:SequenceBlockView}}, 
+                            Path=DataContext.Tracking}" />
                 </StackPanel>
             </view:SequenceBlockView.SequenceItemContent>
         </view:SequenceBlockView>

--- a/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
+++ b/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
@@ -64,6 +64,7 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
         
         partial void AfterClone(SlewScopeToAltAz clone) {
             clone.Coordinates = Coordinates?.Clone();
+            clone.Tracking = Tracking;
         }
 
         [OnDeserialized]
@@ -84,6 +85,17 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
 
         [JsonProperty]
         public InputTopocentricCoordinates Coordinates { get; set; }
+
+        private bool tracking = true;
+
+        [JsonProperty]
+        public bool Tracking {
+            get => tracking;
+            set {
+                tracking = value;
+                RaisePropertyChanged();
+            }
+        }
 
         private IList<string> issues = new List<string>();
 
@@ -131,7 +143,14 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
                 throw new SequenceEntityFailedException(Loc.Instance["LblTelescopeParkedWarning"]);
             }
             var stoppedGuiding = await guiderMediator.StopGuiding(token);
-            await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+            if (telescopeMediator.GetInfo().CanSlewAltAz) {
+                await telescopeMediator.SlewToTopocentricCoordinates(Coordinates.Coordinates, token);
+            } else {
+                await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+            }
+            if (tracking != telescopeMediator.GetInfo().TrackingEnabled) {
+                telescopeMediator.SetTrackingEnabled(tracking);
+            }
             if (stoppedGuiding) {
                 await guiderMediator.StartGuiding(false, progress, token);
             }
@@ -178,7 +197,7 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
         }
 
         public override string ToString() {
-            return $"Category: {Category}, Item: {nameof(SlewScopeToAltAz)}, Coordinates: {Coordinates}";
+            return $"Category: {Category}, Item: {nameof(SlewScopeToAltAz)}, Coordinates: {Coordinates}, Tracking: {Tracking}";
         }
     }
 }

--- a/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
+++ b/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
@@ -131,7 +131,7 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
                 throw new SequenceEntityFailedException(Loc.Instance["LblTelescopeParkedWarning"]);
             }
             var stoppedGuiding = await guiderMediator.StopGuiding(token);
-            await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+            await telescopeMediator.SlewToTopocentricCoordinates(Coordinates.Coordinates, token);
             if (stoppedGuiding) {
                 await guiderMediator.StartGuiding(false, progress, token);
             }

--- a/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
+++ b/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
@@ -64,6 +64,7 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
         
         partial void AfterClone(SlewScopeToAltAz clone) {
             clone.Coordinates = Coordinates?.Clone();
+            clone.Tracking = Tracking;
         }
 
         [OnDeserialized]
@@ -84,6 +85,17 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
 
         [JsonProperty]
         public InputTopocentricCoordinates Coordinates { get; set; }
+
+        private bool tracking = true;
+
+        [JsonProperty]
+        public bool Tracking {
+            get => tracking;
+            set {
+                tracking = value;
+                RaisePropertyChanged();
+            }
+        }
 
         private IList<string> issues = new List<string>();
 
@@ -131,7 +143,14 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
                 throw new SequenceEntityFailedException(Loc.Instance["LblTelescopeParkedWarning"]);
             }
             var stoppedGuiding = await guiderMediator.StopGuiding(token);
-            await telescopeMediator.SlewToTopocentricCoordinates(Coordinates.Coordinates, token);
+            if (telescopeMediator.GetInfo().CanSlewAltAz) {
+                await telescopeMediator.SlewToTopocentricCoordinates(Coordinates.Coordinates, token);
+            } else {
+                await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+            }
+            if (tracking != telescopeMediator.GetInfo().TrackingEnabled) {
+                telescopeMediator.SetTrackingEnabled(tracking);
+            }
             if (stoppedGuiding) {
                 await guiderMediator.StartGuiding(false, progress, token);
             }
@@ -178,7 +197,7 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
         }
 
         public override string ToString() {
-            return $"Category: {Category}, Item: {nameof(SlewScopeToAltAz)}, Coordinates: {Coordinates}";
+            return $"Category: {Category}, Item: {nameof(SlewScopeToAltAz)}, Coordinates: {Coordinates}, Tracking: {Tracking}";
         }
     }
 }

--- a/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
@@ -48,6 +48,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             sut.Description = "SomeDescription";
             sut.Icon = new System.Windows.Media.GeometryGroup();
             sut.Coordinates.Coordinates = new TopocentricCoordinates(Angle.ByDegree(10), Angle.ByDegree(-10), Angle.ByDegree(1), Angle.ByDegree(5), 10);
+            sut.Tracking = true;
             var item2 = (SlewScopeToAltAz)sut.Clone();
 
             item2.Should().NotBeSameAs(sut);
@@ -58,6 +59,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             item2.Coordinates.Coordinates.Altitude.Should().Be(sut.Coordinates.Coordinates.Altitude);
             item2.Coordinates.Coordinates.Azimuth.Should().Be(sut.Coordinates.Coordinates.Azimuth);
             item2.Coordinates.Coordinates.Elevation.Should().Be(10);
+            item2.Tracking.Should().BeTrue();
         }
 
         [Test]
@@ -89,7 +91,38 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             var latitude = 5;
             var longitude = 5;
             var elevation = 100;
-            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true });
+
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz=true });
+            guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
+            var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
+            var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);
+
+            var sut = new SlewScopeToAltAz(profileServiceMock.Object, telescopeMediatorMock.Object, guiderMediatorMock.Object);
+            sut.Coordinates.Coordinates = topo;
+            await sut.Execute(default, default);
+
+            guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
+            telescopeMediatorMock
+                .Verify(
+                x => x.SlewToTopocentricCoordinates(
+                    It.Is<TopocentricCoordinates>(c =>
+                        c.Altitude == topo.Altitude
+                        && c.Azimuth == topo.Azimuth),
+                    It.IsAny<CancellationToken>()
+                    )
+                , Times.Once
+            );
+            guiderMediatorMock.Verify(x => x.StartGuiding(It.IsAny<bool>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Execute_NoIssues_LogicCalled_CannotSlewAltAz() {
+            var referenceDate = new DateTime(2020, 01, 01);
+            var latitude = 5;
+            var longitude = 5;
+            var elevation = 100;
+
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz = false });
             guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
             var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);
@@ -118,7 +151,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             var latitude = 5;
             var longitude = 5;
             var elevation = 100;
-            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true });
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz = true });
             guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
             var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
             var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);
@@ -130,7 +163,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
             telescopeMediatorMock
                 .Verify(
-                x => x.SlewToCoordinatesAsync(
+                x => x.SlewToTopocentricCoordinates(
                     It.Is<TopocentricCoordinates>(c =>
                         c.Altitude == topo.Altitude
                         && c.Azimuth == topo.Azimuth),

--- a/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
@@ -48,6 +48,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             sut.Description = "SomeDescription";
             sut.Icon = new System.Windows.Media.GeometryGroup();
             sut.Coordinates.Coordinates = new TopocentricCoordinates(Angle.ByDegree(10), Angle.ByDegree(-10), Angle.ByDegree(1), Angle.ByDegree(5), 10);
+            sut.Tracking = true;
             var item2 = (SlewScopeToAltAz)sut.Clone();
 
             item2.Should().NotBeSameAs(sut);
@@ -58,6 +59,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             item2.Coordinates.Coordinates.Altitude.Should().Be(sut.Coordinates.Coordinates.Altitude);
             item2.Coordinates.Coordinates.Azimuth.Should().Be(sut.Coordinates.Coordinates.Azimuth);
             item2.Coordinates.Coordinates.Elevation.Should().Be(10);
+            item2.Tracking.Should().BeTrue();
         }
 
         [Test]
@@ -89,7 +91,8 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             var latitude = 5;
             var longitude = 5;
             var elevation = 100;
-            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true });
+
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz=true });
             guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
             var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);
@@ -113,12 +116,42 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
         }
 
         [Test]
+        public async Task Execute_NoIssues_LogicCalled_CannotSlewAltAz() {
+            var referenceDate = new DateTime(2020, 01, 01);
+            var latitude = 5;
+            var longitude = 5;
+            var elevation = 100;
+
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz = false });
+            guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
+            var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
+            var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);
+
+            var sut = new SlewScopeToAltAz(profileServiceMock.Object, telescopeMediatorMock.Object, guiderMediatorMock.Object);
+            sut.Coordinates.Coordinates = topo;
+            await sut.Execute(default, default);
+
+            guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
+            telescopeMediatorMock
+                .Verify(
+                x => x.SlewToCoordinatesAsync(
+                    It.Is<TopocentricCoordinates>(c =>
+                        c.Altitude == topo.Altitude
+                        && c.Azimuth == topo.Azimuth),
+                    It.IsAny<CancellationToken>()
+                    )
+                , Times.Once
+            );
+            guiderMediatorMock.Verify(x => x.StartGuiding(It.IsAny<bool>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
         public async Task Execute_NoIssues_LogicCalled_GuidingNotStoppedAndNotResumed() {
             var referenceDate = new DateTime(2020, 01, 01);
             var latitude = 5;
             var longitude = 5;
             var elevation = 100;
-            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true });
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo() { Connected = true, CanSlewAltAz = true });
             guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).Returns(Task.FromResult(false));
             var coordinates = new Coordinates(Angle.ByDegree(1), Angle.ByDegree(2), Epoch.J2000, referenceDate);
             var topo = coordinates.Transform(Angle.ByDegree(latitude), Angle.ByDegree(longitude), elevation);

--- a/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Telescope/SlewScopeToAltAzTest.cs
@@ -101,7 +101,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
             telescopeMediatorMock
                 .Verify(
-                x => x.SlewToCoordinatesAsync(
+                x => x.SlewToTopocentricCoordinates(
                     It.Is<TopocentricCoordinates>(c =>
                         c.Altitude == topo.Altitude
                         && c.Azimuth == topo.Azimuth),
@@ -130,7 +130,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Telescope {
             guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
             telescopeMediatorMock
                 .Verify(
-                x => x.SlewToCoordinatesAsync(
+                x => x.SlewToTopocentricCoordinates(
                     It.Is<TopocentricCoordinates>(c =>
                         c.Altitude == topo.Altitude
                         && c.Azimuth == topo.Azimuth),

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ This allows you to safely return to a stable release if needed.
 - When updating the application, the color schema upgrades now properly apply updated or added colors
 - The native driver for SBIG cameras now provides the proper electrons/ADU value for the `EGAIN` keyword in image metadata
 - Fixed excessive debug logging after disconnecting the OpenMeteo weather client
+- Fixed "Slew To Alt/Az" sequence instruction incorrectly using SlewToCoordinatesAsync instead of SlewToAltAzAsync
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,6 @@ This allows you to safely return to a stable release if needed.
 - When updating the application, the color schema upgrades now properly apply updated or added colors
 - The native driver for SBIG cameras now provides the proper electrons/ADU value for the `EGAIN` keyword in image metadata
 - Fixed excessive debug logging after disconnecting the OpenMeteo weather client
-- Fixed "Slew To Alt/Az" sequence instruction incorrectly using SlewToCoordinatesAsync instead of SlewToAltAzAsync
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose
Fixes #251

The "Slew To Alt/Az" sequence instruction was calling
`SlewToCoordinatesAsync(TopocentricCoordinates, token)` (marked [Obsolete]),
which converts Alt/Az to RA/Dec before slewing. This causes unpredictable
and potentially dangerous mount movement when the mount is not yet synced,
since the RA/Dec calculated from Alt/Az coordinates is invalid when the mount is not yet synchronized.

## 🧪 How Was It Tested?

Verified with ASCOM Device Hub activity log: the mount now receives a
SlewToAltAzAsync command instead of SlewToCoordinatesAsync.

## ✅ PR Checklist

- [X] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [X] No breaking changes to interfaces  
  - [X] No changes to method/class signatures (especially optional parameters)
- [X] `Changelog.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

 Closes #251

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
