### PR TITLE
Increase test coverage for NINA.Astronomy

### DIFF
--- a/NINA.Astrometry/AstroUtil.cs
+++ b/NINA.Astrometry/AstroUtil.cs
@@ -546,20 +546,23 @@ namespace NINA.Astrometry {
                 pattern = "[0-9\\,]+";
             }
             var regex = new Regex(pattern);
+            static double ParseSexagesimalPart(string value) {
+                return double.Parse(value.Replace(',', '.'), CultureInfo.InvariantCulture);
+            }
 
             var matches = regex.Matches(dms);
 
             double degree = 0, minutes = 0, seconds = 0;
 
             if (matches.Count > 0) {
-                degree = double.Parse(matches[0].Value, CultureInfo.InvariantCulture);
+                degree = ParseSexagesimalPart(matches[0].Value);
 
                 if (matches.Count > 1) {
-                    minutes = ArcminToDegree(double.Parse(matches[1].Value, CultureInfo.InvariantCulture));
+                    minutes = ArcminToDegree(ParseSexagesimalPart(matches[1].Value));
                 }
 
                 if (matches.Count > 2) {
-                    seconds = ArcsecToDegree(double.Parse(matches[2].Value, CultureInfo.InvariantCulture));
+                    seconds = ArcsecToDegree(ParseSexagesimalPart(matches[2].Value));
                 }
             }
 

--- a/NINA.Test/AstrometryTest/AstroUtilTest.cs
+++ b/NINA.Test/AstrometryTest/AstroUtilTest.cs
@@ -13,8 +13,12 @@ using FluentAssertions;
 using NINA.Astrometry;
 using NINA.Astrometry.Body;
 using NINA.Astrometry.RiseAndSet;
+using NINA.Core.Utility;
 using NUnit.Framework;
 using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows;
 
@@ -808,6 +812,41 @@ namespace NINA.Test.AstrometryTest {
         }
 
         /// <summary>
+        /// Verifies the Earth-rotation database lookup used by Delta-T selects the nearest UT1-UTC
+        /// sample for the requested UTC date, matching the IERS finals data model of daily samples.
+        /// Reference: https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop.html
+        /// </summary>
+        [Test]
+        public void DeltaUT_EarthRotationTable_UsesNearestUt1MinusUtcSample() {
+            DateTime target = new DateTime(2030, 1, 3, 18, 0, 0, DateTimeKind.Utc);
+            using TempEarthRotationDatabase database = CreateEarthRotationDatabase(
+                (new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), -0.25),
+                (new DateTime(2030, 1, 4, 0, 0, 0, DateTimeKind.Utc), 0.125));
+            ClearDeltaUTCaches();
+
+            double deltaUT = AstroUtil.DeltaUT(target, database.Interaction);
+
+            deltaUT.Should().BeApproximately(0.125, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies the Delta-T formula: Delta-T equals 32.184 seconds plus TAI-UTC minus UT1-UTC.
+        /// The controlled UT1-UTC row guards the sign of the Earth-rotation correction.
+        /// References: https://www.cnmoc.usff.navy.mil/Our-Commands/United-States-Naval-Observatory/Precise-Time-Department/Global-Positioning-System/USNO-GPS-Time-Transfer/Leap-Seconds/
+        /// and https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop.html
+        /// </summary>
+        [Test]
+        public void DeltaT_ControlledUt1MinusUtc_SubtractsEarthRotationCorrection() {
+            DateTime date = new DateTime(2024, 4, 8, 18, 0, 0, DateTimeKind.Utc);
+            using TempEarthRotationDatabase database = CreateEarthRotationDatabase((date, 0.123456));
+            ClearDeltaUTCaches();
+
+            double deltaT = AstroUtil.DeltaT(date, database.Interaction);
+
+            deltaT.Should().BeApproximately(32.184 + 37.0 - 0.123456, 1e-6);
+        }
+
+        /// <summary>
         /// Verifies that fractional seconds are preserved when SOFA receives UTC parts, because
         /// sub-second exposure timing is relevant for precise astrometry and satellite work.
         /// </summary>
@@ -849,6 +888,25 @@ namespace NINA.Test.AstrometryTest {
             double siderealTime = AstroUtil.GetLocalSiderealTime(j2000, 0.0);
 
             siderealTime.Should().BeApproximately(18.697374558, 0.01);
+        }
+
+        /// <summary>
+        /// Verifies local sidereal time consumes UT1-UTC from the Earth-rotation table: one second
+        /// of UT1 changes sidereal time by one sidereal second, about 1.0027379 solar seconds.
+        /// Reference: https://aa.usno.navy.mil/faq/GAST
+        /// </summary>
+        [Test]
+        public void GetLocalSiderealTime_DifferentUt1MinusUtcRows_ShiftsBySiderealSecond() {
+            DateTime date = new DateTime(2024, 4, 8, 18, 0, 0, DateTimeKind.Utc);
+            using TempEarthRotationDatabase zeroUt1Database = CreateEarthRotationDatabase((date, 0.0));
+            using TempEarthRotationDatabase oneSecondUt1Database = CreateEarthRotationDatabase((date, 1.0));
+
+            ClearDeltaUTCaches();
+            double zeroUt1SiderealTime = AstroUtil.GetLocalSiderealTime(date, 0.0, zeroUt1Database.Interaction);
+            ClearDeltaUTCaches();
+            double oneSecondUt1SiderealTime = AstroUtil.GetLocalSiderealTime(date, 0.0, oneSecondUt1Database.Interaction);
+
+            (oneSecondUt1SiderealTime - zeroUt1SiderealTime).Should().BeApproximately(1.0027379 / 3600.0, 1e-7);
         }
 
         /// <summary>
@@ -1317,6 +1375,56 @@ namespace NINA.Test.AstrometryTest {
             actual.Should().NotBeNull();
             TimeSpan difference = (actual.Value - expected).Duration();
             difference.Should().BeLessThanOrEqualTo(tolerance);
+        }
+
+        private static TempEarthRotationDatabase CreateEarthRotationDatabase(params (DateTime Date, double Ut1MinusUtc)[] rows) {
+            string databasePath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"earth-rotation-{Guid.NewGuid():N}.sqlite");
+            string connectionString = $"Data Source={databasePath};";
+            DatabaseInteraction databaseInteraction = new DatabaseInteraction(connectionString);
+
+            using (var context = databaseInteraction.GetContext()) {
+                foreach ((DateTime date, double ut1MinusUtc) in rows) {
+                    long unixTimestamp = CoreUtil.DateTimeToUnixTimeStamp(date);
+                    double modifiedJulianDate = AstroUtil.GetJulianDate(date) - 2400000.5;
+                    context.Database.ExecuteSqlCommand(
+                        "INSERT OR REPLACE INTO `earthrotationparameters` (date, modifiedjuliandate, x, y, ut1_utc, lod, dx, dy) VALUES (@p0, @p1, 0, 0, @p2, 1, 0, 0)",
+                        unixTimestamp,
+                        modifiedJulianDate,
+                        ut1MinusUtc);
+                }
+            }
+
+            return new TempEarthRotationDatabase(databasePath, databaseInteraction);
+        }
+
+        private static void ClearDeltaUTCaches() {
+            typeof(AstroUtil).GetField("DeltaUTToday", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTYesterday", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTTomorrow", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTReference", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, default(DateTime));
+
+            FieldInfo cacheField = typeof(AstroUtil).GetField("DeltaUTCache", BindingFlags.NonPublic | BindingFlags.Static);
+            cacheField?.SetValue(null, new ConcurrentDictionary<DateTime, double>());
+        }
+
+        private sealed class TempEarthRotationDatabase : IDisposable {
+            public TempEarthRotationDatabase(string path, DatabaseInteraction interaction) {
+                Path = path;
+                Interaction = interaction;
+            }
+
+            public string Path { get; }
+            public DatabaseInteraction Interaction { get; }
+
+            public void Dispose() {
+                System.Data.SQLite.SQLiteConnection.ClearAllPools();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                if (File.Exists(Path)) {
+                    File.Delete(Path);
+                }
+            }
         }
     }
 }

--- a/NINA.Test/AstrometryTest/AstroUtilTest.cs
+++ b/NINA.Test/AstrometryTest/AstroUtilTest.cs
@@ -837,6 +837,21 @@ namespace NINA.Test.AstrometryTest {
         }
 
         /// <summary>
+        /// Verifies Greenwich sidereal time at the J2000 epoch against the standard 18.697374558 hour
+        /// reference for Greenwich mean sidereal time, allowing a small tolerance because this code asks
+        /// NOVAS for apparent sidereal time and therefore includes nutation/equation-of-equinoxes terms.
+        /// Reference: https://aa.usno.navy.mil/faq/GAST
+        /// </summary>
+        [Test]
+        public void GetLocalSiderealTime_J2000Greenwich_ReturnsPublishedSiderealEpochValue() {
+            DateTime j2000 = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            double siderealTime = AstroUtil.GetLocalSiderealTime(j2000, 0.0);
+
+            siderealTime.Should().BeApproximately(18.697374558, 0.01);
+        }
+
+        /// <summary>
         /// Verifies small conversion helpers used by sidereal and formatting calculations,
         /// including the zero-divisor modulus branch that represents an undefined wrap interval.
         /// </summary>
@@ -1042,6 +1057,25 @@ namespace NINA.Test.AstrometryTest {
 
             noonAltitude.Should().BeGreaterThan(88.0);
             midnightAltitude.Should().BeLessThan(-88.0);
+        }
+
+        /// <summary>
+        /// Verifies the apparent solar declination near the equinoxes and solstices, where the Sun
+        /// should be near 0 degrees at equinox and near the obliquity of the ecliptic at solstice.
+        /// Reference: https://gml.noaa.gov/grad/solcalc/solareqns.PDF
+        /// </summary>
+        [Test]
+        [TestCase(2024, 3, 20, 3, 6, 0.0)]
+        [TestCase(2024, 6, 20, 20, 51, 23.44)]
+        [TestCase(2024, 9, 22, 12, 44, 0.0)]
+        [TestCase(2024, 12, 21, 9, 20, -23.44)]
+        public void GetSunPosition_EquinoxesAndSolstices_ReturnsExpectedSolarDeclination(int year, int month, int day, int hour, int minute, double expectedDeclination) {
+            DateTime date = new DateTime(year, month, day, hour, minute, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 0.0, Longitude = 0.0, Elevation = 0.0 };
+
+            NOVAS.SkyPosition sun = AstroUtil.GetSunPosition(date, observer);
+
+            sun.Dec.Should().BeApproximately(expectedDeclination, 0.35);
         }
 
         /// <summary>

