### PR TITLE
Increase test coverage for NINA.Plugin

### DIFF
--- a/NINA.Plugin/Properties/AssemblyInfo.cs
+++ b/NINA.Plugin/Properties/AssemblyInfo.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NINA.Plugin")]
 [assembly: AssemblyDescription("This assembly contains the plugin related components of N.I.N.A.")]
 [assembly: AssemblyConfiguration("")]
+[assembly: InternalsVisibleTo("NINA.Test")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/NINA.Test/NINA.Test.csproj
+++ b/NINA.Test/NINA.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>

--- a/NINA.Test/Plugin/ConcreteManifestConverterTest.cs
+++ b/NINA.Test/Plugin/ConcreteManifestConverterTest.cs
@@ -1,0 +1,71 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Newtonsoft.Json;
+using NINA.Plugin.Interfaces;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class ConcreteManifestConverterTest {
+
+        /// <summary>
+        /// Verifies that interface-backed manifest properties serialize through their concrete
+        /// converter and can be read back into the same concrete plugin version shape.
+        /// </summary>
+        [Test]
+        public void Converter_WritesAndReadsConcreteManifestProperty() {
+            var manifest = new PluginManifest {
+                Name = "Converter Fixture",
+                Identifier = "63a6fe09-6e9a-4524-b258-91e7efbb4cda",
+                Version = new PluginVersion("2.4.6.8"),
+                Author = "NINA Test Observatory",
+                Repository = "https://example.invalid/converter-fixture.git",
+                License = "MPL-2.0",
+                LicenseURL = "https://www.mozilla.org/en-US/MPL/2.0/",
+                MinimumApplicationVersion = new PluginVersion("3.0.0.0"),
+                Descriptions = new PluginDescription {
+                    ShortDescription = "Converter fixture"
+                },
+                Installer = new PluginInstallerDetails {
+                    URL = "https://example.invalid/converter-fixture.dll",
+                    Type = InstallerType.DLL,
+                    Checksum = new string('a', 64),
+                    ChecksumType = InstallerChecksum.SHA256
+                }
+            };
+
+            string json = JsonConvert.SerializeObject(manifest);
+            PluginManifest roundTrip = JsonConvert.DeserializeObject<PluginManifest>(json);
+
+            json.Should().Contain("\"Major\":2");
+            roundTrip.Version.Should().BeOfType<PluginVersion>();
+            roundTrip.Version.ToString().Should().Be("2.4.6.8");
+        }
+
+        /// <summary>
+        /// Verifies that the generic manifest converter advertises support for interface-shaped
+        /// properties because manifest JSON stores interface contracts with concrete values.
+        /// </summary>
+        [Test]
+        public void CanConvert_ReturnsTrueForInterfacePropertyTypes() {
+            var converter = new ConcreteManifestConverter<PluginVersion>();
+
+            converter.CanConvert(typeof(IPluginVersion)).Should().BeTrue();
+        }
+    }
+}

--- a/NINA.Test/Plugin/ConstantsTest.cs
+++ b/NINA.Test/Plugin/ConstantsTest.cs
@@ -1,0 +1,49 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Core.Utility;
+using NINA.Plugin;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class ConstantsTest {
+
+        /// <summary>
+        /// Verifies that plugin runtime folders are version-scoped by the plugin API floor rather
+        /// than the full nightly application revision, preserving installed plugins across patch builds.
+        /// </summary>
+        [Test]
+        public void PluginFolders_UseMinimumApplicationVersionScope() {
+            string expectedMinimumApplicationVersion = typeof(PluginLoader).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(x => x.Key == "PluginMinimumApplicationVersion")
+                .Value;
+            var expectedVersion = new Version(expectedMinimumApplicationVersion);
+            string expectedVersionFolder = $"{expectedVersion.Major}.{expectedVersion.Minor}.{expectedVersion.Build}";
+
+            Constants.ApplicationVersion.Should().Be(new Version(CoreUtil.Version));
+            Constants.ApplicationVersionWithoutRevision.Should().Be(expectedVersionFolder);
+
+            Constants.BaseUserExtensionsFolder.Should().Be(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "Plugins"));
+            Constants.UserExtensionsFolder.Should().Be(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "Plugins", expectedVersionFolder));
+            Constants.StagingFolder.Should().Be(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "PluginStaging", expectedVersionFolder));
+            Constants.DeletionFolder.Should().Be(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "PluginDeletion", expectedVersionFolder));
+            Constants.MainPluginRepository.Should().Be("https://nighttime-imaging.eu/wp-json/nina/v1");
+        }
+    }
+}