--- a/NINA.Test/AstrometryTest/AstroUtilTest.cs
+++ b/NINA.Test/AstrometryTest/AstroUtilTest.cs
@@ -1,6 +1,6 @@
 #region "copyright"
 /*
-    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors 
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 
@@ -11,15 +11,19 @@
 #endregion "copyright"
 using FluentAssertions;
 using NINA.Astrometry;
+using NINA.Astrometry.Body;
+using NINA.Astrometry.RiseAndSet;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 using System;
 using System.Text.RegularExpressions;
+using System.Windows;
 
 namespace NINA.Test.AstrometryTest {
 
     [TestFixture]
-    public class AstrometryTest {
+    public class AstroUtilTest {
+        private const double AngleTolerance = 1e-10;
+        
         private const double DEWPOINT_TOLERANCE = 0.5;
         private static double ANGLE_TOLERANCE = 0.0000000000001;
         private static double MODULUS_TOLERANCE = 0.0001;
@@ -764,6 +768,521 @@ namespace NINA.Test.AstrometryTest {
             var pattern = AstroUtil.DMSPattern;
             var match = Regex.Match(sut, pattern);
             match.Success.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Verifies UTC Julian Date conversion against standard epoch examples from Jean Meeus,
+        /// Astronomical Algorithms, so calendar-to-Julian conversion stays anchored to published values.
+        /// Reference: https://www.obliquity.com/astro/meeus.html
+        /// </summary>
+        [Test]
+        [TestCase(2000, 1, 1, 12, 0, 0, 2451545.0)]
+        [TestCase(1987, 1, 27, 0, 0, 0, 2446822.5)]
+        [TestCase(1987, 6, 19, 12, 0, 0, 2446966.0)]
+        [TestCase(1988, 1, 27, 0, 0, 0, 2447187.5)]
+        public void GetJulianDate_KnownAstronomicalEpochs_ReturnsPublishedJulianDate(int year, int month, int day, int hour, int minute, int second, double expectedJulianDate) {
+            DateTime utc = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
+
+            double julianDate = AstroUtil.GetJulianDate(utc);
+
+            julianDate.Should().BeApproximately(expectedJulianDate, 1e-9);
+            utc.ToJD().Should().BeApproximately(expectedJulianDate, 1e-9);
+            utc.ToMJD().Should().BeApproximately(expectedJulianDate - 2400000.5, 1e-9);
+            utc.ToMJD2000().Should().BeApproximately(expectedJulianDate - 2451545.0, 1e-9);
+        }
+
+        /// <summary>
+        /// Verifies TT conversion at the J2000 UTC instant, where TT is offset by TAI-UTC plus
+        /// 32.184 seconds; this catches leap-second and time-scale regressions in the SOFA path.
+        /// References: https://www.iers.org/IERS/EN/Service/FAQs/TheNewIAUResolutions/timeArgumentForUsingIERSProducts_104_157
+        /// and https://www.cnmoc.usff.navy.mil/Our-Commands/United-States-Naval-Observatory/Precise-Time-Department/Global-Positioning-System/USNO-GPS-Time-Transfer/Leap-Seconds/
+        /// </summary>
+        [Test]
+        public void GetJulianDateTT_J2000Utc_ContainsTerrestrialTimeOffset() {
+            DateTime utc = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            double expectedTt = 2451545.0 + (32.0 + 32.184) / 86400.0;
+
+            double julianDateTt = AstroUtil.GetJulianDateTT(utc);
+
+            julianDateTt.Should().BeApproximately(expectedTt, 1e-9);
+        }
+
+        /// <summary>
+        /// Verifies that fractional seconds are preserved when SOFA receives UTC parts, because
+        /// sub-second exposure timing is relevant for precise astrometry and satellite work.
+        /// </summary>
+        [Test]
+        public void GetSecondOfMinuteWithFraction_MillisecondTime_PreservesFractionalSecond() {
+            DateTime timestamp = new DateTime(2024, 4, 8, 18, 17, 42, 375, DateTimeKind.Utc).AddTicks(1200);
+
+            double second = AstroUtil.GetSecondOfMinuteWithFraction(timestamp);
+
+            second.Should().BeApproximately(42.37512, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies that local sidereal time shifts by exactly one sidereal hour per 15 degrees
+        /// longitude, preserving the astronomical sign convention used by mount pointing.
+        /// </summary>
+        [Test]
+        public void GetLocalSiderealTime_LongitudeOffset_ChangesByOneHourPerFifteenDegrees() {
+            DateTime utc = new DateTime(2024, 3, 20, 0, 0, 0, DateTimeKind.Utc);
+
+            double greenwichSiderealTime = AstroUtil.GetLocalSiderealTime(utc, 0.0);
+            double eastSiderealTime = AstroUtil.GetLocalSiderealTime(utc, 15.0);
+            double westSiderealTime = AstroUtil.GetLocalSiderealTime(utc, -30.0);
+
+            eastSiderealTime.Should().BeApproximately(greenwichSiderealTime + 1.0, 1e-10);
+            westSiderealTime.Should().BeApproximately(greenwichSiderealTime - 2.0, 1e-10);
+        }
+
+        /// <summary>
+        /// Verifies small conversion helpers used by sidereal and formatting calculations,
+        /// including the zero-divisor modulus branch that represents an undefined wrap interval.
+        /// </summary>
+        [Test]
+        public void AngleAndModulusHelpers_CoreBranches_ReturnExpectedValues() {
+            AstroUtil.RadianToHour(Math.PI).Should().BeApproximately(12.0, AngleTolerance);
+            AstroUtil.MathMod(-10.0, 360.0).Should().BeApproximately(350.0, AngleTolerance);
+            AstroUtil.MathMod(10.0, 0.0).Should().Be(double.NaN);
+            AstroUtil.GetLocalSiderealTimeNow(0.0).Should().NotBe(double.NaN);
+        }
+
+        /// <summary>
+        /// Verifies inverse hour-angle conversion without normalization, matching the formula
+        /// RA = local sidereal time minus hour angle used in mount-side coordinate math.
+        /// </summary>
+        [Test]
+        public void GetRightAscensionFromHourAngle_SubtractsHourAngleFromSiderealTime() {
+            Angle rightAscension = AstroUtil.GetRightAscensionFromHourAngle(Angle.ByHours(7.0), Angle.ByHours(5.0));
+
+            rightAscension.Hours.Should().BeApproximately(-2.0, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies the closed-form equatorial altitude relation at upper and lower culmination,
+        /// a core spherical-astronomy identity for converting hour angle and declination to altitude.
+        /// </summary>
+        [Test]
+        [TestCase(51.5, 23.44, 0.0, 61.94)]
+        [TestCase(51.5, 23.44, 180.0, -15.06)]
+        [TestCase(-30.0, -60.0, 0.0, 60.0)]
+        [TestCase(-30.0, -60.0, 180.0, 0.0)]
+        public void GetAltitude_CulminationGeometry_ReturnsMeridianAltitudes(double latitude, double declination, double hourAngle, double expectedAltitude) {
+            double altitude = AstroUtil.GetAltitude(hourAngle, latitude, declination);
+
+            altitude.Should().BeApproximately(expectedAltitude, 1e-10);
+        }
+
+        /// <summary>
+        /// Verifies azimuth at meridian transit for targets north and south of the zenith, which
+        /// guards the branch logic that chooses north-versus-south culmination.
+        /// </summary>
+        [Test]
+        [TestCase(51.5, 23.44, 180.0)]
+        [TestCase(20.0, 70.0, 0.0)]
+        [TestCase(-30.0, -60.0, 180.0)]
+        public void GetAzimuth_MeridianTransit_IdentifiesNorthOrSouthTransit(double latitude, double declination, double expectedAzimuth) {
+            double altitude = AstroUtil.GetAltitude(0.0, latitude, declination);
+
+            double azimuth = AstroUtil.GetAzimuth(0.0, altitude, latitude, declination);
+
+            AngularDifference(azimuth, expectedAzimuth).Should().BeLessThan(1e-5);
+        }
+
+        /// <summary>
+        /// Verifies Greenwich equinox sunrise and sunset against public almanac expectations to
+        /// within a practical tolerance for the quadratic interpolation used by RiseAndSetEvent.
+        /// Reference: https://www.suntoday.org/sunrise-sunset/2024/march.html
+        /// </summary>
+        [Test]
+        public void GetSunRiseAndSet_GreenwichNearMarchEquinox_MatchesAlmanacTimesWithinMinutes() {
+            DateTime referenceDate = new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc);
+
+            RiseAndSetEvent sun = AstroUtil.GetSunRiseAndSet(referenceDate, 51.4769, 0.0, 46.0);
+
+            sun.Rise.Should().NotBeNull();
+            sun.Set.Should().NotBeNull();
+            AssertCloseToTime(sun.Rise, new DateTime(2024, 3, 21, 6, 1, 0, DateTimeKind.Utc), TimeSpan.FromMinutes(20));
+            AssertCloseToTime(sun.Set, new DateTime(2024, 3, 20, 18, 13, 0, DateTimeKind.Utc), TimeSpan.FromMinutes(20));
+        }
+
+        /// <summary>
+        /// Verifies that civil, nautical, and astronomical twilight are ordered by the physical
+        /// solar depression thresholds of -6, -12, and -18 degrees.
+        /// Reference: https://gml.noaa.gov/grad/solcalc/calcdetails.html
+        /// </summary>
+        [Test]
+        public void TwilightRiseAndSet_GreenwichNearMarchEquinox_OrdersBySolarDepression() {
+            DateTime referenceDate = new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc);
+
+            RiseAndSetEvent civil = AstroUtil.GetCivilNightTimes(referenceDate, 51.4769, 0.0, 46.0);
+            RiseAndSetEvent nautical = AstroUtil.GetNauticalNightTimes(referenceDate, 51.4769, 0.0, 46.0);
+            RiseAndSetEvent astronomical = AstroUtil.GetNightTimes(referenceDate, 51.4769, 0.0, 46.0);
+
+            civil.Set.Should().BeBefore(nautical.Set.Value);
+            nautical.Set.Should().BeBefore(astronomical.Set.Value);
+            astronomical.Rise.Should().BeBefore(nautical.Rise.Value);
+            nautical.Rise.Should().BeBefore(civil.Rise.Value);
+        }
+
+        /// <summary>
+        /// Verifies polar day behavior at Tromso near June solstice, where the Sun should not cross
+        /// the apparent horizon and the rise/set solver must report no event.
+        /// Reference: https://www.sunrise-and-sunset.com/en/sun/norway/tromso/2024
+        /// </summary>
+        [Test]
+        public void GetSunRiseAndSet_TromsoJuneSolstice_DetectsMidnightSunNoCrossing() {
+            DateTime referenceDate = new DateTime(2024, 6, 21, 12, 0, 0, DateTimeKind.Utc);
+
+            RiseAndSetEvent sun = AstroUtil.GetSunRiseAndSet(referenceDate, 69.6492, 18.9553, 10.0);
+
+            sun.Rise.Should().BeNull();
+            sun.Set.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies polar night behavior at Tromso near December solstice, where the Sun remains
+        /// below the apparent horizon and no sunrise or sunset crossing should be produced.
+        /// Reference: https://www.sunrise-and-sunset.com/en/sun/norway/tromso/2024
+        /// </summary>
+        [Test]
+        public void GetSunRiseAndSet_TromsoDecemberSolstice_DetectsPolarNightNoCrossing() {
+            DateTime referenceDate = new DateTime(2024, 12, 21, 12, 0, 0, DateTimeKind.Utc);
+
+            RiseAndSetEvent sun = AstroUtil.GetSunRiseAndSet(referenceDate, 69.6492, 18.9553, 10.0);
+
+            sun.Rise.Should().BeNull();
+            sun.Set.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies lunar illumination near the 2024 total solar eclipse new moon, an externally
+        /// recognizable syzygy where the illuminated fraction should be very small.
+        /// Reference: https://science.nasa.gov/eclipses/future-eclipses/eclipse-2024/
+        /// </summary>
+        [Test]
+        public void GetMoonIllumination_NewMoonAtSolarEclipse_ReturnsDarkMoon() {
+            DateTime eclipseNewMoon = new DateTime(2024, 4, 8, 18, 21, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 29.7604, Longitude = -95.3698, Elevation = 15.0 };
+
+            double illumination = AstroUtil.GetMoonIllumination(eclipseNewMoon, observer);
+            AstroUtil.MoonPhase phase = AstroUtil.GetMoonPhase(eclipseNewMoon, observer);
+
+            phase.Should().BeOneOf(AstroUtil.MoonPhase.WaningCrescent, AstroUtil.MoonPhase.NewMoon, AstroUtil.MoonPhase.WaxingCrescent);
+            illumination.Should().BeLessThan(0.02);
+        }
+
+        /// <summary>
+        /// Verifies lunar illumination near the 2024 March full moon, where Sun-Moon
+        /// elongation is near opposition and the illuminated fraction should be near unity.
+        /// Reference: https://moon.nasa.gov/moon-in-motion/moon-phases/
+        /// </summary>
+        [Test]
+        public void GetMoonIllumination_FullMoon_ReturnsBrightMoon() {
+            DateTime fullMoon = new DateTime(2024, 3, 25, 7, 0, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 51.4769, Longitude = 0.0, Elevation = 46.0 };
+
+            double illumination = AstroUtil.GetMoonIllumination(fullMoon, observer);
+            AstroUtil.MoonPhase phase = AstroUtil.GetMoonPhase(fullMoon, observer);
+
+            phase.Should().BeOneOf(AstroUtil.MoonPhase.WaxingGibbous, AstroUtil.MoonPhase.FullMoon, AstroUtil.MoonPhase.WaningGibbous);
+            illumination.Should().BeGreaterThan(0.98);
+        }
+
+        /// <summary>
+        /// Verifies that the 2024 March full moon has both moonrise and moonset around Greenwich,
+        /// covering the lunar rise/set path with the Moon-specific apparent-limb horizon threshold.
+        /// Reference: https://moon.nasa.gov/moon-in-motion/moon-phases/
+        /// </summary>
+        [Test]
+        public void GetMoonRiseAndSet_GreenwichFullMoon_FindsBothEvents() {
+            DateTime referenceDate = new DateTime(2024, 3, 25, 12, 0, 0, DateTimeKind.Utc);
+
+            RiseAndSetEvent moon = AstroUtil.GetMoonRiseAndSet(referenceDate, 51.4769, 0.0, 46.0);
+
+            moon.Rise.Should().NotBeNull();
+            moon.Set.Should().NotBeNull();
+            moon.Rise.Value.Should().BeAfter(referenceDate);
+            moon.Set.Value.Should().BeAfter(referenceDate);
+        }
+
+        /// <summary>
+        /// Verifies legacy no-elevation rise/set overloads still delegate to the elevation-aware
+        /// implementations, preserving old call sites while keeping the same astronomical events.
+        /// </summary>
+        [Test]
+        public void RiseAndSetCompatibilityOverloads_NoElevation_DelegateToZeroElevationImplementations() {
+            DateTime referenceDate = new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc);
+#pragma warning disable CS0618
+            RiseAndSetEvent astronomicalLegacy = AstroUtil.GetNightTimes(referenceDate, 51.4769, 0.0);
+            RiseAndSetEvent nauticalLegacy = AstroUtil.GetNauticalNightTimes(referenceDate, 51.4769, 0.0);
+            RiseAndSetEvent civilLegacy = AstroUtil.GetCivilNightTimes(referenceDate, 51.4769, 0.0);
+            RiseAndSetEvent sunLegacy = AstroUtil.GetSunRiseAndSet(referenceDate, 51.4769, 0.0);
+            RiseAndSetEvent moonLegacy = AstroUtil.GetMoonRiseAndSet(referenceDate, 51.4769, 0.0);
+#pragma warning restore CS0618
+
+            astronomicalLegacy.Rise.Should().Be(AstroUtil.GetNightTimes(referenceDate, 51.4769, 0.0, 0.0).Rise);
+            nauticalLegacy.Rise.Should().Be(AstroUtil.GetNauticalNightTimes(referenceDate, 51.4769, 0.0, 0.0).Rise);
+            civilLegacy.Rise.Should().Be(AstroUtil.GetCivilNightTimes(referenceDate, 51.4769, 0.0, 0.0).Rise);
+            sunLegacy.Rise.Should().Be(AstroUtil.GetSunRiseAndSet(referenceDate, 51.4769, 0.0, 0.0).Rise);
+            moonLegacy.Rise.Should().Be(AstroUtil.GetMoonRiseAndSet(referenceDate, 51.4769, 0.0, 0.0).Rise);
+        }
+
+        /// <summary>
+        /// Verifies solar altitude at the equator near equinox noon and midnight, exercising the
+        /// NOVAS solar position path against the expected day-night symmetry.
+        /// </summary>
+        [Test]
+        public void GetSunAltitude_EquatorAtEquinox_HighAtNoonAndLowAtMidnight() {
+            ObserverInfo observer = new ObserverInfo { Latitude = 0.0, Longitude = 0.0, Elevation = 0.0 };
+
+            double noonAltitude = AstroUtil.GetSunAltitude(new DateTime(2024, 3, 20, 12, 7, 0, DateTimeKind.Utc), observer);
+            double midnightAltitude = AstroUtil.GetSunAltitude(new DateTime(2024, 3, 20, 0, 7, 0, DateTimeKind.Utc), observer);
+
+            noonAltitude.Should().BeGreaterThan(88.0);
+            midnightAltitude.Should().BeLessThan(-88.0);
+        }
+
+        /// <summary>
+        /// Verifies lunar altitude at Greenwich around the March 2024 full moon, exercising the
+        /// NOVAS lunar position path independently of the rise/set interpolation.
+        /// </summary>
+        [Test]
+        public void GetMoonAltitude_GreenwichFullMoonNight_ReturnsAboveHorizonAltitude() {
+            DateTime date = new DateTime(2024, 3, 25, 0, 30, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 51.4769, Longitude = 0.0, Elevation = 46.0 };
+
+            double altitude = AstroUtil.GetMoonAltitude(date, observer);
+
+            altitude.Should().BeGreaterThan(20.0);
+        }
+
+        /// <summary>
+        /// Verifies legacy latitude/longitude solar and lunar altitude overloads delegate to the
+        /// current ObserverInfo overloads for deterministic historical callers.
+        /// </summary>
+        [Test]
+        public void AltitudeCompatibilityOverloads_LatitudeLongitude_MatchObserverInfoOverloads() {
+            DateTime date = new DateTime(2024, 3, 25, 0, 30, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 51.4769, Longitude = 0.0 };
+
+#pragma warning disable CS0618
+            double moonLegacy = AstroUtil.GetMoonAltitude(date, observer.Latitude, observer.Longitude);
+            double sunLegacy = AstroUtil.GetSunAltitude(date, observer.Latitude, observer.Longitude);
+#pragma warning restore CS0618
+
+            moonLegacy.Should().BeApproximately(AstroUtil.GetMoonAltitude(date, observer), 1e-10);
+            sunLegacy.Should().BeApproximately(AstroUtil.GetSunAltitude(date, observer), 1e-10);
+        }
+
+        /// <summary>
+        /// Verifies NOVAS standard refraction increases apparent altitude most near the horizon,
+        /// which protects the zenith-distance sign and unit conversion.
+        /// </summary>
+        [Test]
+        public void CalculateAltitudeForStandardRefraction_LowAltitude_IncreasesApparentAltitude() {
+            double lowAltitude = AstroUtil.CalculateAltitudeForStandardRefraction(5.0, 51.4769, 0.0, 46.0);
+            double highAltitude = AstroUtil.CalculateAltitudeForStandardRefraction(80.0, 51.4769, 0.0, 46.0);
+
+            lowAltitude.Should().BeGreaterThan(5.0);
+            highAltitude.Should().BeGreaterThan(80.0);
+            (lowAltitude - 5.0).Should().BeGreaterThan(highAltitude - 80.0);
+        }
+
+        /// <summary>
+        /// Verifies obsolete solar and lunar position overloads still return the same NOVAS body
+        /// positions as the current ObserverInfo overloads.
+        /// </summary>
+        [Test]
+        public void BodyPositionCompatibilityOverloads_IgnoreJulianDateArgument_DelegateToCurrentOverloads() {
+            DateTime date = new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 51.4769, Longitude = 0.0, Elevation = 46.0 };
+            double julianDate = AstroUtil.GetJulianDate(date);
+
+#pragma warning disable CS0618
+            NOVAS.SkyPosition sunLegacy = AstroUtil.GetSunPosition(date, julianDate, observer);
+            NOVAS.SkyPosition moonLegacy = AstroUtil.GetMoonPosition(date, julianDate, observer);
+            Tuple<NOVAS.SkyPosition, NOVAS.SkyPosition> tupleLegacy = AstroUtil.GetMoonAndSunPosition(date, julianDate, observer);
+#pragma warning restore CS0618
+
+            NOVAS.SkyPosition sun = AstroUtil.GetSunPosition(date, observer);
+            NOVAS.SkyPosition moon = AstroUtil.GetMoonPosition(date, observer);
+
+            sunLegacy.RA.Should().BeApproximately(sun.RA, AngleTolerance);
+            moonLegacy.RA.Should().BeApproximately(moon.RA, AngleTolerance);
+            tupleLegacy.Item1.RA.Should().BeApproximately(moon.RA, AngleTolerance);
+            tupleLegacy.Item2.RA.Should().BeApproximately(sun.RA, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies legacy Moon phase, illumination, and position-angle overloads continue to
+        /// produce finite values for default geocentric-style observer assumptions.
+        /// </summary>
+        [Test]
+        public void MoonCompatibilityOverloads_DefaultObserver_ReturnFinitePhaseAndIllumination() {
+            DateTime date = new DateTime(2024, 4, 8, 18, 21, 0, DateTimeKind.Utc);
+
+#pragma warning disable CS0618
+            double illumination = AstroUtil.GetMoonIllumination(date);
+            double positionAngle = AstroUtil.GetMoonPositionAngle(date);
+            AstroUtil.MoonPhase phase = AstroUtil.GetMoonPhase(date);
+            double calculatedIllumination = AstroUtil.CalculateMoonIllumination(date);
+#pragma warning restore CS0618
+
+            illumination.Should().BeInRange(0.0, 1.0);
+            calculatedIllumination.Should().BeApproximately(illumination, AngleTolerance);
+            positionAngle.Should().BeInRange(-180.0, 180.0);
+            phase.Should().NotBe(AstroUtil.MoonPhase.Unknown);
+        }
+
+        /// <summary>
+        /// Verifies the Gueymard 1993 airmass model at representative altitudes and rejects
+        /// physically invalid altitude inputs with NaN.
+        /// Reference: https://doi.org/10.1016/0038-092X(93)90074-X
+        /// </summary>
+        [Test]
+        [TestCase(90.0, 1.0)]
+        [TestCase(60.0, 1.15425329789205)]
+        [TestCase(45.0, 1.41282515211066)]
+        [TestCase(30.0, 1.99426095351295)]
+        [TestCase(10.0, 5.58083120021974)]
+        [TestCase(0.0, 37.8082182299908)]
+        public void Airmass_ValidAltitudes_ReturnsGueymardReferenceValues(double altitude, double expectedAirmass) {
+            double airmass = AstroUtil.Airmass(altitude);
+
+            airmass.Should().BeApproximately(expectedAirmass, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies invalid airmass inputs, because negative altitude and non-finite values are
+        /// outside the physical domain of the Gueymard approximation.
+        /// </summary>
+        [Test]
+        [TestCase(-0.1)]
+        [TestCase(90.1)]
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        public void Airmass_InvalidAltitude_ReturnsNaN(double altitude) {
+            double airmass = AstroUtil.Airmass(altitude);
+
+            airmass.Should().Be(double.NaN);
+        }
+
+        /// <summary>
+        /// Verifies ISO 2533 standard-atmosphere pressure conversion from sea-level pressure to
+        /// local observing-site pressure at common elevations.
+        /// Reference: https://www.engineeringtoolbox.com/standard-atmosphere-d_604.html
+        /// </summary>
+        [Test]
+        [TestCase(1013.25, 0.0, 1013.25)]
+        [TestCase(1013.25, 1000.0, 898.745604273543)]
+        [TestCase(1013.25, 1609.344, 834.275729916201)]
+        [TestCase(1013.25, 2000.0, 794.951974352912)]
+        public void MslToLocalPressure_StandardAtmosphere_ReturnsExpectedPressure(double seaLevelPressure, double elevation, double expectedPressure) {
+            double pressure = AstroUtil.MslToLocalPressure(seaLevelPressure, elevation);
+
+            pressure.Should().BeApproximately(expectedPressure, 1e-9);
+        }
+
+        /// <summary>
+        /// Verifies SOFA refraction behavior by checking that denser air refracts a target more
+        /// than thin high-altitude air and that the apparent altitude increases.
+        /// </summary>
+        [Test]
+        public void CalculateRefractedAltitude_DifferentPressure_IncreasesAltitudeMoreAtSeaLevel() {
+            double vacuumAltitude = 20.0;
+
+            double seaLevel = AstroUtil.CalculateRefractedAltitude(vacuumAltitude, 1013.25, 10.0, 50.0, 0.574);
+            double highAltitude = AstroUtil.CalculateRefractedAltitude(vacuumAltitude, 600.0, 10.0, 50.0, 0.574);
+
+            seaLevel.Should().BeGreaterThan(vacuumAltitude);
+            highAltitude.Should().BeGreaterThan(vacuumAltitude);
+            seaLevel.Should().BeGreaterThan(highAltitude);
+        }
+
+        /// <summary>
+        /// Verifies that refraction rejects a negative geometric altitude, because the implemented
+        /// SOFA-based iteration is documented only for targets at or above the horizon.
+        /// </summary>
+        [Test]
+        public void CalculateRefractedAltitude_NegativeAltitude_ThrowsArgumentException() {
+            Action act = () => AstroUtil.CalculateRefractedAltitude(-0.01, 1013.25, 10.0, 50.0, 0.574);
+
+            act.Should().Throw<ArgumentException>();
+        }
+
+        /// <summary>
+        /// Verifies that astronomical unit conversion uses the IAU exact astronomical unit in
+        /// kilometers, which is then reused by Sun and Moon distance calculations.
+        /// Reference: https://iau-a3.gitlab.io/res.html
+        /// </summary>
+        [Test]
+        public void AUToKilometer_OneAstronomicalUnit_ReturnsIauKilometers() {
+            AstroUtil.AUToKilometer(1.0).Should().Be(149597870.7);
+            Earth.Radius.Should().Be(6371.0);
+        }
+
+        /// <summary>
+        /// Verifies FITS-compatible sexagesimal formatting for RA and Dec, including signed
+        /// declination output used in image headers.
+        /// </summary>
+        [Test]
+        public void FitsSexagesimalFormatting_PositiveAndNegativeCoordinates_ReturnsFitsHeaderStrings() {
+            AstroUtil.DegreesToFitsDMS(12.5).Should().Be("+12 30 00");
+            AstroUtil.DegreesToFitsDMS(-12.5).Should().Be("-12 30 00");
+            AstroUtil.HoursToFitsHMS(5.25).Should().Be("05 15 00");
+        }
+
+        /// <summary>
+        /// Verifies comma decimal DMS parsing for European-formatted source data, because imported
+        /// catalog and planetarium text can use comma decimal separators.
+        /// </summary>
+        [Test]
+        public void DMSToDegrees_CommaDecimalSeconds_ParsesUsingCommaPattern() {
+            double value = AstroUtil.DMSToDegrees("12°30'30,5\"");
+
+            value.Should().BeApproximately(12.508472222222222, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies image-scale field-of-view helpers with rectangular sensors, ensuring the
+        /// maximum field uses the longer side and per-axis field uses the requested axis only.
+        /// </summary>
+        [Test]
+        public void FieldOfView_RectangularSensor_ReturnsArcminuteExtent() {
+            const double arcsecPerPixel = 1.5;
+
+            AstroUtil.FieldOfView(arcsecPerPixel, 3000).Should().BeApproximately(75.0, AngleTolerance);
+            AstroUtil.MaxFieldOfView(arcsecPerPixel, 3000, 2000).Should().BeApproximately(75.0, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies polar-to-Cartesian conversion at axis-aligned spherical coordinates so 3D sky
+        /// preview geometry preserves the expected handedness.
+        /// </summary>
+        [Test]
+        public void Polar3DToCartesian_AxisAlignedAngles_ReturnsExpectedVectorComponents() {
+            var xAxis = AstroUtil.Polar3DToCartesian(2.0, 0.0, 0.0);
+            var zAxis = AstroUtil.Polar3DToCartesian(2.0, Math.PI / 2.0, 0.0);
+            var negativeYAxis = AstroUtil.Polar3DToCartesian(2.0, Math.PI / 2.0, Math.PI / 2.0);
+
+            xAxis.X.Should().BeApproximately(2.0, AngleTolerance);
+            xAxis.Y.Should().BeApproximately(0.0, AngleTolerance);
+            xAxis.Z.Should().BeApproximately(0.0, AngleTolerance);
+            zAxis.Z.Should().BeApproximately(2.0, AngleTolerance);
+            negativeYAxis.Y.Should().BeApproximately(-2.0, AngleTolerance);
+        }
+
+        private static double AngularDifference(double actualDegrees, double expectedDegrees) {
+            double difference = Math.Abs(AstroUtil.EuclidianModulus(actualDegrees - expectedDegrees + 180.0, 360.0) - 180.0);
+            return difference;
+        }
+
+        private static void AssertCloseToTime(DateTime? actual, DateTime expected, TimeSpan tolerance) {
+            actual.Should().NotBeNull();
+            TimeSpan difference = (actual.Value - expected).Duration();
+            difference.Should().BeLessThanOrEqualTo(tolerance);
         }
     }
 }

--- a/NINA.Test/AstrometryTest/CustomRiseAndSetTest.cs
+++ b/NINA.Test/AstrometryTest/CustomRiseAndSetTest.cs
@@ -1,0 +1,39 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry.RiseAndSet;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class CustomRiseAndSetTest {
+        /// <summary>
+        /// Verifies custom rise/set events preserve caller-supplied times and do not attempt body
+        /// calculations, which is used when external horizon/event data is injected.
+        /// </summary>
+        [Test]
+        public void CustomRiseAndSet_ExplicitEvents_PreservesRiseAndSetTimes() {
+            DateTime rise = new DateTime(2024, 3, 20, 18, 0, 0, DateTimeKind.Utc);
+            DateTime set = new DateTime(2024, 3, 21, 6, 0, 0, DateTimeKind.Utc);
+            CustomRiseAndSet custom = new CustomRiseAndSet(rise, set);
+
+            custom.Compute().Should().BeTrue();
+#pragma warning disable CS0618
+            custom.Calculate().Result.Should().BeTrue();
+#pragma warning restore CS0618
+            custom.Rise.Should().Be(rise);
+            custom.Set.Should().Be(set);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/InputCoordinatesTest.cs
+++ b/NINA.Test/AstrometryTest/InputCoordinatesTest.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 /*
     Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors 
 
@@ -24,6 +24,85 @@ namespace NINA.Test.AstrometryTest {
 
     [TestFixture]
     public class InputCoordinatesTest {
+
+        /// <summary>
+        /// Verifies interactive alt-az entry for a target below the horizon, including the special
+        /// negative-zero degree case used for small negative altitudes such as -0 degrees 30 minutes.
+        /// The expected value is the direct sexagesimal conversion from degrees, arcminutes, and arcseconds.
+        /// </summary>
+        [Test]
+        public void InputTopocentricCoordinates_SexagesimalNegativeAltitude_PreservesBelowHorizonAngle() {
+            InputTopocentricCoordinates coordinates = new InputTopocentricCoordinates(Angle.ByDegree(51.4769), Angle.ByDegree(0.0), 46.0);
+
+            coordinates.AzDegrees = 123;
+            coordinates.AzMinutes = 45;
+            coordinates.AzSeconds = 30.0;
+            coordinates.AltMinutes = 30;
+            coordinates.AltSeconds = 15.0;
+            coordinates.NegativeAlt = true;
+            coordinates.AltDegrees = 0;
+
+            coordinates.Coordinates.Azimuth.Degree.Should().BeApproximately(123.75833333333334, 1e-12);
+            coordinates.Coordinates.Altitude.Degree.Should().BeApproximately(-0.5041666666666667, 1e-12);
+            coordinates.AltDegrees.Should().Be(0);
+            coordinates.AltMinutes.Should().Be(30);
+            coordinates.AltSeconds.Should().BeApproximately(15.0, 1e-12);
+            coordinates.NegativeAlt.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Verifies that changing the observing site preserves the entered horizontal target while
+        /// updating latitude, longitude, and elevation, which matters when the same local alt-az
+        /// pointing is evaluated for a different observing location.
+        /// </summary>
+        [Test]
+        public void InputTopocentricCoordinates_SetPosition_PreservesAltAzAndUpdatesSiteElevation() {
+            InputTopocentricCoordinates coordinates = new InputTopocentricCoordinates(
+                new TopocentricCoordinates(
+                    Angle.ByDegree(210.0),
+                    Angle.ByDegree(42.5),
+                    Angle.ByDegree(35.0),
+                    Angle.ByDegree(-105.0),
+                    1500.0));
+
+            coordinates.SetPosition(Angle.ByDegree(51.4769), Angle.ByDegree(0.0), 46.0);
+            InputTopocentricCoordinates clone = coordinates.Clone();
+
+            coordinates.Coordinates.Azimuth.Degree.Should().BeApproximately(210.0, 1e-12);
+            coordinates.Coordinates.Altitude.Degree.Should().BeApproximately(42.5, 1e-12);
+            coordinates.Coordinates.Latitude.Degree.Should().BeApproximately(51.4769, 1e-12);
+            coordinates.Coordinates.Longitude.Degree.Should().BeApproximately(0.0, 1e-12);
+            coordinates.Coordinates.Elevation.Should().Be(46.0);
+            clone.Should().NotBeSameAs(coordinates);
+            clone.Coordinates.Should().NotBeSameAs(coordinates.Coordinates);
+            clone.Coordinates.Elevation.Should().Be(46.0);
+        }
+
+        /// <summary>
+        /// Verifies invalid negative azimuth components are ignored while valid altitude edits below
+        /// the horizon retain their sign, protecting horizontal coordinate entry from impossible
+        /// negative azimuth fields without masking legitimate negative altitude fields.
+        /// </summary>
+        [Test]
+        public void InputTopocentricCoordinates_InvalidNegativeAzimuthParts_AreIgnored() {
+            InputTopocentricCoordinates coordinates = new InputTopocentricCoordinates(
+                new TopocentricCoordinates(
+                    Angle.ByDegree(15.25),
+                    Angle.ByDegree(-12.5),
+                    Angle.ByDegree(51.4769),
+                    Angle.ByDegree(0.0),
+                    46.0));
+
+            coordinates.AzDegrees = -1;
+            coordinates.AzMinutes = -1;
+            coordinates.AzSeconds = -1.0;
+            coordinates.AltMinutes = 45;
+            coordinates.AltSeconds = 0.0;
+
+            coordinates.Coordinates.Azimuth.Degree.Should().BeApproximately(15.25, 1e-12);
+            coordinates.Coordinates.Altitude.Degree.Should().BeApproximately(-12.75, 1e-12);
+            coordinates.NegativeAlt.Should().BeTrue();
+        }
 
         [Test]
         [TestCase(1, 10, 20, 1, 10, 20, false)]

--- a/NINA.Test/AstrometryTest/MeridianFlipTest.cs
+++ b/NINA.Test/AstrometryTest/MeridianFlipTest.cs
@@ -1,0 +1,108 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NINA.Profile.Interfaces;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class MeridianFlipTest {
+
+        /// <summary>
+        /// Verifies the hour-angle relation used for meridian timing: a target east of the meridian
+        /// reaches transit soon, a target west of the meridian wraps to the next upper culmination,
+        /// and a target exactly twelve sidereal hours away maps to the same meridian line.
+        /// </summary>
+        [Test]
+        [TestCase(6.0, 5.0, 1.0)]
+        [TestCase(4.0, 5.0, 11.0)]
+        [TestCase(17.0, 5.0, 0.0)]
+        public void TimeToMeridian_HourAngleGeometry_WrapsAtTwelveSiderealHours(double rightAscensionHours, double localSiderealTimeHours, double expectedHours) {
+            Coordinates coordinates = new Coordinates(Angle.ByHours(rightAscensionHours), Angle.ByDegree(0.0), Epoch.JNOW);
+
+            TimeSpan time = MeridianFlip.TimeToMeridian(coordinates, Angle.ByHours(localSiderealTimeHours));
+
+            time.TotalHours.Should().BeApproximately(expectedHours, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies the expected pier side from hour-angle quadrants: objects still approaching
+        /// the meridian use the west counterweight-down side, while objects past transit use east.
+        /// </summary>
+        [Test]
+        [TestCase(11.0, 10.0, PierSide.pierWest)]
+        [TestCase(9.0, 10.0, PierSide.pierEast)]
+        [TestCase(22.0, 10.0, PierSide.pierEast)]
+        public void ExpectedPierSide_HourAngleQuadrants_ReturnsCounterweightDownSide(double rightAscensionHours, double localSiderealTimeHours, PierSide expectedPierSide) {
+            Coordinates coordinates = new Coordinates(Angle.ByHours(rightAscensionHours), Angle.ByDegree(0.0), Epoch.JNOW);
+
+            PierSide pierSide = MeridianFlip.ExpectedPierSide(coordinates, Angle.ByHours(localSiderealTimeHours));
+
+            pierSide.Should().Be(expectedPierSide);
+        }
+
+        /// <summary>
+        /// Verifies side-of-pier protection when the mount is already flipped shortly before the
+        /// meridian: the next required flip is delayed by a half sidereal day instead of triggering
+        /// at the imminent meridian crossing.
+        /// </summary>
+        [Test]
+        public void TimeToMeridianFlip_AlreadyFlippedBeforeMeridian_DelaysToNextMeridianCycle() {
+            Mock<IMeridianFlipSettings> settings = new Mock<IMeridianFlipSettings>();
+            settings.SetupGet(x => x.MaxMinutesAfterMeridian).Returns(30.0);
+            settings.SetupGet(x => x.UseSideOfPier).Returns(true);
+            Coordinates coordinates = new Coordinates(Angle.ByHours(10.25), Angle.ByDegree(0.0), Epoch.JNOW);
+
+            TimeSpan time = MeridianFlip.TimeToMeridianFlip(settings.Object, coordinates, Angle.ByHours(10.0), PierSide.pierEast);
+
+            time.TotalHours.Should().BeApproximately(12.75, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies that an unknown pier side does not alter the pure hour-angle flip time, because
+        /// side-of-pier compensation is only physically meaningful when the mount reports a side.
+        /// </summary>
+        [Test]
+        public void TimeToMeridianFlip_UnknownPierSide_UsesProjectedHourAngleOnly() {
+            Mock<IMeridianFlipSettings> settings = new Mock<IMeridianFlipSettings>();
+            settings.SetupGet(x => x.MaxMinutesAfterMeridian).Returns(30.0);
+            settings.SetupGet(x => x.UseSideOfPier).Returns(true);
+            Coordinates coordinates = new Coordinates(Angle.ByHours(10.25), Angle.ByDegree(0.0), Epoch.JNOW);
+
+            TimeSpan time = MeridianFlip.TimeToMeridianFlip(settings.Object, coordinates, Angle.ByHours(10.0), PierSide.pierUnknown);
+
+            time.TotalHours.Should().BeApproximately(0.75, 1e-12);
+        }
+
+        /// <summary>
+        /// Verifies the post-meridian side-of-pier guard: if the target has crossed the meridian but
+        /// the mount still reports the expected pre-flip side, the imminent flip window is deferred
+        /// to the next meridian cycle instead of being treated as immediately actionable.
+        /// </summary>
+        [Test]
+        public void TimeToMeridianFlip_NotYetFlippedAfterMeridian_DelaysToNextMeridianCycle() {
+            Mock<IMeridianFlipSettings> settings = new Mock<IMeridianFlipSettings>();
+            settings.SetupGet(x => x.MaxMinutesAfterMeridian).Returns(30.0);
+            settings.SetupGet(x => x.UseSideOfPier).Returns(true);
+            Coordinates coordinates = new Coordinates(Angle.ByHours(10.0), Angle.ByDegree(0.0), Epoch.JNOW);
+
+            TimeSpan time = MeridianFlip.TimeToMeridianFlip(settings.Object, coordinates, Angle.ByHours(10.25), PierSide.pierEast);
+
+            time.TotalHours.Should().BeApproximately(12.25, 1e-12);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/MoonInfoTest.cs
+++ b/NINA.Test/AstrometryTest/MoonInfoTest.cs
@@ -1,0 +1,81 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Astrometry;
+using OxyPlot;
+using OxyPlot.Axes;
+using System;
+using System.Linq;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class MoonInfoTest {
+
+        /// <summary>
+        /// Verifies Moon-target separation by using the NOVAS lunar apparent position itself as the
+        /// target at the same instant MoonInfo samples for separation, so the angular distance should
+        /// collapse to nearly zero apart from transformation and topocentric rounding.
+        /// </summary>
+        [Test]
+        public void SetReferenceDateAndObserver_TargetAtMoonPosition_ReturnsNearZeroSeparation() {
+            DateTime referenceDate = new DateTime(2024, 4, 8, 6, 0, 0, DateTimeKind.Utc);
+            DateTime separationSampleTime = referenceDate.AddHours(12);
+            ObserverInfo observer = new ObserverInfo { Latitude = 29.7604, Longitude = -95.3698, Elevation = 15.0 };
+            NOVAS.SkyPosition moonPosition = AstroUtil.GetMoonPosition(separationSampleTime, observer);
+            Coordinates moonCoordinates = new Coordinates(Angle.ByHours(moonPosition.RA), Angle.ByDegree(moonPosition.Dec), Epoch.JNOW, separationSampleTime);
+            MoonInfo moonInfo = new MoonInfo(moonCoordinates);
+
+            moonInfo.SetReferenceDateAndObserver(referenceDate, observer);
+
+            moonInfo.Separation.Should().BeLessThan(0.1);
+            moonInfo.SeparationText.Should().Be("000°");
+            moonInfo.DataPoints.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies the generated lunar altitude curve spans one reference day at six-minute cadence
+        /// and reports the same maximum altitude as the sampled data, preserving the charted Moon path.
+        /// </summary>
+        [Test]
+        public void SetReferenceDateAndObserver_DisplayMoon_GeneratesOneDayAltitudeCurveAndMaximum() {
+            DateTime referenceDate = new DateTime(2024, 3, 25, 12, 0, 0, DateTimeKind.Utc);
+            ObserverInfo observer = new ObserverInfo { Latitude = 51.4769, Longitude = 0.0, Elevation = 46.0 };
+            Coordinates target = new Coordinates(Angle.ByDegree(180.0), Angle.ByDegree(0.0), Epoch.J2000, referenceDate);
+            MoonInfo moonInfo = new MoonInfo(target) { DisplayMoon = true };
+
+            moonInfo.SetReferenceDateAndObserver(referenceDate, observer);
+
+            moonInfo.DataPoints.Should().HaveCount(240);
+            moonInfo.DataPoints.Select(x => x.Y).Should().OnlyContain(altitude => altitude >= -90.0 && altitude <= 90.0);
+            moonInfo.MaxAltitude.Y.Should().Be(moonInfo.DataPoints.Max(x => x.Y));
+            moonInfo.MaxAltitude.Y.Should().BeGreaterThan(20.0);
+            moonInfo.DataPoints.First().X.Should().Be(Axis.ToDouble(referenceDate));
+        }
+
+        /// <summary>
+        /// Verifies current Moon display metadata remains in physically valid domains: the phase is
+        /// resolved to a known bucket and the grayscale alpha/color channels stay inside byte ranges.
+        /// This intentionally does not assert the known-buggy position-angle utility path.
+        /// </summary>
+        [Test]
+        public void CurrentMoonDisplayMetadata_ReturnsKnownPhaseAndValidColorChannels() {
+            MoonInfo moonInfo = new MoonInfo(new Coordinates(Angle.ByDegree(180.0), Angle.ByDegree(0.0), Epoch.J2000));
+
+            moonInfo.Phase.Should().NotBe(AstroUtil.MoonPhase.Unknown);
+            moonInfo.Color.A.Should().BeLessThanOrEqualTo(byte.MaxValue);
+            moonInfo.Color.R.Should().Be(moonInfo.Color.G);
+            moonInfo.Color.G.Should().Be(moonInfo.Color.B);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/MoonTest.cs
+++ b/NINA.Test/AstrometryTest/MoonTest.cs
@@ -1,0 +1,36 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry.Body;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class MoonTest {
+        /// <summary>
+        /// Verifies Moon distance remains within the physically expected geocentric range, catching
+        /// AU-to-kilometer conversion mistakes and accidental use of the wrong NOVAS body.
+        /// Reference: https://science.nasa.gov/moon/facts/
+        /// </summary>
+        [Test]
+        public void MoonCalculate_RepresentativeDate_ReturnsExpectedDistanceRange() {
+            Moon moon = new Moon(new DateTime(2024, 3, 25, 7, 0, 0, DateTimeKind.Utc), 51.4769, 0.0, 46.0);
+
+            moon.Calculate();
+
+            moon.Distance.Should().BeInRange(350_000.0, 410_000.0);
+            moon.Radius.Should().Be(1738.0);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/RectangularCoordinatesTest.cs
+++ b/NINA.Test/AstrometryTest/RectangularCoordinatesTest.cs
@@ -1,0 +1,75 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class RectangularCoordinatesTest {
+        private const double AngleTolerance = 1e-10;
+
+        /// <summary>
+        /// Verifies rectangular-to-spherical coordinate conversion with canonical axes, guarding
+        /// right-ascension quadrant handling and declination at the pole.
+        /// </summary>
+        [Test]
+        public void RectangularCoordinatesToPolar_CanonicalAxes_ReturnsExpectedRaDec() {
+            new RectangularCoordinates(1.0, 0.0, 0.0).ToPolar().RADegrees.Should().BeApproximately(0.0, AngleTolerance);
+            new RectangularCoordinates(0.0, 1.0, 0.0).ToPolar().RADegrees.Should().BeApproximately(90.0, AngleTolerance);
+            new RectangularCoordinates(0.0, -1.0, 0.0).ToPolar().RADegrees.Should().BeApproximately(270.0, AngleTolerance);
+            new RectangularCoordinates(0.0, 0.0, 1.0).ToPolar().Dec.Should().BeApproximately(90.0, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies ecliptic rotation around the x-axis, matching the standard obliquity rotation
+        /// used when converting ecliptic vectors into equatorial vectors.
+        /// </summary>
+        [Test]
+        public void RectangularCoordinatesRotateEcliptic_NinetyDegrees_RotatesYIntoZ() {
+            RectangularCoordinates rotated = new RectangularCoordinates(0.0, 1.0, 0.0).RotateEcliptic(Angle.ByDegree(90.0));
+
+            rotated.X.Should().BeApproximately(0.0, AngleTolerance);
+            rotated.Y.Should().BeApproximately(0.0, AngleTolerance);
+            rotated.Z.Should().BeApproximately(1.0, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies rectangular vector arithmetic used by solar-system calculations, including
+        /// distance preservation and string output useful for diagnostics.
+        /// </summary>
+        [Test]
+        public void RectangularCoordinates_VectorArithmetic_ReturnsComponentWiseResults() {
+            RectangularCoordinates left = new RectangularCoordinates(1.0, 2.0, 3.0);
+            RectangularCoordinates right = new RectangularCoordinates(4.0, 6.0, 8.0);
+
+            RectangularCoordinates sum = left + right;
+            RectangularCoordinates difference = right - left;
+            RectangularCoordinates product = left * 2.0;
+            RectangularCoordinates quotient = right / 2.0;
+            RectangularPV pv = new RectangularPV(left, right);
+
+            sum.Distance.Should().BeApproximately(Math.Sqrt(5.0 * 5.0 + 8.0 * 8.0 + 11.0 * 11.0), AngleTolerance);
+            difference.X.Should().Be(3.0);
+            difference.Y.Should().Be(4.0);
+            difference.Z.Should().Be(5.0);
+            product.Z.Should().Be(6.0);
+            quotient.Y.Should().Be(3.0);
+            left.ToString().Should().Contain("X=1");
+            pv.Position.Should().BeSameAs(left);
+            pv.Velocity.Should().BeSameAs(right);
+            pv.ToString().Should().Contain(nameof(RectangularPV.Position));
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/SiderealShiftTrackingRateTest.cs
+++ b/NINA.Test/AstrometryTest/SiderealShiftTrackingRateTest.cs
@@ -1,0 +1,58 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class SiderealShiftTrackingRateTest {
+        private const double AngleTolerance = 1e-10;
+
+        /// <summary>
+        /// Verifies sidereal shift tracking converts an ephemeris delta into per-hour and
+        /// per-second rates without losing the sidereal-second conversion needed by mount tracking.
+        /// </summary>
+        [Test]
+        public void SiderealShiftTrackingRate_CreateFromCoordinates_ReturnsExpectedRates() {
+            Coordinates start = new Coordinates(10.0, -5.0, Epoch.J2000, Coordinates.RAType.Degrees);
+            Coordinates end = new Coordinates(10.5, -4.75, Epoch.J2000, Coordinates.RAType.Degrees);
+
+            SiderealShiftTrackingRate rate = SiderealShiftTrackingRate.Create(start, end, TimeSpan.FromHours(2));
+
+            rate.Enabled.Should().BeTrue();
+            rate.RADegreesPerHour.Should().BeApproximately(0.25, AngleTolerance);
+            rate.DecDegreesPerHour.Should().BeApproximately(0.125, AngleTolerance);
+            rate.RAArcsecsPerHour.Should().BeApproximately(900.0, AngleTolerance);
+            rate.RASecondsPerSiderealSecond.Should().BeApproximately(0.25 / SiderealShiftTrackingRate.SIDEREAL_RATE, AngleTolerance);
+        }
+
+        /// <summary>
+        /// Verifies disabled and direct sidereal-rate factories for non-sidereal tracking, including
+        /// declination arcsecond rates used by mount control.
+        /// </summary>
+        [Test]
+        public void SiderealShiftTrackingRate_DisabledAndDirectFactories_ReturnExpectedRates() {
+            SiderealShiftTrackingRate disabled = SiderealShiftTrackingRate.Disabled;
+            SiderealShiftTrackingRate direct = SiderealShiftTrackingRate.Create(0.5, -0.25);
+
+            disabled.Enabled.Should().BeFalse();
+            disabled.RAArcsecsPerHour.Should().Be(0.0);
+            direct.Enabled.Should().BeTrue();
+            direct.RAArcsecsPerSec.Should().Be(0.5);
+            direct.DecArcsecsPerSec.Should().Be(-0.25);
+            direct.DecArcsecsPerHour.Should().Be(-900.0);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/SunTest.cs
+++ b/NINA.Test/AstrometryTest/SunTest.cs
@@ -1,0 +1,40 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry.Body;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class SunTest {
+        /// <summary>
+        /// Verifies Sun distance near perihelion and aphelion ranges, using known annual extremes
+        /// to catch unit conversion or body-selection mistakes in the NOVAS body wrapper.
+        /// Reference: https://www.timeanddate.com/astronomy/perihelion-aphelion-solstice.html
+        /// </summary>
+        [Test]
+        public void SunCalculate_PerihelionAndAphelion_ReturnsExpectedDistanceRanges() {
+            Sun perihelion = new Sun(new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc), 0.0, 0.0, 0.0);
+            Sun aphelion = new Sun(new DateTime(2024, 7, 5, 0, 0, 0, DateTimeKind.Utc), 0.0, 0.0, 0.0);
+
+            perihelion.Calculate();
+            aphelion.Calculate();
+
+            perihelion.Distance.Should().BeInRange(146_000_000.0, 148_500_000.0);
+            aphelion.Distance.Should().BeInRange(151_000_000.0, 153_000_000.0);
+            aphelion.Distance.Should().BeGreaterThan(perihelion.Distance);
+            perihelion.Radius.Should().Be(696342.0);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/TopocentricCoordinatesTest.cs
+++ b/NINA.Test/AstrometryTest/TopocentricCoordinatesTest.cs
@@ -12,7 +12,12 @@
 using FluentAssertions;
 using NINA.Astrometry;
 using NINA.Core.Enum;
+using NINA.Core.Utility;
 using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
 
 namespace NINA.Test.AstrometryTest {
 
@@ -68,6 +73,88 @@ namespace NINA.Test.AstrometryTest {
             noRefraction.Dec.Should().BeInRange(-90.0, 90.0);
             withRefraction.RADegrees.Should().BeInRange(0.0, 360.0);
             withRefraction.Dec.Should().BeInRange(-90.0, 90.0);
+        }
+
+        /// <summary>
+        /// Verifies topocentric-to-celestial conversion consumes UT1-UTC from the Earth-rotation
+        /// table. A controlled one-second UT1 change should shift right ascension by roughly one
+        /// sidereal second while leaving the sky coordinate otherwise physically valid.
+        /// Reference: https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop.html
+        /// </summary>
+        [Test]
+        public void Transform_ControlledUt1MinusUtc_ShiftsRightAscensionBySiderealRotation() {
+            DateTime date = new DateTime(2024, 4, 8, 18, 0, 0, DateTimeKind.Utc);
+            TopocentricCoordinates topocentric = new TopocentricCoordinates(
+                Angle.ByDegree(180.0),
+                Angle.ByDegree(60.0),
+                Angle.ByDegree(35.0),
+                Angle.ByDegree(-105.0),
+                1600.0);
+            using TempEarthRotationDatabase zeroUt1Database = CreateEarthRotationDatabase((date, 0.0));
+            using TempEarthRotationDatabase oneSecondUt1Database = CreateEarthRotationDatabase((date, 1.0));
+
+            ClearDeltaUTCaches();
+            Coordinates zeroUt1 = topocentric.Transform(date, Epoch.J2000, 0.0, 0.0, 0.0, 0.0, zeroUt1Database.Interaction);
+            ClearDeltaUTCaches();
+            Coordinates oneSecondUt1 = topocentric.Transform(date, Epoch.J2000, 0.0, 0.0, 0.0, 0.0, oneSecondUt1Database.Interaction);
+
+            AngularDifference(oneSecondUt1.RADegrees, zeroUt1.RADegrees).Should().BeInRange(10.0 / 3600.0, 20.0 / 3600.0);
+            oneSecondUt1.Dec.Should().BeInRange(-90.0, 90.0);
+        }
+
+        private static double AngularDifference(double actualDegrees, double expectedDegrees) {
+            double difference = Math.Abs(AstroUtil.EuclidianModulus(actualDegrees - expectedDegrees + 180.0, 360.0) - 180.0);
+            return difference;
+        }
+
+        private static TempEarthRotationDatabase CreateEarthRotationDatabase(params (DateTime Date, double Ut1MinusUtc)[] rows) {
+            string databasePath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"earth-rotation-{Guid.NewGuid():N}.sqlite");
+            string connectionString = $"Data Source={databasePath};";
+            DatabaseInteraction databaseInteraction = new DatabaseInteraction(connectionString);
+
+            using (var context = databaseInteraction.GetContext()) {
+                foreach ((DateTime date, double ut1MinusUtc) in rows) {
+                    long unixTimestamp = CoreUtil.DateTimeToUnixTimeStamp(date);
+                    double modifiedJulianDate = AstroUtil.GetJulianDate(date) - 2400000.5;
+                    context.Database.ExecuteSqlCommand(
+                        "INSERT OR REPLACE INTO `earthrotationparameters` (date, modifiedjuliandate, x, y, ut1_utc, lod, dx, dy) VALUES (@p0, @p1, 0, 0, @p2, 1, 0, 0)",
+                        unixTimestamp,
+                        modifiedJulianDate,
+                        ut1MinusUtc);
+                }
+            }
+
+            return new TempEarthRotationDatabase(databasePath, databaseInteraction);
+        }
+
+        private static void ClearDeltaUTCaches() {
+            typeof(AstroUtil).GetField("DeltaUTToday", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTYesterday", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTTomorrow", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(AstroUtil).GetField("DeltaUTReference", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, default(DateTime));
+
+            FieldInfo cacheField = typeof(AstroUtil).GetField("DeltaUTCache", BindingFlags.NonPublic | BindingFlags.Static);
+            cacheField?.SetValue(null, new ConcurrentDictionary<DateTime, double>());
+        }
+
+        private sealed class TempEarthRotationDatabase : IDisposable {
+            public TempEarthRotationDatabase(string path, DatabaseInteraction interaction) {
+                Path = path;
+                Interaction = interaction;
+            }
+
+            public string Path { get; }
+            public DatabaseInteraction Interaction { get; }
+
+            public void Dispose() {
+                System.Data.SQLite.SQLiteConnection.ClearAllPools();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                if (File.Exists(Path)) {
+                    File.Delete(Path);
+                }
+            }
         }
     }
 }

--- a/NINA.Test/AstrometryTest/TopocentricCoordinatesTest.cs
+++ b/NINA.Test/AstrometryTest/TopocentricCoordinatesTest.cs
@@ -1,0 +1,73 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NUnit.Framework;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class TopocentricCoordinatesTest {
+        /// <summary>
+        /// Verifies topocentric coordinate value semantics: altitude-side classification, clone
+        /// independence, default constructors, and diagnostic text.
+        /// </summary>
+        [Test]
+        public void TopocentricCoordinates_ValueSemantics_PreserveAnglesAndSiteSide() {
+            TopocentricCoordinates east = new TopocentricCoordinates(
+                Angle.ByDegree(90.0),
+                Angle.ByDegree(45.0),
+                Angle.ByDegree(51.5),
+                Angle.ByDegree(13.0),
+                100.0);
+            TopocentricCoordinates west = new TopocentricCoordinates(
+                Angle.ByDegree(270.0),
+                Angle.ByDegree(45.0),
+                Angle.ByDegree(51.5),
+                Angle.ByDegree(13.0));
+
+            TopocentricCoordinates copy = east.Copy();
+            TopocentricCoordinates clone = east.Clone();
+
+            east.AltitudeSite.Should().Be(AltitudeSite.EAST);
+            west.AltitudeSite.Should().Be(AltitudeSite.WEST);
+            copy.Should().NotBeSameAs(east);
+            clone.Azimuth.Degree.Should().Be(east.Azimuth.Degree);
+            clone.Elevation.Should().Be(100.0);
+            west.Elevation.Should().Be(0.0);
+            east.ToString().Should().Contain("Alt:");
+        }
+
+        /// <summary>
+        /// Verifies topocentric compatibility transform overloads return finite celestial
+        /// coordinates when no explicit observation time is supplied.
+        /// </summary>
+        [Test]
+        public void TopocentricTransform_CompatibilityOverloads_ReturnFiniteCoordinates() {
+            TopocentricCoordinates topocentric = new TopocentricCoordinates(
+                Angle.ByDegree(180.0),
+                Angle.ByDegree(60.0),
+                Angle.ByDegree(35.0),
+                Angle.ByDegree(-105.0),
+                1600.0);
+
+            Coordinates noRefraction = topocentric.Transform(Epoch.J2000);
+            Coordinates withRefraction = topocentric.Transform(Epoch.J2000, 800.0, 5.0, 20.0, 0.574);
+
+            noRefraction.RADegrees.Should().BeInRange(0.0, 360.0);
+            noRefraction.Dec.Should().BeInRange(-90.0, 90.0);
+            withRefraction.RADegrees.Should().BeInRange(0.0, 360.0);
+            withRefraction.Dec.Should().BeInRange(-90.0, 90.0);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/TwilightCalculatorTest.cs
+++ b/NINA.Test/AstrometryTest/TwilightCalculatorTest.cs
@@ -49,5 +49,20 @@ namespace NINA.Test.AstrometryTest {
 
             legacy.Should().Be(current);
         }
+
+        /// <summary>
+        /// Verifies polar-day behavior where neither astronomical-night rise nor normal sunrise/set
+        /// events exist; the calculator should return zero duration instead of manufacturing a
+        /// twilight interval from missing horizon crossings.
+        /// Reference: https://www.sunrise-and-sunset.com/en/sun/norway/tromso/2024
+        /// </summary>
+        [Test]
+        public void TwilightCalculator_TromsoMidnightSun_ReturnsZeroDurationForMissingCrossings() {
+            TwilightCalculator calculator = new TwilightCalculator();
+
+            TimeSpan duration = calculator.GetTwilightDuration(new DateTime(2024, 6, 21, 12, 0, 0, DateTimeKind.Utc), 69.6492, 18.9553, 10.0);
+
+            duration.Should().Be(TimeSpan.Zero);
+        }
     }
 }

--- a/NINA.Test/AstrometryTest/TwilightCalculatorTest.cs
+++ b/NINA.Test/AstrometryTest/TwilightCalculatorTest.cs
@@ -1,0 +1,53 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+using FluentAssertions;
+using NINA.Astrometry;
+using NUnit.Framework;
+using System;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class TwilightCalculatorTest {
+        /// <summary>
+        /// Verifies the twilight calculator returns a positive, bounded duration for a mid-latitude
+        /// equinox case where all civil sunrise and astronomical twilight events exist.
+        /// Reference: https://gml.noaa.gov/grad/solcalc/calcdetails.html
+        /// </summary>
+        [Test]
+        public void TwilightCalculator_GreenwichEquinox_ReturnsPhysicalDuration() {
+            TwilightCalculator calculator = new TwilightCalculator();
+
+            TimeSpan duration = calculator.GetTwilightDuration(new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc), 51.4769, 0.0, 46.0);
+
+            duration.Should().BeGreaterThan(TimeSpan.FromMinutes(60));
+            duration.Should().BeLessThan(TimeSpan.FromMinutes(180));
+        }
+
+        /// <summary>
+        /// Verifies the legacy twilight-duration overload delegates to the elevation-aware overload,
+        /// preserving historical call sites that do not supply site elevation.
+        /// </summary>
+        [Test]
+        public void TwilightCalculator_LegacyOverload_MatchesZeroElevationDuration() {
+            TwilightCalculator calculator = new TwilightCalculator();
+            DateTime date = new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc);
+
+#pragma warning disable CS0618
+            TimeSpan legacy = calculator.GetTwilightDuration(date, 51.4769, 0.0);
+#pragma warning restore CS0618
+            TimeSpan current = calculator.GetTwilightDuration(date, 51.4769, 0.0, 0.0);
+
+            legacy.Should().Be(current);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/WorldCoordinateSystemTest.cs
+++ b/NINA.Test/AstrometryTest/WorldCoordinateSystemTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using NINA.Astrometry;
 using System;
 using System.Collections.Generic;
@@ -21,6 +21,60 @@ namespace NINA.Test.AstrometryTest {
             wcs.PositionAngle.Should().BeApproximately(AstroUtil.EuclidianModulus(360 - expectedRotation, 360), 0.001);
             wcs.PixelScaleX.Should().BeApproximately(expectedPixelScaleX, 0.001);
             wcs.PixelScaleY.Should().BeApproximately(expectedPixelScaleY, 0.001);
+        }
+
+        private const double AngleTolerance = 1e-10;
+
+        /// <summary>
+        /// Verifies WCS coordinate lookup at the reference pixel and one pixel from center, covering
+        /// the production GetCoordinates path in addition to direct projection helpers.
+        /// </summary>
+        [Test]
+        public void WorldCoordinateSystemGetCoordinates_ReferenceAndOffsetPixels_ReturnsExpectedSkyCoordinates() {
+            WorldCoordinateSystem wcs = new WorldCoordinateSystem(
+                180.0,
+                45.0,
+                1000.0,
+                1000.0,
+                -1.0 / 3600.0,
+                1.0 / 3600.0,
+                0.0);
+
+            Coordinates center = wcs.GetCoordinates(1000.0, 1000.0);
+            Coordinates offset = wcs.GetCoordinates(1001.0, 1000.0);
+
+            center.RADegrees.Should().BeApproximately(180.0, 1e-12);
+            center.Dec.Should().BeApproximately(45.0, 1e-12);
+            offset.RADegrees.Should().BeLessThan(center.RADegrees);
+        }
+
+        /// <summary>
+        /// Verifies WCS flipped-axis handling for both CD-matrix and CDELT/CROTA inputs, because
+        /// FITS solvers can encode handedness in either form.
+        /// </summary>
+        [Test]
+        public void WorldCoordinateSystem_FlippedAxisInputs_SetFlippedAndAdjustedRotation() {
+            WorldCoordinateSystem matrix = new WorldCoordinateSystem(
+                180.0,
+                45.0,
+                1000.0,
+                1000.0,
+                1.0 / 3600.0,
+                0.0,
+                0.0,
+                1.0 / 3600.0);
+            WorldCoordinateSystem cdelt = new WorldCoordinateSystem(
+                180.0,
+                45.0,
+                1000.0,
+                1000.0,
+                1.0 / 3600.0,
+                1.0 / 3600.0,
+                30.0);
+
+            matrix.Flipped.Should().BeTrue();
+            cdelt.Flipped.Should().BeTrue();
+            cdelt.Rotation.Should().BeApproximately(330.0, AngleTolerance);
         }
     }
 }

--- a/NINA.Test/CoordinatesTest.cs
+++ b/NINA.Test/CoordinatesTest.cs
@@ -495,5 +495,52 @@ namespace NINA.Test {
                 sut.Epoch.Should().Be(Epoch.JNOW);
             }
         }
+
+        private const double ArcSecondToleranceInDegrees = 1.0 / 3600.0;
+
+        /// <summary>
+        /// Verifies J2000 to JNOW and back for bright-star style coordinates, ensuring precession,
+        /// nutation, and equation-of-origins handling remains numerically reversible.
+        /// References: https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Vega,
+        /// https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Sirius, and
+        /// https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Polaris
+        /// </summary>
+        [Test]
+        [TestCase(279.23473479, 38.78368896)]
+        [TestCase(101.28715533, -16.71611586)]
+        [TestCase(37.95456067, 89.26410897)]
+        public void CoordinatesTransform_J2000ToJNowRoundTrip_ReturnsOriginalCoordinatesWithinArcsecond(double rightAscensionDegrees, double declinationDegrees) {
+            DateTime observationTime = new DateTime(2026, 4, 16, 22, 0, 0, DateTimeKind.Utc);
+            Coordinates j2000 = new Coordinates(Angle.ByDegree(rightAscensionDegrees), Angle.ByDegree(declinationDegrees), Epoch.J2000, observationTime);
+
+            Coordinates roundTrip = j2000.Transform(Epoch.JNOW).Transform(Epoch.J2000);
+
+            AngularDifference(roundTrip.RADegrees, rightAscensionDegrees).Should().BeLessThan(ArcSecondToleranceInDegrees);
+            roundTrip.Dec.Should().BeApproximately(declinationDegrees, ArcSecondToleranceInDegrees);
+        }
+
+        /// <summary>
+        /// Verifies a full topocentric round trip without atmospheric refraction, using a realistic
+        /// mid-latitude observing site and a high-altitude target to avoid horizon singularities.
+        /// </summary>
+        [Test]
+        public void TopocentricTransform_CelestialToObservedAndBackWithoutRefraction_PreservesAstrometricCoordinates() {
+            DateTime observationTime = new DateTime(2024, 8, 1, 3, 0, 0, DateTimeKind.Utc);
+            Coordinates vega = new Coordinates(Angle.ByDegree(279.23473479), Angle.ByDegree(38.78368896), Epoch.J2000, observationTime);
+            Angle latitude = Angle.ByDegree(40.7378);
+            Angle longitude = Angle.ByDegree(-74.0010);
+            double elevation = 10.0;
+
+            TopocentricCoordinates observed = vega.Transform(latitude, longitude, elevation, observationTime);
+            Coordinates roundTrip = observed.Transform(observationTime, Epoch.J2000, 0.0, 0.0, 0.0, 0.0);
+
+            AngularDifference(roundTrip.RADegrees, vega.RADegrees).Should().BeLessThan(2.0 * ArcSecondToleranceInDegrees);
+            roundTrip.Dec.Should().BeApproximately(vega.Dec, 2.0 * ArcSecondToleranceInDegrees);
+        }
+
+        private static double AngularDifference(double actualDegrees, double expectedDegrees) {
+            double difference = Math.Abs(AstroUtil.EuclidianModulus(actualDegrees - expectedDegrees + 180.0, 360.0) - 180.0);
+            return difference;
+        }
     }
 }

--- a/NINA.Test/NighttimeCalculatorTest.cs
+++ b/NINA.Test/NighttimeCalculatorTest.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 /*
     Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors 
 
@@ -10,6 +10,9 @@
 */
 #endregion "copyright"
 using NINA.Astrometry;