--- a/NINA.Test/Plugin/LoopbackHttpServer.cs
+++ b/NINA.Test/Plugin/LoopbackHttpServer.cs
@@ -1,0 +1,85 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace NINA.Test.Plugin {
+
+    internal sealed class LoopbackHttpServer : IDisposable {
+        private readonly TcpListener listener;
+        private readonly Task serverTask;
+        private readonly byte[] body;
+        private readonly string contentType;
+        private readonly string fileName;
+
+        public LoopbackHttpServer(byte[] body, string contentType = "application/octet-stream", string fileName = null) {
+            this.body = body;
+            this.contentType = contentType;
+            this.fileName = fileName;
+            listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Url = $"http://127.0.0.1:{port}";
+            serverTask = Task.Run(ServeSingleRequest);
+        }
+
+        public string Url { get; }
+
+        public void Dispose() {
+            listener.Stop();
+            try {
+                serverTask.Wait(TimeSpan.FromSeconds(5));
+            } catch {
+            }
+        }
+
+        private async Task ServeSingleRequest() {
+            try {
+                using TcpClient client = await listener.AcceptTcpClientAsync();
+                await using NetworkStream stream = client.GetStream();
+                await ReadHeaders(stream);
+
+                string contentDisposition = string.IsNullOrEmpty(fileName) ? string.Empty : $"Content-Disposition: attachment; filename=\"{fileName}\"\r\n";
+                string headers =
+                    "HTTP/1.1 200 OK\r\n" +
+                    $"Content-Length: {body.Length}\r\n" +
+                    $"Content-Type: {contentType}\r\n" +
+                    contentDisposition +
+                    "Connection: close\r\n" +
+                    "\r\n";
+                byte[] headerBytes = Encoding.ASCII.GetBytes(headers);
+                await stream.WriteAsync(headerBytes);
+                await stream.WriteAsync(body);
+            } finally {
+                listener.Stop();
+            }
+        }
+
+        private static async Task ReadHeaders(NetworkStream stream) {
+            var buffer = new byte[1];
+            var recentBytes = new Queue<byte>(4);
+            while (await stream.ReadAsync(buffer.AsMemory(0, 1)) == 1) {
+                recentBytes.Enqueue(buffer[0]);
+                while (recentBytes.Count > 4) {
+                    recentBytes.Dequeue();
+                }
+                if (recentBytes.Count == 4 && recentBytes.SequenceEqual(new byte[] { 13, 10, 13, 10 })) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/NINA.Test/Plugin/MessageBrokerTest.cs
+++ b/NINA.Test/Plugin/MessageBrokerTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using NINA.Plugin.Interfaces;
 using NINA.Plugin.Messaging;
 using System;
@@ -18,6 +18,10 @@ namespace NINA.Test.Plugin {
             _messageBroker = new MessageBroker();
         }
 
+        /// <summary>
+        /// Verifies that publishing a plugin message delivers the exact message object to a subscriber
+        /// registered for the same topic.
+        /// </summary>
         [Test]
         public async Task PublishAsync_ShouldNotifySubscribers() {
             // Arrange
@@ -33,6 +37,10 @@ namespace NINA.Test.Plugin {
                 .Which.Should().Be(message);
         }
 
+        /// <summary>
+        /// Verifies that topic routing isolates plugin messages from subscribers registered for a
+        /// different topic.
+        /// </summary>
         [Test]
         public async Task PublishAsync_ShouldNotNotifyUnsubscribedTopics() {
             // Arrange
@@ -47,6 +55,9 @@ namespace NINA.Test.Plugin {
             subscriber.ReceivedMessages.Should().BeEmpty();
         }
 
+        /// <summary>
+        /// Verifies that all subscribers on a plugin message topic receive the published message.
+        /// </summary>
         [Test]
         public async Task PublishAsync_ShouldHandleMultipleSubscribers() {
             // Arrange
@@ -66,6 +77,9 @@ namespace NINA.Test.Plugin {
                 .Which.Should().Be(message);
         }
 
+        /// <summary>
+        /// Verifies that a valid subscriber can be registered for a topic without side effects.
+        /// </summary>
         [Test]
         public void Subscribe_ShouldAddSubscriber() {
             // Arrange
@@ -78,6 +92,9 @@ namespace NINA.Test.Plugin {
             act.Should().NotThrow();
         }
 
+        /// <summary>
+        /// Verifies that a subscriber can be removed from a topic without throwing.
+        /// </summary>
         [Test]
         public void Unsubscribe_ShouldRemoveSubscriber() {
             // Arrange
@@ -91,6 +108,27 @@ namespace NINA.Test.Plugin {
             act.Should().NotThrow();
         }
 
+        /// <summary>
+        /// Verifies that an unsubscribed plugin listener no longer receives messages for that topic.
+        /// </summary>
+        [Test]
+        public async Task Unsubscribe_ShouldStopFutureDeliveryToSubscriber() {
+            // Arrange
+            var message = new ExampleMessage("test_topic", "Hello, World!", "TestSender", Guid.NewGuid());
+            var subscriber = new TestSubscriber();
+            _messageBroker.Subscribe("test_topic", subscriber);
+            _messageBroker.Unsubscribe("test_topic", subscriber);
+
+            // Act
+            await _messageBroker.Publish(message);
+
+            // Assert
+            subscriber.ReceivedMessages.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies that publishing a null message is rejected before routing is attempted.
+        /// </summary>
         [Test]
         public Task PublishAsync_ShouldThrowException_ForNullMessage() {
             // Act
@@ -100,6 +138,10 @@ namespace NINA.Test.Plugin {
             return act.Should().ThrowAsync<ArgumentException>().WithMessage("Message or message topic cannot be null.");
         }
 
+        /// <summary>
+        /// Verifies that a message with an empty topic is rejected because topic is the broker's
+        /// routing key.
+        /// </summary>
         [Test]
         public Task PublishAsync_ShouldThrowException_ForMessageWithEmptyTopic() {
             // Arrange
@@ -112,6 +154,9 @@ namespace NINA.Test.Plugin {
             return act.Should().ThrowAsync<ArgumentException>().WithMessage("Message or message topic cannot be null.");
         }
 
+        /// <summary>
+        /// Verifies that topic validation prevents subscriptions with null routing keys.
+        /// </summary>
         [Test]
         public void Subscribe_ShouldThrowException_ForNullTopic() {
             // Arrange
@@ -124,6 +169,9 @@ namespace NINA.Test.Plugin {
             act.Should().Throw<ArgumentException>().WithMessage("Topic or subscriber cannot be null.");
         }
 
+        /// <summary>
+        /// Verifies that subscriber validation prevents null handlers from being stored for a topic.
+        /// </summary>
         [Test]
         public void Subscribe_ShouldThrowException_ForNullSubscriber() {
             // Act
@@ -133,6 +181,9 @@ namespace NINA.Test.Plugin {
             act.Should().Throw<ArgumentException>().WithMessage("Topic or subscriber cannot be null.");
         }
 
+        /// <summary>
+        /// Verifies that topic validation is also enforced when removing subscribers.
+        /// </summary>
         [Test]
         public void Unsubscribe_ShouldThrowException_ForNullTopic() {
             // Arrange
@@ -145,6 +196,10 @@ namespace NINA.Test.Plugin {
             act.Should().Throw<ArgumentException>().WithMessage("Topic or subscriber cannot be null.");
         }
 
+        /// <summary>
+        /// Verifies that unsubscribe rejects null subscribers instead of silently mutating broker
+        /// state.
+        /// </summary>
         [Test]
         public void Unsubscribe_ShouldThrowException_ForNullSubscriber() {
             // Act

--- a/NINA.Test/Plugin/PluginAssemblyReaderTest.cs
+++ b/NINA.Test/Plugin/PluginAssemblyReaderTest.cs
@@ -1,0 +1,63 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Plugin;
+using NUnit.Framework;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginAssemblyReaderTest {
+
+        /// <summary>
+        /// Verifies that the metadata-only assembly reader can identify NINA.Plugin dependencies
+        /// without loading the target assembly into the process.
+        /// </summary>
+        [Test]
+        public void GrabAssemblyReferences_ReturnsReferencedAssemblyNames() {
+            string assemblyPath = typeof(PluginLoader).Assembly.Location;
+
+            List<string> references = PluginAssemblyReader.GrabAssemblyReferences(assemblyPath);
+
+            references.Should().Contain("NINA.Core");
+            references.Should().Contain("NINA.Sequencer");
+            references.Should().Contain("System.Runtime");
+        }
+
+        /// <summary>
+        /// Verifies that metadata needed for failed-plugin fallback manifests can be read from a
+        /// plugin assembly file without executing plugin code.
+        /// </summary>
+        [Test]
+        public void GrabPluginMetaData_ReturnsAssemblyAttributesAndPluginMetadata() {
+            string assemblyPath = typeof(PluginLoader).Assembly.Location;
+            string expectedFileVersion = typeof(PluginLoader).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()!.Version;
+            string expectedMinimumApplicationVersion = typeof(PluginLoader).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(x => x.Key == "PluginMinimumApplicationVersion")
+                .Value;
+
+            Dictionary<string, string> metadata = PluginAssemblyReader.GrabPluginMetaData(assemblyPath);
+
+            metadata[nameof(AssemblyTitleAttribute)].Should().Be("NINA.Plugin");
+            metadata[nameof(AssemblyDescriptionAttribute)].Should().Be("This assembly contains the plugin related components of N.I.N.A.");
+            metadata[nameof(GuidAttribute)].Should().Be("03ace0fa-069a-43cf-8b20-7bb3c32d8c1d");
+            metadata[nameof(AssemblyFileVersionAttribute)].Should().Be(expectedFileVersion);
+            metadata["PluginMinimumApplicationVersion"].Should().Be(expectedMinimumApplicationVersion);
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginBaseTest.cs
+++ b/NINA.Test/Plugin/PluginBaseTest.cs
@@ -1,0 +1,152 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Plugin;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginBaseTest {
+
+        /// <summary>
+        /// Verifies that plugin assemblies expose their runtime manifest through assembly attributes
+        /// and assembly metadata, including descriptions and astronomy-relevant tag data.
+        /// </summary>
+        [Test]
+        public void ManifestProperties_ReadAssemblyAttributesAndMetadata() {
+            var plugin = CreatePluginBase(
+                "a00f6af4-f9f1-4e77-b271-490d68f8578f",
+                "Filter Wheel Meridian Planner",
+                "Schedules filter changes around meridian-safe windows.",
+                "NINA Test Observatory",
+                "2.1.3.5",
+                new Dictionary<string, string> {
+                    ["License"] = "MPL-2.0",
+                    ["LicenseURL"] = "https://www.mozilla.org/en-US/MPL/2.0/",
+                    ["Homepage"] = "https://example.invalid/filter-wheel-meridian-planner",
+                    ["Repository"] = "https://example.invalid/filter-wheel-meridian-planner.git",
+                    ["ChangelogURL"] = "https://example.invalid/filter-wheel-meridian-planner/changelog",
+                    ["Tags"] = "filter-wheel,meridian,planning",
+                    ["MinimumApplicationVersion"] = "3.0.0.0",
+                    ["LongDescription"] = "Coordinates planned filter changes with meridian-safe imaging windows.",
+                    ["FeaturedImageURL"] = "https://example.invalid/filter-wheel-meridian-planner/featured.png",
+                    ["ScreenshotURL"] = "https://example.invalid/filter-wheel-meridian-planner/main.png",
+                    ["AltScreenshotURL"] = "https://example.invalid/filter-wheel-meridian-planner/secondary.png"
+                });
+
+            plugin.Identifier.Should().Be("a00f6af4-f9f1-4e77-b271-490d68f8578f");
+            plugin.Name.Should().Be("Filter Wheel Meridian Planner");
+            plugin.Author.Should().Be("NINA Test Observatory");
+            plugin.Version.ToString().Should().Be("2.1.3.5");
+            plugin.MinimumApplicationVersion.ToString().Should().Be("3.0.0.0");
+            plugin.License.Should().Be("MPL-2.0");
+            plugin.LicenseURL.Should().Be("https://www.mozilla.org/en-US/MPL/2.0/");
+            plugin.Homepage.Should().Be("https://example.invalid/filter-wheel-meridian-planner");
+            plugin.Repository.Should().Be("https://example.invalid/filter-wheel-meridian-planner.git");
+            plugin.ChangelogURL.Should().Be("https://example.invalid/filter-wheel-meridian-planner/changelog");
+            plugin.Tags.Should().Equal("filter-wheel", "meridian", "planning");
+            plugin.Descriptions.ShortDescription.Should().Be("Schedules filter changes around meridian-safe windows.");
+            plugin.Descriptions.LongDescription.Should().Be("Coordinates planned filter changes with meridian-safe imaging windows.");
+            plugin.Descriptions.FeaturedImageURL.Should().Be("https://example.invalid/filter-wheel-meridian-planner/featured.png");
+            plugin.Descriptions.ScreenshotURL.Should().Be("https://example.invalid/filter-wheel-meridian-planner/main.png");
+            plugin.Descriptions.AltScreenshotURL.Should().Be("https://example.invalid/filter-wheel-meridian-planner/secondary.png");
+        }
+
+        /// <summary>
+        /// Verifies the conservative defaults used when optional plugin metadata is absent from the
+        /// assembly so plugin authors get predictable empty values instead of nulls.
+        /// </summary>
+        [Test]
+        public void ManifestProperties_UseDefaultsWhenOptionalMetadataIsMissing() {
+            var plugin = CreatePluginBase(
+                "fef529e1-9826-49d0-9182-84efb1701f98",
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                null,
+                new Dictionary<string, string>());
+
+            plugin.Version.ToString().Should().Be("1.0.0.0");
+            plugin.MinimumApplicationVersion.ToString().Should().Be("1.11.0.0");
+            plugin.Tags.Should().BeEmpty();
+            plugin.License.Should().BeEmpty();
+            plugin.LicenseURL.Should().BeEmpty();
+            plugin.Homepage.Should().BeEmpty();
+            plugin.Repository.Should().BeEmpty();
+            plugin.ChangelogURL.Should().BeEmpty();
+            plugin.Descriptions.ShortDescription.Should().BeEmpty();
+            plugin.Descriptions.LongDescription.Should().BeEmpty();
+            plugin.Installer.Should().BeOfType<PluginInstallerDetails>();
+            plugin.Installer.URL.Should().BeEmpty();
+            plugin.Installer.Checksum.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies that the base plugin lifecycle is intentionally no-op and immediately completed
+        /// unless a plugin overrides initialization or teardown behavior.
+        /// </summary>
+        [Test]
+        public async Task LifecycleMethods_CompleteWithoutSideEffectsByDefault() {
+            var plugin = CreatePluginBase(
+                "ea68f114-44dd-4c40-9714-40cda2fe77d9",
+                "Lifecycle Fixture",
+                string.Empty,
+                string.Empty,
+                "1.0.0.0",
+                new Dictionary<string, string>());
+
+            await plugin.Initialize();
+            await plugin.Teardown();
+        }
+
+        private static PluginBase CreatePluginBase(
+            string identifier,
+            string title,
+            string description,
+            string company,
+            string fileVersion,
+            IDictionary<string, string> metadata) {
+            var assemblyName = new AssemblyName("NINA.Test.Plugin.PluginBaseFixture" + Guid.NewGuid().ToString("N"));
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+
+            SetAttribute<GuidAttribute>(assemblyBuilder, identifier);
+            SetAttribute<AssemblyTitleAttribute>(assemblyBuilder, title);
+            SetAttribute<AssemblyDescriptionAttribute>(assemblyBuilder, description);
+            SetAttribute<AssemblyCompanyAttribute>(assemblyBuilder, company);
+            if (!string.IsNullOrEmpty(fileVersion)) {
+                SetAttribute<AssemblyFileVersionAttribute>(assemblyBuilder, fileVersion);
+            }
+            foreach (KeyValuePair<string, string> item in metadata) {
+                ConstructorInfo constructor = typeof(AssemblyMetadataAttribute).GetConstructor(new[] { typeof(string), typeof(string) })!;
+                assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(constructor, new object[] { item.Key, item.Value }));
+            }
+
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("PluginBaseFixtureModule");
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("SyntheticPlugin", TypeAttributes.Public, typeof(PluginBase));
+            Type pluginType = typeBuilder.CreateType()!;
+            return (PluginBase)Activator.CreateInstance(pluginType)!;
+        }
+
+        private static void SetAttribute<TAttribute>(AssemblyBuilder assemblyBuilder, string value) where TAttribute : Attribute {
+            ConstructorInfo constructor = typeof(TAttribute).GetConstructor(new[] { typeof(string) })!;
+            assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(constructor, new object[] { value }));
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginCompatibilityMapTest.cs
+++ b/NINA.Test/Plugin/PluginCompatibilityMapTest.cs
@@ -1,0 +1,133 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Plugin;
+using NINA.Plugin.Interfaces;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginCompatibilityMapTest {
+
+        private const string OrbuculumIdentifier = "a6c614f3-c3ab-423a-8be1-d480a253f07c";
+
+        /// <summary>
+        /// Verifies that an unknown plugin compiled for the current plugin API floor is accepted
+        /// and does not inherit an artificial minimum plugin version from the hard-coded map.
+        /// </summary>
+        [Test]
+        public void IsCompatible_AcceptsUnknownPluginCompiledForCurrentPluginApi() {
+            var compatibilityMap = new PluginCompatibilityMap();
+            var manifest = CreateManifest("f67eeaf0-7123-4c5c-9579-83032bbf6f85", "1.2.3.4", CurrentMinimumApplicationVersion().ToString());
+
+            compatibilityMap.IsCompatible(manifest).Should().BeTrue();
+            compatibilityMap.IsNotCompatible(manifest).Should().BeFalse();
+            compatibilityMap.GetMinimumVersion(manifest).Should().Be(new Version(0, 0, 0, 0));
+        }
+
+        /// <summary>
+        /// Verifies that a plugin built against an application API lower than the assembly metadata
+        /// floor is rejected even when the plugin itself is not listed in the compatibility map.
+        /// </summary>
+        [Test]
+        public void IsCompatible_RejectsPluginCompiledForLegacyApplicationApi() {
+            var compatibilityMap = new PluginCompatibilityMap();
+            var manifest = CreateManifest("11fca23c-ce52-44f5-9889-b6a7764eae2d", "4.0.0.0", VersionBelow(CurrentMinimumApplicationVersion()).ToString());
+
+            compatibilityMap.IsCompatible(manifest).Should().BeFalse();
+            compatibilityMap.IsNotCompatible(manifest).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Verifies that a known plugin with a version below its minimum safe version is rejected
+        /// and reported as requiring an update instead of being treated like an unknown plugin.
+        /// </summary>
+        [Test]
+        public void IsCompatible_RejectsKnownPluginBelowRequiredVersion() {
+            var compatibilityMap = new PluginCompatibilityMap();
+            var manifest = CreateManifest(OrbuculumIdentifier, "1.0.3.9", CurrentMinimumApplicationVersion().ToString());
+
+            compatibilityMap.IsCompatible(manifest).Should().BeFalse();
+            compatibilityMap.IsUpdateRequired(manifest).Should().BeTrue();
+            compatibilityMap.GetMinimumVersion(manifest).Should().Be(new Version(1, 0, 4, 0));
+        }
+
+        /// <summary>
+        /// Verifies that a known plugin newer than the compatibility-map floor is accepted and no
+        /// longer reports an update-required state.
+        /// </summary>
+        [Test]
+        public void IsCompatible_AcceptsKnownPluginAboveRequiredVersion() {
+            var compatibilityMap = new PluginCompatibilityMap();
+            var manifest = CreateManifest(OrbuculumIdentifier, "1.0.4.1", CurrentMinimumApplicationVersion().ToString());
+
+            compatibilityMap.IsCompatible(manifest).Should().BeTrue();
+            compatibilityMap.IsUpdateRequired(manifest).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Verifies the sentinel version used by the compatibility model to identify manifests that
+        /// should be considered deprecated by version value alone.
+        /// </summary>
+        [Test]
+        public void IsDeprecated_UsesDocumentedSentinelVersion() {
+            var compatibilityMap = new PluginCompatibilityMap();
+            var deprecatedManifest = CreateManifest("0529e68b-fcc5-4ef3-b116-13ac6e83fc33", "65535.0.0.0", CurrentMinimumApplicationVersion().ToString());
+            var supportedManifest = CreateManifest("0529e68b-fcc5-4ef3-b116-13ac6e83fc33", "65534.9999.9999.9999", CurrentMinimumApplicationVersion().ToString());
+
+            compatibilityMap.IsDeprecated(deprecatedManifest).Should().BeTrue();
+            compatibilityMap.IsDeprecated(supportedManifest).Should().BeFalse();
+        }
+
+        private static IPluginManifest CreateManifest(string identifier, string version, string minimumApplicationVersion) {
+            return new PluginManifest {
+                Identifier = identifier,
+                Name = "Compatibility Test Plugin",
+                Version = new PluginVersion(version),
+                MinimumApplicationVersion = new PluginVersion(minimumApplicationVersion),
+                Descriptions = new PluginDescription {
+                    ShortDescription = "Compatibility test fixture"
+                },
+                Installer = new PluginInstallerDetails {
+                    URL = "https://example.invalid/plugin.dll",
+                    Checksum = new string('a', 64),
+                    ChecksumType = InstallerChecksum.SHA256,
+                    Type = InstallerType.DLL
+                }
+            };
+        }
+
+        private static Version CurrentMinimumApplicationVersion() {
+            string value = typeof(PluginLoader).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(x => x.Key == "PluginMinimumApplicationVersion")
+                .Value;
+            return new Version(value);
+        }
+
+        private static Version VersionBelow(Version version) {
+            if (version.Build > 0) {
+                return new Version(version.Major, version.Minor, version.Build - 1, version.Revision);
+            }
+            if (version.Minor > 0) {
+                return new Version(version.Major, version.Minor - 1, 0, version.Revision);
+            }
+            return new Version(Math.Max(0, version.Major - 1), 0, 0, version.Revision);
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginFetcherRequestAllTest.cs
+++ b/NINA.Test/Plugin/PluginFetcherRequestAllTest.cs
@@ -1,0 +1,104 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Core.Utility;
+using NINA.Core.Model;
+using NINA.Plugin;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+using System.Reflection;
+using System.Text;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginFetcherRequestAllTest {
+
+        /// <summary>
+        /// Verifies that repository fetching accepts only schema-valid manifests compatible with the
+        /// requested application version and the current plugin API floor.
+        /// </summary>
+        [Test]
+        public async Task RequestAll_FiltersRepositoryManifestsBySchemaAndCompatibility() {
+            Version minimumPluginApiVersion = CurrentMinimumApplicationVersion();
+            Version futureApplicationVersion = new Version(minimumPluginApiVersion.Major + 1, 0, 0, 0);
+            Version legacyApplicationVersion = VersionBelow(minimumPluginApiVersion);
+            string manifests = "[" +
+                CreateManifestJson("Compatible Spectroscopy Planner", "20e79561-6a8d-48fd-a584-13c4eb543fbf", minimumPluginApiVersion.ToString()) + "," +
+                CreateManifestJson("Future API Planner", "985a03bb-cb30-4256-a6f9-0370eed5673f", futureApplicationVersion.ToString()) + "," +
+                CreateManifestJson("Legacy API Planner", "d343d3b8-9a4a-4690-aefc-0bd9cd1de840", legacyApplicationVersion.ToString()) + "," +
+                "{ 'Name': 'Invalid Missing Installer' }" +
+                "]";
+            using var server = new LoopbackHttpServer(Encoding.UTF8.GetBytes(manifests), "application/json");
+            var fetcher = new PluginFetcher(server.Url);
+
+            IList<PluginManifest> plugins = await fetcher.RequestAll(new PluginVersion(CoreUtil.Version), new Progress<ApplicationStatus>(), CancellationToken.None);
+
+            plugins.Should().ContainSingle();
+            plugins.Single().Name.Should().Be("Compatible Spectroscopy Planner");
+            plugins.Single().Identifier.Should().Be("20e79561-6a8d-48fd-a584-13c4eb543fbf");
+        }
+
+        private static string CreateManifestJson(string name, string identifier, string minimumApplicationVersion) {
+            return @"{
+                'Name': '" + name + @"',
+                'Identifier': '" + identifier + @"',
+                'Version': {
+                    'Major': 1,
+                    'Minor': 0,
+                    'Patch': 0,
+                    'Build': 0
+                },
+                'Author': 'NINA Test Observatory',
+                'Repository': 'https://example.invalid/repository.git',
+                'License': 'MPL-2.0',
+                'LicenseURL': 'https://www.mozilla.org/en-US/MPL/2.0/',
+                'MinimumApplicationVersion': {
+                    'Major': " + new PluginVersion(minimumApplicationVersion).Major + @",
+                    'Minor': " + new PluginVersion(minimumApplicationVersion).Minor + @",
+                    'Patch': " + new PluginVersion(minimumApplicationVersion).Patch + @",
+                    'Build': " + new PluginVersion(minimumApplicationVersion).Build + @"
+                },
+                'Descriptions': {
+                    'ShortDescription': 'Repository compatibility fixture'
+                },
+                'Installer': {
+                    'URL': 'https://example.invalid/download/plugin.dll',
+                    'Checksum': '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                    'ChecksumType': 'SHA256',
+                    'Type': 'DLL'
+                }
+            }";
+        }
+
+        private static Version CurrentMinimumApplicationVersion() {
+            string value = typeof(PluginLoader).Assembly
+                .GetCustomAttributes<AssemblyMetadataAttribute>()
+                .Single(x => x.Key == "PluginMinimumApplicationVersion")
+                .Value;
+            return new Version(value);
+        }
+
+        private static Version VersionBelow(Version version) {
+            if (version.Build > 0) {
+                return new Version(version.Major, version.Minor, version.Build - 1, version.Revision);
+            }
+            if (version.Minor > 0) {
+                return new Version(version.Major, version.Minor - 1, 0, version.Revision);
+            }
+            return new Version(Math.Max(0, version.Major - 1), 0, 0, version.Revision);
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginInstallerTest.cs
+++ b/NINA.Test/Plugin/PluginInstallerTest.cs
@@ -1,0 +1,438 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Core.Utility;
+using NINA.Plugin;
+using NINA.Plugin.Interfaces;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+using System.IO.Compression;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginInstallerTest {
+
+        /// <summary>
+        /// Verifies that installer checksum validation accepts the supported algorithms used by
+        /// repository manifests before plugin payloads are staged for installation.
+        /// </summary>
+        [Test]
+        [TestCase(InstallerChecksum.MD5)]
+        [TestCase(InstallerChecksum.SHA1)]
+        [TestCase(InstallerChecksum.SHA256)]
+        public void ValidateChecksum_AcceptsSupportedManifestAlgorithms(InstallerChecksum checksumType) {
+            string tempFile = CreateTempPayloadFile();
+            try {
+                IPluginManifest manifest = CreateManifest(checksumType, ComputeChecksum(tempFile, checksumType));
+                var installer = new PluginInstaller();
+
+                bool result = InvokeValidateChecksum(installer, tempFile, manifest);
+
+                result.Should().BeTrue();
+            } finally {
+                File.Delete(tempFile);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that installer checksum validation rejects payload bytes that do not match the
+        /// manifest hash, which protects plugin installation from corrupted downloads.
+        /// </summary>
+        [Test]
+        public void ValidateChecksum_RejectsMismatchedHash() {
+            string tempFile = CreateTempPayloadFile();
+            try {
+                IPluginManifest manifest = CreateManifest(InstallerChecksum.SHA256, new string('0', 64));
+                var installer = new PluginInstaller();
+
+                bool result = InvokeValidateChecksum(installer, tempFile, manifest);
+
+                result.Should().BeFalse();
+            } finally {
+                File.Delete(tempFile);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the end-to-end DLL installation path: download, filename selection from the
+        /// response header, checksum validation, and copy into the version-scoped plugin folder.
+        /// </summary>
+        [Test]
+        public async Task Install_DownloadsDllPayloadAndStagesItByManifestName() {
+            byte[] payload = Encoding.UTF8.GetBytes("downloaded dll payload");
+            string pluginName = "Loopback Download Planner " + Guid.NewGuid().ToString("N");
+            using var server = new LoopbackHttpServer(payload, "application/octet-stream", "LoopbackPlanner.dll");
+            IPluginManifest manifest = CreateManifest(pluginName, server.Url + "/download", InstallerType.DLL, InstallerChecksum.SHA256, ComputeChecksum(payload, InstallerChecksum.SHA256));
+            string destinationFolder = GetDestinationFolder(manifest);
+            try {
+                await new PluginInstaller().Install(manifest, false, CancellationToken.None);
+
+                string destinationFile = Path.Combine(destinationFolder, "LoopbackPlanner.dll");
+                File.Exists(destinationFile).Should().BeTrue();
+                File.ReadAllText(destinationFile).Should().Be("downloaded dll payload");
+            } finally {
+                DeleteDirectoryIfExists(destinationFolder);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the end-to-end archive installation path: download, checksum validation, and
+        /// extraction of plugin DLL plus dependency files into the plugin folder.
+        /// </summary>
+        [Test]
+        public async Task Install_DownloadsArchivePayloadAndExtractsIt() {
+            byte[] payload = CreateArchivePayload(new Dictionary<string, string> {
+                ["ArchivePlugin.dll"] = "archive plugin payload",
+                ["Dependencies/ArchiveDependency.dll"] = "archive dependency payload"
+            });
+            string pluginName = "Loopback Archive Planner " + Guid.NewGuid().ToString("N");
+            using var server = new LoopbackHttpServer(payload, "application/zip", "LoopbackArchive.zip");
+            IPluginManifest manifest = CreateManifest(pluginName, server.Url + "/download", InstallerType.ARCHIVE, InstallerChecksum.SHA256, ComputeChecksum(payload, InstallerChecksum.SHA256));
+            string destinationFolder = GetDestinationFolder(manifest);
+            try {
+                await new PluginInstaller().Install(manifest, false, CancellationToken.None);
+
+                File.ReadAllText(Path.Combine(destinationFolder, "ArchivePlugin.dll")).Should().Be("archive plugin payload");
+                File.ReadAllText(Path.Combine(destinationFolder, "Dependencies", "ArchiveDependency.dll")).Should().Be("archive dependency payload");
+            } finally {
+                DeleteDirectoryIfExists(destinationFolder);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the install workflow stops after download when the payload checksum does
+        /// not match the manifest and therefore never stages an untrusted plugin file.
+        /// </summary>
+        [Test]
+        public async Task Install_RejectsDownloadedPayloadWithMismatchedChecksum() {
+            byte[] payload = Encoding.UTF8.GetBytes("tampered dll payload");
+            string pluginName = "Loopback Tampered Planner " + Guid.NewGuid().ToString("N");
+            using var server = new LoopbackHttpServer(payload, "application/octet-stream", "TamperedPlanner.dll");
+            IPluginManifest manifest = CreateManifest(pluginName, server.Url + "/download", InstallerType.DLL, InstallerChecksum.SHA256, new string('0', 64));
+            string destinationFolder = GetDestinationFolder(manifest);
+            try {
+                Func<Task> act = async () => await new PluginInstaller().Install(manifest, false, CancellationToken.None);
+
+                await act.Should().ThrowAsync<Exception>().WithMessage("Checksum of file*does not match expected checksum*");
+                Directory.Exists(destinationFolder).Should().BeFalse();
+            } finally {
+                DeleteDirectoryIfExists(destinationFolder);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a downloaded DLL payload is copied into the version-scoped plugin folder
+        /// using the same sanitized plugin-name convention that uninstall later relies on.
+        /// </summary>
+        [Test]
+        public async Task InstallDLL_CopiesPayloadIntoSanitizedPluginFolder() {
+            string pluginName = "Installer Safety DLL " + Guid.NewGuid().ToString("N") + "/Unsafe";
+            IPluginManifest manifest = CreateManifest(pluginName, InstallerChecksum.SHA256, new string('a', 64));
+            string sourceFile = CreateTempPayloadFile("InstallerSafetyFixture.dll", "dll payload");
+            string destinationFolder = GetDestinationFolder(manifest);
+            try {
+                await InvokeInstallDLL(new PluginInstaller(), manifest, sourceFile);
+
+                string destinationFile = Path.Combine(destinationFolder, Path.GetFileName(sourceFile));
+                File.Exists(destinationFile).Should().BeTrue();
+                File.ReadAllText(destinationFile).Should().Be("dll payload");
+            } finally {
+                File.Delete(sourceFile);
+                DeleteDirectoryIfExists(destinationFolder);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that archive payloads are extracted into the same version-scoped destination
+        /// folder used by DLL installs, including nested dependency files.
+        /// </summary>
+        [Test]
+        public async Task InstallArchive_ExtractsPayloadIntoSanitizedPluginFolder() {
+            string pluginName = "Installer Safety Archive " + Guid.NewGuid().ToString("N") + "/Unsafe";
+            IPluginManifest manifest = CreateManifest(pluginName, InstallerChecksum.SHA256, new string('a', 64));
+            string tempRoot = CreateTempDirectory();
+            string zipPath = Path.Combine(tempRoot, "archive.zip");
+            string destinationFolder = GetDestinationFolder(manifest);
+            try {
+                using (ZipArchive archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+                    WriteArchiveEntry(archive, "Plugin.dll", "plugin payload");
+                    WriteArchiveEntry(archive, "Dependencies/Dependency.dll", "dependency payload");
+                }
+
+                await InvokeInstallArchive(new PluginInstaller(), manifest, zipPath);
+
+                File.ReadAllText(Path.Combine(destinationFolder, "Plugin.dll")).Should().Be("plugin payload");
+                File.ReadAllText(Path.Combine(destinationFolder, "Dependencies", "Dependency.dll")).Should().Be("dependency payload");
+            } finally {
+                Directory.Delete(tempRoot, true);
+                DeleteDirectoryIfExists(destinationFolder);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that uninstall moves files from a conventionally named plugin folder into the
+        /// version-scoped deletion area so running plugin DLLs can be removed on the next startup.
+        /// </summary>
+        [Test]
+        public void Uninstall_MovesConventionFolderContentsIntoDeletionArea() {
+            string pluginName = "Installer Safety Uninstall " + Guid.NewGuid().ToString("N");
+            IPluginManifest manifest = CreateManifest(pluginName, InstallerChecksum.SHA256, new string('a', 64));
+            string destinationFolder = GetDestinationFolder(manifest);
+            string pluginFile = Path.Combine(destinationFolder, "Plugin.dll");
+            HashSet<string> deletionFilesBefore = GetDeletionFiles();
+            try {
+                Directory.CreateDirectory(destinationFolder);
+                File.WriteAllText(pluginFile, "pending deletion");
+
+                new PluginInstaller().Uninstall(manifest);
+
+                File.Exists(pluginFile).Should().BeFalse();
+                HashSet<string> deletionFilesAfter = GetDeletionFiles();
+                List<string> newDeletionFiles = deletionFilesAfter.Except(deletionFilesBefore).ToList();
+                newDeletionFiles.Should().ContainSingle();
+                File.ReadAllText(newDeletionFiles.Single()).Should().Be("pending deletion");
+            } finally {
+                DeleteDirectoryIfExists(destinationFolder);
+                DeleteNewDeletionFiles(deletionFilesBefore);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that archive extraction overwrites an existing plugin file when installation is
+        /// applying an update to an already staged plugin folder.
+        /// </summary>
+        [Test]
+        public void ExtractToDirectory_OverwritesExistingPluginFiles() {
+            string tempRoot = CreateTempDirectory();
+            string zipPath = Path.Combine(tempRoot, "plugin.zip");
+            string destination = Path.Combine(tempRoot, "destination");
+            try {
+                Directory.CreateDirectory(destination);
+                File.WriteAllText(Path.Combine(destination, "Plugin.dll"), "old payload");
+                using (ZipArchive archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+                    ZipArchiveEntry entry = archive.CreateEntry("Plugin.dll");
+                    using StreamWriter writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+                    writer.Write("new payload");
+                }
+
+                using (ZipArchive archive = ZipFile.OpenRead(zipPath)) {
+                    ZipArchiveExtensions.ExtractToDirectory(archive, destination, true);
+                }
+
+                File.ReadAllText(Path.Combine(destination, "Plugin.dll")).Should().Be("new payload");
+            } finally {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that archive extraction with overwrite disabled delegates to the framework
+        /// extraction behavior used for first-time plugin installs.
+        /// </summary>
+        [Test]
+        public void ExtractToDirectory_WithoutOverwriteExtractsNewPluginFiles() {
+            string tempRoot = CreateTempDirectory();
+            string zipPath = Path.Combine(tempRoot, "plugin.zip");
+            string destination = Path.Combine(tempRoot, "destination");
+            try {
+                using (ZipArchive archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+                    WriteArchiveEntry(archive, "Plugin.dll", "new payload");
+                }
+
+                using (ZipArchive archive = ZipFile.OpenRead(zipPath)) {
+                    ZipArchiveExtensions.ExtractToDirectory(archive, destination, false);
+                }
+
+                File.ReadAllText(Path.Combine(destination, "Plugin.dll")).Should().Be("new payload");
+            } finally {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that explicit directory entries in plugin archives create the expected folder
+        /// structure before nested dependency files are extracted.
+        /// </summary>
+        [Test]
+        public void ExtractToDirectory_CreatesExplicitArchiveDirectories() {
+            string tempRoot = CreateTempDirectory();
+            string zipPath = Path.Combine(tempRoot, "plugin.zip");
+            string destination = Path.Combine(tempRoot, "destination");
+            try {
+                using (ZipArchive archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+                    archive.CreateEntry("Dependencies/");
+                    WriteArchiveEntry(archive, "Dependencies/Dependency.dll", "dependency payload");
+                }
+
+                using (ZipArchive archive = ZipFile.OpenRead(zipPath)) {
+                    ZipArchiveExtensions.ExtractToDirectory(archive, destination, true);
+                }
+
+                Directory.Exists(Path.Combine(destination, "Dependencies")).Should().BeTrue();
+                File.ReadAllText(Path.Combine(destination, "Dependencies", "Dependency.dll")).Should().Be("dependency payload");
+            } finally {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that archive extraction rejects entries attempting to escape the destination
+        /// folder, preventing a malicious plugin archive from writing outside the plugin directory.
+        /// </summary>
+        [Test]
+        public void ExtractToDirectory_RejectsZipSlipTraversalEntry() {
+            string tempRoot = CreateTempDirectory();
+            string zipPath = Path.Combine(tempRoot, "plugin.zip");
+            string destination = Path.Combine(tempRoot, "destination");
+            string outsideFile = Path.Combine(tempRoot, "outside.txt");
+            try {
+                using (ZipArchive archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+                    ZipArchiveEntry entry = archive.CreateEntry("../outside.txt");
+                    using StreamWriter writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+                    writer.Write("escape");
+                }
+
+                using ZipArchive readArchive = ZipFile.OpenRead(zipPath);
+                Action act = () => ZipArchiveExtensions.ExtractToDirectory(readArchive, destination, true);
+
+                act.Should().Throw<IOException>().WithMessage("Trying to extract file outside of destination directory*");
+                File.Exists(outsideFile).Should().BeFalse();
+            } finally {
+                Directory.Delete(tempRoot, true);
+            }
+        }
+
+        private static string CreateTempPayloadFile() {
+            return CreateTempPayloadFile("NINA.PluginInstallerTest." + Guid.NewGuid().ToString("N") + ".bin", "NINA plugin installer checksum fixture");
+        }
+
+        private static string CreateTempPayloadFile(string fileName, string content) {
+            string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "." + fileName);
+            File.WriteAllText(tempFile, content, Encoding.UTF8);
+            return tempFile;
+        }
+
+        private static string CreateTempDirectory() {
+            string directory = Path.Combine(Path.GetTempPath(), "NINA.PluginInstallerTest." + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            return directory;
+        }
+
+        private static string ComputeChecksum(string file, InstallerChecksum checksumType) {
+            using HashAlgorithm algorithm = checksumType switch {
+                InstallerChecksum.MD5 => MD5.Create(),
+                InstallerChecksum.SHA1 => SHA1.Create(),
+                _ => SHA256.Create()
+            };
+            using FileStream stream = File.OpenRead(file);
+            return BitConverter.ToString(algorithm.ComputeHash(stream)).Replace("-", string.Empty).ToLower();
+        }
+
+        private static string ComputeChecksum(byte[] payload, InstallerChecksum checksumType) {
+            using HashAlgorithm algorithm = checksumType switch {
+                InstallerChecksum.MD5 => MD5.Create(),
+                InstallerChecksum.SHA1 => SHA1.Create(),
+                _ => SHA256.Create()
+            };
+            return BitConverter.ToString(algorithm.ComputeHash(payload)).Replace("-", string.Empty).ToLower();
+        }
+
+        private static byte[] CreateArchivePayload(IDictionary<string, string> entries) {
+            using var stream = new MemoryStream();
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true)) {
+                foreach (KeyValuePair<string, string> entry in entries) {
+                    WriteArchiveEntry(archive, entry.Key, entry.Value);
+                }
+            }
+            return stream.ToArray();
+        }
+
+        private static IPluginManifest CreateManifest(InstallerChecksum checksumType, string checksum) {
+            return CreateManifest("Installer Safety Fixture", checksumType, checksum);
+        }
+
+        private static IPluginManifest CreateManifest(string name, InstallerChecksum checksumType, string checksum) {
+            return CreateManifest(name, "https://example.invalid/InstallerSafetyFixture.dll", InstallerType.DLL, checksumType, checksum);
+        }
+
+        private static IPluginManifest CreateManifest(string name, string url, InstallerType installerType, InstallerChecksum checksumType, string checksum) {
+            return new PluginManifest {
+                Identifier = "7e359eef-b8e4-4870-9d59-532fc2963f81",
+                Name = name,
+                Version = new PluginVersion("1.0.0.0"),
+                MinimumApplicationVersion = new PluginVersion("3.0.0.0"),
+                Descriptions = new PluginDescription {
+                    ShortDescription = "Installer safety test fixture"
+                },
+                Installer = new PluginInstallerDetails {
+                    URL = url,
+                    Type = installerType,
+                    Checksum = checksum,
+                    ChecksumType = checksumType
+                }
+            };
+        }
+
+        private static bool InvokeValidateChecksum(PluginInstaller installer, string tempFile, IPluginManifest manifest) {
+            MethodInfo method = typeof(PluginInstaller).GetMethod("ValidateChecksum", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (bool)method.Invoke(installer, new object[] { tempFile, manifest })!;
+        }
+
+        private static async Task InvokeInstallDLL(PluginInstaller installer, IPluginManifest manifest, string sourceFile) {
+            MethodInfo method = typeof(PluginInstaller).GetMethod("InstallDLL", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var task = (Task)method.Invoke(installer, new object[] { manifest, sourceFile })!;
+            await task;
+        }
+
+        private static async Task InvokeInstallArchive(PluginInstaller installer, IPluginManifest manifest, string archiveFile) {
+            MethodInfo method = typeof(PluginInstaller).GetMethod("InstallArchive", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var task = (Task)method.Invoke(installer, new object[] { manifest, archiveFile })!;
+            await task;
+        }
+
+        private static string GetDestinationFolder(IPluginManifest manifest) {
+            return Path.Combine(Constants.UserExtensionsFolder, CoreUtil.ReplaceAllInvalidFilenameChars(manifest.Name));
+        }
+
+        private static HashSet<string> GetDeletionFiles() {
+            if (!Directory.Exists(Constants.DeletionFolder)) {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            return Directory.GetFiles(Constants.DeletionFolder).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static void DeleteNewDeletionFiles(HashSet<string> deletionFilesBefore) {
+            foreach (string file in GetDeletionFiles().Except(deletionFilesBefore).ToList()) {
+                File.Delete(file);
+            }
+        }
+
+        private static void DeleteDirectoryIfExists(string directory) {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        private static void WriteArchiveEntry(ZipArchive archive, string path, string content) {
+            ZipArchiveEntry entry = archive.CreateEntry(path);
+            using StreamWriter writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+            writer.Write(content);
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginLoaderCompositionTest.cs
+++ b/NINA.Test/Plugin/PluginLoaderCompositionTest.cs
@@ -1,0 +1,408 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Astrometry.Interfaces;
+using NINA.Core.Interfaces;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.PlateSolving.Interfaces;
+using NINA.Plugin;
+using NINA.Plugin.Interfaces;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer;
+using NINA.Sequencer.Interfaces.Mediator;
+using NINA.Sequencer.Logic;
+using NINA.Sequencer.SequenceItem;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NUnit.Framework;
+using System.Collections;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Windows.Media;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    [NonParallelizable]
+    public class PluginLoaderCompositionTest {
+
+        /// <summary>
+        /// Verifies that plugin composition imports sequence entities and assigns MEF metadata,
+        /// resource-backed icons, plugin provenance text, and the shared symbol broker.
+        /// </summary>
+        [Test]
+        public void Compose_AssignsMetadataAndPluginContextToSequenceEntity() {
+            var resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+            ISymbolBroker symbolBroker = Mock.Of<ISymbolBroker>();
+            PluginLoader loader = CreateLoader(resourceDictionaryMock.Object, symbolBroker);
+            InitializeCollections(loader);
+
+            InvokeCompose(loader, new TypeCatalog(typeof(ExportedScienceItem), typeof(ExportedScienceUpgrader)), "Synthetic Science Plugin");
+
+            ISequenceItem item = loader.Items.Should().ContainSingle().Subject;
+            item.Should().BeOfType<ExportedScienceItem>();
+            item.Name.Should().Be("Synthetic Focus Sweep");
+            item.Category.Should().Be("Science Planning");
+            item.Description.Should().Be("Evaluates focus drift across altitude bands." + Environment.NewLine + "(Synthetic Science Plugin)");
+            item.Icon.Should().NotBeNull();
+            item.SymbolBroker.Should().BeSameAs(symbolBroker);
+            resourceDictionaryMock.Verify(x => x["FocusSweepSvg"], Times.Once);
+
+            ISequenceEntityUpgrader upgrader = loader.Upgraders.Should().ContainSingle().Subject;
+            upgrader.Should().BeOfType<ExportedScienceUpgrader>();
+            upgrader.Name.Should().Be("Synthetic Science Upgrade");
+        }
+
+        /// <summary>
+        /// Verifies that plugin entities already merged into core are filtered by plugin name and
+        /// type identity so migrated users do not see duplicate Connector entries in the palette.
+        /// </summary>
+        [Test]
+        public void AssignSequenceEntity_FiltersEntitiesMergedIntoCore() {
+            var resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+            PluginLoader loader = CreateLoader(resourceDictionaryMock.Object, Mock.Of<ISymbolBroker>());
+            var imports = new[] {
+                new Lazy<ISequenceItem, IDictionary<string, object>>(
+                    () => new NINA.Plugins.Connector.Instructions.ConnectEquipment(),
+                    CreateMetadata("Connector: Connect Equipment", "Connector duplicate", "ConnectSvg", "Connector"))
+            };
+
+            IList<ISequenceItem> items = InvokeAssignSequenceEntity(loader, imports, resourceDictionaryMock.Object, "Connector");
+
+            items.Should().BeEmpty();
+            resourceDictionaryMock.Verify(x => x[It.IsAny<string>()], Times.Never);
+        }
+
+        /// <summary>
+        /// Verifies that DLLs in the plugin folder which do not reference NINA.Plugin are ignored
+        /// instead of being reported as failed plugins.
+        /// </summary>
+        [Test]
+        public async Task LoadPlugin_IgnoresManagedDllWithoutPluginReference() {
+            PluginLoader loader = CreateLoaderWithInitializedCollections();
+            string assemblyPath = typeof(CoreUtil).Assembly.Location;
+
+            await InvokeLoadPlugin(loader, assemblyPath, 1d);
+
+            loader.Plugins.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies that non-.NET files found beside plugins are treated like native dependencies
+        /// and skipped without adding failed plugin manifests.
+        /// </summary>
+        [Test]
+        public async Task LoadPlugin_IgnoresNonManagedDependencyFile() {
+            PluginLoader loader = CreateLoaderWithInitializedCollections();
+            string tempFile = Path.Combine(Path.GetTempPath(), "NINA.PluginLoader.NativeDependency." + Guid.NewGuid().ToString("N") + ".dll");
+            try {
+                File.WriteAllText(tempFile, "not a managed assembly");
+
+                await InvokeLoadPlugin(loader, tempFile, 1d);
+
+                loader.Plugins.Should().BeEmpty();
+            } finally {
+                File.Delete(tempFile);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a full loader startup against an isolated runtime root initializes plugin
+        /// collections and completes without installed plugins, matching a clean first-run profile.
+        /// </summary>
+        [Test]
+        public async Task Load_WithEmptyPluginRuntimeRoot_InitializesCollectionsWithoutInstalledPlugins() {
+            PluginLoader loader = CreateLoaderWithInitializedResourceDictionary();
+
+            await loader.Load();
+
+            loader.Plugins.Should().NotBeNull();
+            loader.Plugins.Should().BeEmpty();
+            loader.Items.Should().NotBeNull();
+            loader.Conditions.Should().NotBeNull();
+            loader.Triggers.Should().NotBeNull();
+            loader.Container.Should().NotBeNull();
+            loader.Upgraders.Should().NotBeNull();
+        }
+
+        /// <summary>
+        /// Verifies that startup migrates plugin files from the highest older versioned plugin
+        /// folder into the current plugin API folder before scanning installed plugins.
+        /// </summary>
+        [Test]
+        public async Task Load_MigratesHighestOlderVersionedPluginFolder() {
+            ResetPluginRuntimeFolders();
+            string previousVersionFolder = Path.Combine(Constants.BaseUserExtensionsFolder, "1.0.0");
+            string previousPluginFile = Path.Combine(previousVersionFolder, "NativeDependency.dll");
+            Directory.CreateDirectory(previousVersionFolder);
+            File.WriteAllText(previousPluginFile, "native dependency placeholder");
+            PluginLoader loader = CreateLoaderWithInitializedResourceDictionary();
+
+            await loader.Load();
+
+            string migratedPluginFile = Path.Combine(Constants.UserExtensionsFolder, "NativeDependency.dll");
+            File.Exists(migratedPluginFile).Should().BeTrue();
+            File.ReadAllText(migratedPluginFile).Should().Be("native dependency placeholder");
+        }
+
+        /// <summary>
+        /// Verifies that the loader's AppDomain fallback resolver can return assemblies already
+        /// loaded for earlier plugins when a later plugin asks for the same dependency by name.
+        /// </summary>
+        [Test]
+        public void CurrentDomainAssemblyResolve_ReturnsAssemblyBySimpleName() {
+            PluginLoader loader = CreateLoaderWithInitializedCollections();
+            Assembly expectedAssembly = typeof(PluginLoader).Assembly;
+            loader.Assemblies.Add(expectedAssembly);
+            var args = new ResolveEventArgs(expectedAssembly.GetName().FullName);
+
+            MethodInfo method = typeof(PluginLoader).GetMethod("CurrentDomain_AssemblyResolve", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            Assembly resolvedAssembly = (Assembly)method.Invoke(loader, new object[] { this, args })!;
+
+            resolvedAssembly.Should().BeSameAs(expectedAssembly);
+        }
+
+        /// <summary>
+        /// Verifies that the plugin assembly load context can resolve a dependency from the plugin
+        /// directory by simple assembly name.
+        /// </summary>
+        [Test]
+        public void PluginAssemblyLoadContext_ResolvesDependencyFromPluginDirectory() {
+            string fixtureAssembly = typeof(PluginLoader).Assembly.Location;
+            Type contextType = typeof(PluginLoader).GetNestedType("PluginAssemblyLoadContext", BindingFlags.NonPublic)!;
+            var context = (AssemblyLoadContext)Activator.CreateInstance(contextType, "plugin-resolver", fixtureAssembly, true)!;
+            try {
+                MethodInfo method = contextType.GetMethod("PluginAssemblyLoadContext_Resolving", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+                Assembly resolvedAssembly = (Assembly)method.Invoke(context, new object[] { context, new AssemblyName("NINA.Plugin") })!;
+
+                resolvedAssembly.GetName().Name.Should().Be("NINA.Plugin");
+            } finally {
+                context.Unload();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the plugin assembly load context returns null for dependencies that do not
+        /// exist beside the plugin assembly.
+        /// </summary>
+        [Test]
+        public void PluginAssemblyLoadContext_ReturnsNullForMissingDependency() {
+            string fixtureAssembly = typeof(PluginLoader).Assembly.Location;
+            Type contextType = typeof(PluginLoader).GetNestedType("PluginAssemblyLoadContext", BindingFlags.NonPublic)!;
+            var context = (AssemblyLoadContext)Activator.CreateInstance(contextType, "plugin-missing-resolver", fixtureAssembly, true)!;
+            try {
+                MethodInfo method = contextType.GetMethod("PluginAssemblyLoadContext_Resolving", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+                Assembly resolvedAssembly = (Assembly)method.Invoke(context, new object[] { context, new AssemblyName("Definitely.Missing.Plugin.Dependency") })!;
+
+                resolvedAssembly.Should().BeNull();
+            } finally {
+                context.Unload();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that repeated load calls are idempotent once initialization is complete and do
+        /// not recompose plugin state.
+        /// </summary>
+        [Test]
+        public async Task Load_ReturnsWithoutWorkWhenAlreadyInitialized() {
+            PluginLoader loader = CreateLoaderWithInitializedCollections();
+            FieldInfo initializedField = typeof(PluginLoader).GetField("initialized", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            initializedField.SetValue(loader, true);
+
+            await loader.Load();
+
+            loader.Plugins.Should().BeEmpty();
+            loader.Items.Should().BeEmpty();
+        }
+
+        private static IDictionary<string, object> CreateMetadata(string name, string description, string icon, string category) {
+            return new Dictionary<string, object> {
+                ["Name"] = name,
+                ["Description"] = description,
+                ["Icon"] = icon,
+                ["Category"] = category
+            };
+        }
+
+        private static void InvokeCompose(PluginLoader loader, ComposablePartCatalog catalog, string pluginName) {
+            MethodInfo method = typeof(PluginLoader).GetMethod("Compose", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            method.Invoke(loader, new object[] { catalog, pluginName });
+        }
+
+        private static async Task InvokeLoadPlugin(PluginLoader loader, string file, double progress) {
+            MethodInfo method = typeof(PluginLoader).GetMethod("LoadPlugin", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var task = (Task)method.Invoke(loader, new object[] { file, progress })!;
+            await task;
+        }
+
+        private static IList<ISequenceItem> InvokeAssignSequenceEntity(
+            PluginLoader loader,
+            IEnumerable<Lazy<ISequenceItem, IDictionary<string, object>>> imports,
+            IApplicationResourceDictionary resourceDictionary,
+            string pluginName) {
+            MethodInfo method = typeof(PluginLoader).GetMethod("AssignSequenceEntity", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            MethodInfo genericMethod = method.MakeGenericMethod(typeof(ISequenceItem));
+            IEnumerable result = (IEnumerable)genericMethod.Invoke(loader, new object[] { imports, resourceDictionary, pluginName })!;
+            return result.Cast<ISequenceItem>().ToList();
+        }
+
+        private static void InitializeCollections(PluginLoader loader) {
+            SetProperty(loader, nameof(PluginLoader.Items), new List<ISequenceItem>());
+            SetProperty(loader, nameof(PluginLoader.Conditions), new List<NINA.Sequencer.Conditions.ISequenceCondition>());
+            SetProperty(loader, nameof(PluginLoader.Triggers), new List<NINA.Sequencer.Trigger.ISequenceTrigger>());
+            SetProperty(loader, nameof(PluginLoader.Container), new List<NINA.Sequencer.Container.ISequenceContainer>());
+            SetProperty(loader, nameof(PluginLoader.DockableVMs), new List<IDockableVM>());
+            SetProperty(loader, nameof(PluginLoader.PluggableBehaviors), new List<IPluggableBehavior>());
+            SetProperty(loader, nameof(PluginLoader.DeviceProviders), new List<IEquipmentProvider>());
+            SetProperty(loader, nameof(PluginLoader.Plugins), new Dictionary<IPluginManifest, bool>());
+            SetProperty(loader, nameof(PluginLoader.Upgraders), new List<ISequenceEntityUpgrader>());
+        }
+
+        private static void SetProperty(PluginLoader loader, string propertyName, object value) {
+            PropertyInfo property = typeof(PluginLoader).GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)!;
+            property.SetValue(loader, value);
+        }
+
+        private static void ResetPluginRuntimeFolders() {
+            DeleteDirectoryIfExists(Constants.BaseUserExtensionsFolder);
+            DeleteDirectoryIfExists(Constants.BaseStagingFolder);
+            DeleteDirectoryIfExists(Constants.BaseDeletionFolder);
+        }
+
+        private static void DeleteDirectoryIfExists(string directory) {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        private static PluginLoader CreateLoaderWithInitializedCollections() {
+            PluginLoader loader = CreateLoaderWithInitializedResourceDictionary();
+            InitializeCollections(loader);
+            return loader;
+        }
+
+        private static PluginLoader CreateLoaderWithInitializedResourceDictionary() {
+            var resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+            return CreateLoader(resourceDictionaryMock.Object, Mock.Of<ISymbolBroker>());
+        }
+
+        private static PluginLoader CreateLoader(IApplicationResourceDictionary resourceDictionary, ISymbolBroker symbolBroker) {
+            var applicationStatusMediatorMock = new Mock<IApplicationStatusMediator>();
+            applicationStatusMediatorMock
+                .Setup(x => x.StatusUpdate(It.IsAny<ApplicationStatus>()))
+                .Verifiable();
+
+            return new PluginLoader(
+                Mock.Of<IProfileService>(),
+                Mock.Of<ICameraMediator>(),
+                Mock.Of<ITelescopeMediator>(),
+                Mock.Of<IFocuserMediator>(),
+                Mock.Of<IFilterWheelMediator>(),
+                Mock.Of<IGuiderMediator>(),
+                Mock.Of<IRotatorMediator>(),
+                Mock.Of<IFlatDeviceMediator>(),
+                Mock.Of<IWeatherDataMediator>(),
+                Mock.Of<IImagingMediator>(),
+                applicationStatusMediatorMock.Object,
+                Mock.Of<INighttimeCalculator>(),
+                Mock.Of<IPlanetariumFactory>(),
+                Mock.Of<IImageHistoryVM>(),
+                Mock.Of<IDeepSkyObjectSearchVM>(),
+                Mock.Of<IDomeMediator>(),
+                Mock.Of<IImageSaveMediator>(),
+                Mock.Of<ISwitchMediator>(),
+                Mock.Of<ISafetyMonitorMediator>(),
+                resourceDictionary,
+                Mock.Of<IApplicationMediator>(),
+                Mock.Of<IFramingAssistantVM>(),
+                Mock.Of<IPlateSolverFactory>(),
+                Mock.Of<IWindowServiceFactory>(),
+                Mock.Of<IDomeFollower>(),
+                Mock.Of<IPluggableBehaviorSelector<IStarDetection>>(),
+                Mock.Of<IPluggableBehaviorSelector<IStarAnnotator>>(),
+                Mock.Of<IImageDataFactory>(),
+                Mock.Of<IMeridianFlipVMFactory>(),
+                Mock.Of<IAutoFocusVMFactory>(),
+                Mock.Of<IImageControlVM>(),
+                Mock.Of<IImageStatisticsVM>(),
+                Mock.Of<IDomeSynchronization>(),
+                Mock.Of<ISequenceMediator>(),
+                Mock.Of<IOptionsVM>(),
+                Mock.Of<IExposureDataFactory>(),
+                Mock.Of<ITwilightCalculator>(),
+                Mock.Of<IMessageBroker>(),
+                symbolBroker);
+        }
+
+        [ExportMetadata("Name", "Synthetic Focus Sweep")]
+        [ExportMetadata("Description", "Evaluates focus drift across altitude bands.")]
+        [ExportMetadata("Icon", "FocusSweepSvg")]
+        [ExportMetadata("Category", "Science Planning")]
+        [Export(typeof(ISequenceItem))]
+        public class ExportedScienceItem : SequenceItem {
+            public override object Clone() {
+                return new ExportedScienceItem();
+            }
+
+            public override Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+                return Task.CompletedTask;
+            }
+        }
+
+        [ExportMetadata("Name", "Synthetic Science Upgrade")]
+        [Export(typeof(ISequenceEntityUpgrader))]
+        public class ExportedScienceUpgrader : ISequenceEntityUpgrader {
+            public string Name { get; set; } = string.Empty;
+            public SequenceUpgradeStage Stages => SequenceUpgradeStage.AfterPopulate;
+
+            public object Upgrade(SequenceUpgradeContext context, SequenceUpgradeStage stage, object? current) {
+                return current;
+            }
+        }
+    }
+}
+
+namespace NINA.Plugins.Connector.Instructions {
+    using NINA.Core.Model;
+    using NINA.Sequencer.SequenceItem;
+
+    public class ConnectEquipment : SequenceItem {
+        public override object Clone() {
+            return new ConnectEquipment();
+        }
+
+        public override Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginManifestValidationTest.cs
+++ b/NINA.Test/Plugin/PluginManifestValidationTest.cs
@@ -1,0 +1,130 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NINA.Plugin;
+using NINA.Plugin.ManifestDefinition;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace NINA.Test.Plugin {
+
+    [TestFixture]
+    public class PluginManifestValidationTest {
+
+        /// <summary>
+        /// Verifies that a repository manifest with realistic astronomy plugin metadata validates
+        /// against the schema and materializes concrete manifest, version, description, and installer types.
+        /// </summary>
+        [Test]
+        public async Task ValidateAndParseManifest_AcceptsCompleteRepositoryManifest() {
+            var token = CreateValidManifestToken();
+
+            PluginManifest manifest = await ValidateAndParseManifest(token);
+
+            manifest.Should().NotBeNull();
+            manifest.Name.Should().Be("Spectral Focus Planner");
+            manifest.Identifier.Should().Be("5c26f12d-8f12-49ed-8f7d-5df71f0c923a");
+            manifest.Version.Should().BeOfType<PluginVersion>();
+            manifest.Version.ToString().Should().Be("1.2.3.4");
+            manifest.MinimumApplicationVersion.Should().BeOfType<PluginVersion>();
+            manifest.MinimumApplicationVersion.ToString().Should().Be("3.0.0.0");
+            manifest.Descriptions.Should().BeOfType<PluginDescription>();
+            manifest.Descriptions.ShortDescription.Should().Be("Plans focus offsets for narrowband filter changes.");
+            manifest.Installer.Should().BeOfType<PluginInstallerDetails>();
+            manifest.Installer.Type.Should().Be(InstallerType.DLL);
+            manifest.Installer.ChecksumType.Should().Be(InstallerChecksum.SHA256);
+            manifest.Tags.Should().Equal("focus", "filter-wheel", "narrowband");
+        }
+
+        /// <summary>
+        /// Verifies that a manifest missing the required installer contract is rejected before it can
+        /// participate in plugin discovery or compatibility checks.
+        /// </summary>
+        [Test]
+        public async Task ValidateAndParseManifest_RejectsMissingRequiredInstaller() {
+            var token = CreateValidManifestToken();
+            token["Installer"]?.Parent?.Remove();
+
+            PluginManifest manifest = await ValidateAndParseManifest(token);
+
+            manifest.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies that malformed checksum data is rejected by the repository schema so corrupted
+        /// or ambiguous installer metadata is not accepted as a downloadable plugin version.
+        /// </summary>
+        [Test]
+        public async Task ValidateAndParseManifest_RejectsInvalidChecksumShape() {
+            var token = CreateValidManifestToken();
+            token["Installer"]!["Checksum"] = "not-a-hex-checksum";
+
+            PluginManifest manifest = await ValidateAndParseManifest(token);
+
+            manifest.Should().BeNull();
+        }
+
+        private static JObject CreateValidManifestToken() {
+            return JObject.Parse(@"{
+                'Name': 'Spectral Focus Planner',
+                'Identifier': '5c26f12d-8f12-49ed-8f7d-5df71f0c923a',
+                'Version': {
+                    'Major': '1',
+                    'Minor': 2,
+                    'Patch': 3,
+                    'Build': 4
+                },
+                'Author': 'NINA Test Observatory',
+                'Homepage': 'https://example.invalid/spectral-focus-planner',
+                'Repository': 'https://example.invalid/spectral-focus-planner.git',
+                'License': 'MPL-2.0',
+                'LicenseURL': 'https://www.mozilla.org/en-US/MPL/2.0/',
+                'ChangelogURL': 'https://example.invalid/spectral-focus-planner/changelog',
+                'Tags': [
+                    'focus',
+                    'filter-wheel',
+                    'narrowband'
+                ],
+                'MinimumApplicationVersion': {
+                    'Major': 3,
+                    'Minor': 0,
+                    'Patch': 0,
+                    'Build': 0
+                },
+                'Descriptions': {
+                    'ShortDescription': 'Plans focus offsets for narrowband filter changes.',
+                    'LongDescription': 'Uses filter-specific offsets to plan refocus operations for repeatable narrowband imaging sessions.',
+                    'FeaturedImageURL': 'https://example.invalid/images/focus-planner.png',
+                    'ScreenshotURL': 'https://example.invalid/images/focus-planner-main.png',
+                    'AltScreenshotURL': 'https://example.invalid/images/focus-planner-alt.png'
+                },
+                'Installer': {
+                    'URL': 'https://example.invalid/downloads/SpectralFocusPlanner.dll',
+                    'Checksum': '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                    'ChecksumType': 'SHA256',
+                    'Type': 'DLL'
+                }
+            }");
+        }
+
+        private static async Task<PluginManifest> ValidateAndParseManifest(JToken token) {
+            var fetcher = new PluginFetcher("https://example.invalid");
+            MethodInfo method = typeof(PluginFetcher).GetMethod("ValidateAndParseManifest", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var task = (Task<PluginManifest>)method.Invoke(fetcher, new object[] { token })!;
+            return await task;
+        }
+    }
+}

--- a/NINA.Test/Plugin/PluginTestEnvironment.cs
+++ b/NINA.Test/Plugin/PluginTestEnvironment.cs
@@ -1,0 +1,49 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Utility;
+using NUnit.Framework;
+
+namespace NINA.Test.Plugin {
+
+    [SetUpFixture]
+    public class PluginTestEnvironment {
+        private string originalApplicationTempPath;
+        private string pluginTestRoot;
+
+        /// <summary>
+        /// Redirects plugin filesystem tests to a workspace-local runtime root before NINA.Plugin
+        /// constants are initialized, preventing tests from touching a user's real plugin folders.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp() {
+            originalApplicationTempPath = CoreUtil.APPLICATIONTEMPPATH;
+            pluginTestRoot = Path.Combine(TestContext.CurrentContext.WorkDirectory, "PluginTestRuntime", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(pluginTestRoot);
+            CoreUtil.APPLICATIONTEMPPATH = pluginTestRoot;
+        }
+
+        /// <summary>
+        /// Restores the global application temp path and removes the isolated plugin runtime root
+        /// created for plugin loader and installer tests.
+        /// </summary>
+        [OneTimeTearDown]
+        public void OneTimeTearDown() {
+            CoreUtil.APPLICATIONTEMPPATH = originalApplicationTempPath;
+            if (Directory.Exists(pluginTestRoot)) {
+                Directory.Delete(pluginTestRoot, true);
+            }
+        }
+    }
+}

--- a/NINA.Test/Plugin/VersionTests.cs
+++ b/NINA.Test/Plugin/VersionTests.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 
 /*
     Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
@@ -43,6 +43,10 @@ namespace NINA.Test.Plugin {
     [TestFixture]
     public class VersionTests {
 
+        /// <summary>
+        /// Verifies plugin minimum-application compatibility when the running application version is
+        /// represented by System.Version, matching the loader's runtime comparison path.
+        /// </summary>
         [Test]
         //Major
         [TestCase("1.0.0.0", "1.0.0.0", true)]
@@ -67,6 +71,10 @@ namespace NINA.Test.Plugin {
             PluginVersion.IsPluginCompatible(pluginVersion, appVersion).Should().Be(isCompatible);
         }
 
+        /// <summary>
+        /// Verifies plugin minimum-application compatibility when both sides are plugin manifest
+        /// versions, matching repository manifest filtering before download.
+        /// </summary>
         [Test]
         //Major
         [TestCase("1.0.0.0", "1.0.0.0", true)]
@@ -91,6 +99,10 @@ namespace NINA.Test.Plugin {
             PluginVersion.IsPluginCompatible(pluginVersion, appVersion).Should().Be(isCompatible);
         }
 
+        /// <summary>
+        /// Verifies plugin-version ordering across major, minor, patch, and build components so
+        /// compatibility-map minimum-version checks use deterministic semantic ordering.
+        /// </summary>
         [Test]
         //Major
         [TestCase("1.0.0.0", "1.0.0.0", true)]


### PR DESCRIPTION
## Purpose

Improve NINA.Plugin unit test coverage with meaningful scenarios around plugin metadata, manifest parsing,
compatibility checks, installer safety, repository filtering, loader behavior, and message broker routing.

This PR adds focused tests for:

- Plugin manifest schema validation and interface-backed JSON conversion
- Plugin compatibility map behavior, including legacy API floors, update-required plugins, and deprecated sentinel
  versions
- PluginBase assembly metadata extraction and default values
- Metadata-only assembly reading via PluginAssemblyReader
- Installer checksum validation, DLL/archive staging, uninstall staging, and zip-slip protection
- Repository manifest fetching/filtering using a loopback HTTP server
- Loader collection initialization, migration from older versioned plugin folders, non-plugin DLL/native
  dependency handling, merged entity filtering, and assembly resolver behavior
- Message broker unsubscribe behavior
- XML scenario comments for plugin test cases

## How Was It Tested?

Automated tests:

dotnet build NINA.Test\NINA.Test.csproj --no-restore -v quiet /clp:ErrorsOnly
dotnet test NINA.Test\NINA.Test.csproj --no-build --filter 'FullyQualifiedName~NINA.Test.Plugin' -v minimal --
NUnit.NumberOfTestWorkers=1

Result:

Passed: 89
Failed: 0
Skipped: 0

Coverage was also measured for NINA.Plugin.dll with dotnet-coverage scoped to the plugin test namespace:

Line coverage: 79.75%
Block coverage: 77.14%

No UI changes were made.

## AI / Tooling Disclosure

OpenAI Codex (GPT-5-based coding agent)

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
    - [x] No breaking changes to interfaces
    - [x] No changes to method/class signatures (especially optional parameters)
- [ ] RELEASE_NOTES.md updated (if applicable)
- [ ] Documentation (https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None.

## Screenshots

Not applicable. No UI changes.

## Additional Notes

NINA.Plugin now exposes internals to NINA.Test via InternalsVisibleTo so compatibility map behavior can be tested
directly without brittle reflection.