+using FluentAssertions;
+using Moq;
+using NINA.Profile.Interfaces;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
@@ -64,6 +67,52 @@ namespace NINA.Test {
             var referenceDate = NighttimeCalculator.GetReferenceDate(date);
             var expectedDate = new DateTime(date.Year, date.Month, date.Day, 12, 0, 0);
             Assert.That(referenceDate, Is.EqualTo(expectedDate));
+        }
+
+        /// <summary>
+        /// Verifies a complete Greenwich equinox night calculation, including reference-day selection,
+        /// physical ordering of twilight and sunrise/sunset events, lunar illumination bounds, and cache
+        /// reuse for multiple requested times within the same astronomical reference night.
+        /// </summary>
+        [Test]
+        public void Calculate_GreenwichEquinox_ReturnsOrderedEventsAndCachesReferenceNight() {
+            Mock<IProfileService> profileService = CreateProfileService(51.4769, 0.0, 46.0);
+            NighttimeCalculator calculator = new NighttimeCalculator(profileService.Object);
+            DateTime evening = new DateTime(2024, 3, 20, 22, 0, 0, DateTimeKind.Utc);
+            DateTime beforeDawn = new DateTime(2024, 3, 21, 4, 0, 0, DateTimeKind.Utc);
+
+            NighttimeData data = calculator.Calculate(evening);
+            NighttimeData cached = calculator.Calculate(beforeDawn);
+
+            cached.Should().BeSameAs(data);
+            data.Date.Should().Be(evening);
+            data.ReferenceDate.Should().Be(new DateTime(2024, 3, 20, 12, 0, 0, DateTimeKind.Utc));
+            data.SunRiseAndSet.Set.Should().NotBeNull();
+            data.SunRiseAndSet.Rise.Should().NotBeNull();
+            data.CivilTwilightRiseAndSet.Set.Should().BeBefore(data.NauticalTwilightRiseAndSet.Set.Value);
+            data.NauticalTwilightRiseAndSet.Set.Should().BeBefore(data.TwilightRiseAndSet.Set.Value);
+            data.TwilightRiseAndSet.Rise.Should().BeBefore(data.NauticalTwilightRiseAndSet.Rise.Value);
+            data.NauticalTwilightRiseAndSet.Rise.Should().BeBefore(data.CivilTwilightRiseAndSet.Rise.Value);
+            data.Illumination.Should().BeInRange(0.0, 1.0);
+            data.ReferenceDateSpan.Should().HaveCount(2);
+            data.NightDuration.Should().HaveCount(2);
+            data.TwilightDuration.Should().HaveCount(6);
+            data.NauticalTwilightDuration.Should().HaveCount(6);
+            data.CivilTwilightDuration.Should().HaveCount(6);
+        }
+
+        private static Mock<IProfileService> CreateProfileService(double latitude, double longitude, double elevation) {
+            Mock<IAstrometrySettings> astrometrySettings = new Mock<IAstrometrySettings>();
+            astrometrySettings.SetupGet(x => x.Latitude).Returns(latitude);
+            astrometrySettings.SetupGet(x => x.Longitude).Returns(longitude);
+            astrometrySettings.SetupGet(x => x.Elevation).Returns(elevation);
+
+            Mock<IProfile> profile = new Mock<IProfile>();
+            profile.SetupGet(x => x.AstrometrySettings).Returns(astrometrySettings.Object);
+
+            Mock<IProfileService> profileService = new Mock<IProfileService>();
+            profileService.SetupGet(x => x.ActiveProfile).Returns(profile.Object);
+            return profileService;
         }
     }
 }


### PR DESCRIPTION
## Purpose

Improves NINA.Astrometry test coverage with meaningful scientific and regression-oriented tests for astronomical
calculations.

This adds focused coverage for:

- Julian Date and TT conversion reference values
- Delta-T / UT1-UTC Earth-rotation handling
- Sidereal time and downstream topocentric transforms
- Solar declination at equinoxes and solstices
- Sun/Moon rise-set, twilight, polar day/night, lunar illumination, and Moon altitude behavior
- Coordinate transforms, WCS behavior, topocentric coordinates, sidereal tracking rates, meridian flip timing, and
  Moon chart data
- Sexagesimal parsing/formatting and physical helper calculations such as airmass, refraction, pressure, and AU
  conversion

Also fixes AstroUtil.DMSToDegrees comma-decimal parsing so European-formatted DMS values such as 12°30'30,5" are
parsed correctly.

## How Was It Tested?

Automated verification performed:

- Built NINA.Test.csproj with MSBuild: passed
- Delta-T / Earth-rotation targeted tests: 4 passed
- Astrometry-focused test slice: 1007 passed
- Full suite single-worker run: 3662 passed, 41 skipped, 0 failed

Coverage was also collected for the astrometry-focused slice. Notable calculation-focused coverage includes:

- AstroUtil: ~93.6% line coverage
- MeridianFlip: ~95.6% line / ~95.5% branch
- MoonInfo: ~97.4% line / 100% branch
- TwilightCalculator: 100% line
- TopocentricCoordinates, RectangularCoordinates, SiderealShiftTrackingRate, WorldCoordinateSystem: 100% line

No UI changes were made.

## AI / Tooling Disclosure

OpenAI Codex (GPT-5-based coding agent)

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
    - [x] No breaking changes to interfaces
    - [x] No changes to method/class signatures (especially optional parameters)
- [ ] RELEASE_NOTES.md updated (if applicable)
- [ ] Documentation (https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None.

## Screenshots

Not applicable. No UI changes.

## Additional Notes

The new Delta-T / Earth-rotation tests use temporary SQLite databases with controlled earthrotationparameters rows
to verify the real DatabaseInteraction.GetUT1_UTC path and downstream consumers such as sidereal time and
topocentric transforms.