### PR TITLE
Improve centering correction and plate solve failure handling

### DIFF
--- a/NINA.Astrometry/Coordinates.cs
+++ b/NINA.Astrometry/Coordinates.cs
@@ -392,7 +392,8 @@ namespace NINA.Astrometry {
                 viewPort.ViewPortCenterPoint,
                 viewPort.ArcSecWidth,
                 viewPort.ArcSecHeight,
-                viewPort.Rotation);
+                viewPort.Rotation,
+                type);
         }
 
         /// <summary>

--- a/NINA.Astrometry/RectangularCoordinates.cs
+++ b/NINA.Astrometry/RectangularCoordinates.cs
@@ -23,6 +23,16 @@ namespace NINA.Astrometry {
     /// </summary>
     public class RectangularCoordinates {
 
+        public static RectangularCoordinates FromPolar(Coordinates coordinates) {
+            double ra = Angle.ByDegree(coordinates.RADegrees).Radians;
+            double dec = Angle.ByDegree(coordinates.Dec).Radians;
+            double cosDec = Math.Cos(dec);
+            return new RectangularCoordinates(
+                cosDec * Math.Cos(ra),
+                cosDec * Math.Sin(ra),
+                Math.Sin(dec));
+        }
+
         public RectangularCoordinates(double x, double y, double z) {
             this.X = x;
             this.Y = y;
@@ -40,6 +50,30 @@ namespace NINA.Astrometry {
             var y = this.Y * Math.Cos(meanObliquityRad) - this.Z * Math.Sin(meanObliquityRad);
             var z = this.Y * Math.Sin(meanObliquityRad) + this.Z * Math.Cos(meanObliquityRad);
             return new RectangularCoordinates(x, y, z);
+        }
+
+        public RectangularCoordinates Normalize() {
+            return this / Distance;
+        }
+
+        public double Dot(RectangularCoordinates other) {
+            return X * other.X + Y * other.Y + Z * other.Z;
+        }
+
+        public RectangularCoordinates Cross(RectangularCoordinates other) {
+            return new RectangularCoordinates(
+                Y * other.Z - Z * other.Y,
+                Z * other.X - X * other.Z,
+                X * other.Y - Y * other.X);
+        }
+
+        public RectangularCoordinates RotateAroundAxis(RectangularCoordinates axis, Angle angle) {
+            RectangularCoordinates normalizedAxis = axis.Normalize();
+            double sinAngle = Math.Sin(angle.Radians);
+            double cosAngle = Math.Cos(angle.Radians);
+            return this * cosAngle
+                + normalizedAxis.Cross(this) * sinAngle
+                + normalizedAxis * normalizedAxis.Dot(this) * (1 - cosAngle);
         }
 
         public static RectangularCoordinates operator +(RectangularCoordinates l, RectangularCoordinates r) {

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -2487,6 +2487,9 @@ Calculated HFR: {2}
   <data name="LblPlateSolveFailedDelayTooltip" xml:space="preserve">
     <value>Delay, in minutes, between two plate solve attempts</value>
   </data>
+  <data name="LblCenteringFailedAfterMaxAttempts" xml:space="preserve">
+    <value>Centering failed after {0} correction attempts</value>
+  </data>
   <data name="LblPlateSolveImage" xml:space="preserve">
     <value>Plate solve current image</value>
   </data>
@@ -2940,6 +2943,9 @@ This template will be used on startup to initialize the sequence instead of the 
   </data>
   <data name="LblSlew" xml:space="preserve">
     <value>Slew</value>
+  </data>
+  <data name="LblSlewFailed" xml:space="preserve">
+    <value>Slew failed</value>
   </data>
   <data name="LblSlewCenter" xml:space="preserve">
     <value>Slew and Center</value>

--- a/NINA.Platesolving/CaptureSolver.cs
+++ b/NINA.Platesolving/CaptureSolver.cs
@@ -50,27 +50,20 @@ namespace NINA.PlateSolving {
             do {
                 remainingAttempts--;
                 var oldFilter = filterWheelMediator.GetInfo()?.SelectedFilter;
-                progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblCameraStateExposing"] });
-                var renderedImage = await imagingMediator.CaptureAndPrepareImage(seq, new PrepareImageParameters(detectStars: false), ct, progress);
-                progress?.Report(new ApplicationStatus() { Status = string.Empty });
-
-                if (renderedImage == null) {
-                    plateSolveResult = new PlateSolveResult() { Success = false }; ;
-                } else {
-                    Task filterChangeTask = Task.CompletedTask;
-                    if (oldFilter != null) {
-                        filterChangeTask = filterWheelMediator.ChangeFilter(oldFilter);
-                    }
-
-                    solveProgress?.Report(
-                        new PlateSolveProgress {
-                            Thumbnail = await renderedImage.GetThumbnail()
-                        }
-                    );
-
-                    ct.ThrowIfCancellationRequested();
+                try {
+                    progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblCameraStateExposing"] });
+                    var renderedImage = await imagingMediator.CaptureAndPrepareImage(seq, new PrepareImageParameters(detectStars: false), ct, progress);
+                    progress?.Report(new ApplicationStatus() { Status = string.Empty });
 
                     if (renderedImage != null) {
+                        solveProgress?.Report(
+                            new PlateSolveProgress {
+                                Thumbnail = await renderedImage.GetThumbnail()
+                            }
+                        );
+
+                        ct.ThrowIfCancellationRequested();
+
                         plateSolveResult = await ImageSolver.Solve(renderedImage.RawImageData, parameter, progress, ct);
                     } else {
                         plateSolveResult = new PlateSolveResult() { Success = false };
@@ -81,12 +74,17 @@ namespace NINA.PlateSolving {
                             PlateSolveResult = plateSolveResult
                         }
                     );
-
-                    await filterChangeTask;
-
-                    if (!plateSolveResult.Success && remainingAttempts > 0) {
-                        await CoreUtil.Wait(parameter.ReattemptDelay, true, ct, progress, "");
+                } finally {
+                    progress?.Report(new ApplicationStatus() { Status = string.Empty });
+                    if (oldFilter != null) {
+                        Logger.Info($"Restoring filter to {oldFilter} after capture solve attempt");
+                        var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+                        await filterWheelMediator.ChangeFilter(oldFilter, timeoutCts.Token, progress);
                     }
+                }
+
+                if (!plateSolveResult.Success && remainingAttempts > 0) {
+                    await CoreUtil.Wait(parameter.ReattemptDelay, true, ct, progress, "");
                 }
             } while (!plateSolveResult.Success && remainingAttempts > 0);
             return plateSolveResult;

--- a/NINA.Platesolving/CenteringSolver.cs
+++ b/NINA.Platesolving/CenteringSolver.cs
@@ -72,7 +72,6 @@ namespace NINA.PlateSolving {
                 var centered = false;
                 var maxSlewAttempts = 10;
                 PlateSolveResult result;
-                Separation offset = new Separation();
                 do {
                     var centeringAttempt = new CenteringMeasurement();
                     centeringAttempts.Add(centeringAttempt);
@@ -90,51 +89,55 @@ namespace NINA.PlateSolving {
                         break;
                     }
 
-                    // All coordinates need to be in the same epoch as the scope for offsets to correctly be calculated
+                    // All coordinates need to be in the same epoch as the scope for corrections to correctly be calculated
                     var position = telescopeMediator.GetCurrentPosition();
                     var resultCoordinates = result.Coordinates.Transform(position.Epoch);
                     var parameterCoordinates = parameter.Coordinates.Transform(position.Epoch);
                     result.Separation = parameterCoordinates - resultCoordinates;
 
-                    var positionWithOffset = position - offset;
-                    Logger.Info($"Centering Solver - Scope Position: {position}; Offset: {offset}; Centering Coordinates: {parameterCoordinates}; Solved: {resultCoordinates}; Separation {result.Separation}; Threshold: {parameter.Threshold}");
+                    Logger.Info($"Centering Solver - Scope Position: {position}; Centering Coordinates: {parameterCoordinates}; Solved: {resultCoordinates}; Separation {result.Separation}; Threshold: {parameter.Threshold}");
 
                     solveProgress?.Report(new PlateSolveProgress() { PlateSolveResult = result });
 
                     if (Math.Abs(result.Separation.Distance.ArcMinutes) > parameter.Threshold) {
                         var syncMeasurement = new Measurement("Sync").Start();
+                        bool useMeasuredCorrection = false;
 
                         progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblPlateSolveNotInsideToleranceSyncing"] });
                         if (parameter.NoSync || !await telescopeMediator.Sync(resultCoordinates)) {
-                            var oldOffset = offset;
-                            offset = position - resultCoordinates;
-
-                            Logger.Info($"Sync {(parameter.NoSync ? "disabled" : "failed")} - calculating offset instead to compensate.  Original: {positionWithOffset}; Original Offset {oldOffset}; Solved: {resultCoordinates}; New Offset: {offset}");
+                            useMeasuredCorrection = true;
+                            Logger.Info($"Sync {(parameter.NoSync ? "disabled" : "failed")} - using measured centering correction instead. Reported: {position}; Solved: {resultCoordinates}");
                         } else {
                             var positionAfterSync = telescopeMediator.GetCurrentPosition();
 
                             // If Sync affects the scope position by at least 1 arcsecond, then continue iterating without
-                            // using an offset
+                            // applying an additional measured correction.
                             var syncEffect = positionAfterSync - position;
                             if (Math.Abs(syncEffect.Distance.ArcSeconds) < 1.0d) {
-                                var syncDistance = positionAfterSync - resultCoordinates;
-                                offset = syncDistance;
-                                Logger.Warning($"Sync failed silently - calculating offset instead to compensate.  Position after sync: {positionAfterSync}; Solved: {resultCoordinates}; New Offset: {offset}");
+                                useMeasuredCorrection = true;
+                                Logger.Warning($"Sync failed silently - using measured centering correction instead. Position after sync: {positionAfterSync}; Solved: {resultCoordinates}");
                             } else {
-                                // Sync worked - reset offset
                                 Logger.Debug($"Synced sucessfully. Position after sync: {positionAfterSync}");
-                                offset = new Separation();
                             }
 
                             centeringAttempt.AddSubMeasurement(syncMeasurement.Stop());
                         }
 
                         var scopePosition = telescopeMediator.GetCurrentPosition();
-                        Logger.Info($"Slewing to target after sync. Current Position: {scopePosition}; Target coordinates: {parameterCoordinates}; Offset {offset}");
                         progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblPlateSolveNotInsideToleranceReslew"] });
 
                         var slewMeasurement = new Measurement("Reslew").Start();
-                        Coordinates correctedTarget = CalculateCorrectedTarget(parameterCoordinates, scopePosition, resultCoordinates);
+                        // The measured correction needs the mount-reported position and the solved sky position.
+                        // Using the solve result for both sides would erase the mount-vs-sky error that no-sync fallback corrects.
+                        Coordinates correctedTarget;
+                        if (useMeasuredCorrection) {
+                            correctedTarget = CalculateCorrectedTarget(parameterCoordinates, scopePosition, resultCoordinates);
+                            Logger.Info($"Slewing to corrected target after sync fallback. Current Position: {scopePosition}; Target coordinates: {parameterCoordinates}; Solved: {resultCoordinates}; Corrected target: {correctedTarget}");
+                        } else {
+                            correctedTarget = parameterCoordinates;
+                            Logger.Info($"Slewing to target after sync. Current Position: {scopePosition}; Target coordinates: {parameterCoordinates}; Solved: {resultCoordinates}");
+                        }
+
                         bool slewSuccessful = await telescopeMediator.SlewToCoordinatesAsync(correctedTarget, ct);
                         slewMeasurement.Stop();
                         centeringAttempt.AddSubMeasurement(slewMeasurement);

--- a/NINA.Platesolving/CenteringSolver.cs
+++ b/NINA.Platesolving/CenteringSolver.cs
@@ -26,6 +26,7 @@ using NINA.Equipment.Interfaces;
 using NINA.Core.Utility.Notification;
 using NINA.Core.Model.Equipment;
 using System.Collections.Generic;
+using System.Windows;
 
 namespace NINA.PlateSolving {
 
@@ -133,9 +134,16 @@ namespace NINA.PlateSolving {
                         progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblPlateSolveNotInsideToleranceReslew"] });
 
                         var slewMeasurement = new Measurement("Reslew").Start();
-                        await telescopeMediator.SlewToCoordinatesAsync(parameterCoordinates + offset, ct);
+                        Coordinates correctedTarget = CalculateCorrectedTarget(parameterCoordinates, scopePosition, resultCoordinates);
+                        bool slewSuccessful = await telescopeMediator.SlewToCoordinatesAsync(correctedTarget, ct);
                         slewMeasurement.Stop();
                         centeringAttempt.AddSubMeasurement(slewMeasurement);
+                        if (!slewSuccessful) {
+                            result.Success = false;
+                            Logger.Error($"Centering correction slew failed. Current Position: {scopePosition}; Corrected Target: {correctedTarget}; Solved: {resultCoordinates}");
+                            centeringAttempt.Stop();
+                            break;
+                        }
 
                         var domeInfo = domeMediator.GetInfo();
                         if (domeInfo.Connected && domeInfo.CanSetAzimuth && !domeFollower.IsFollowing) {
@@ -170,6 +178,30 @@ namespace NINA.PlateSolving {
                     await filterWheelMediator.ChangeFilter(oldFilter, timeoutCts.Token, progress);
                 }
             }
+        }
+
+        private static Coordinates CalculateCorrectedTarget(Coordinates targetCoordinates, Coordinates reportedCoordinates, Coordinates solvedCoordinates) {
+            Coordinates target = targetCoordinates.Transform(reportedCoordinates.Epoch);
+            Coordinates reported = reportedCoordinates.Transform(reportedCoordinates.Epoch);
+            Coordinates solved = solvedCoordinates.Transform(reportedCoordinates.Epoch);
+
+            Point correction = reported.XYProjection(solved, new Point(0, 0), 1, 1, 0, Coordinates.ProjectionType.Gnomonic);
+            if (!IsFinite(correction.X) || !IsFinite(correction.Y)) {
+                Logger.Warning($"Centering correction projection returned an invalid vector. Falling back to raw coordinate offset. Reported: {reported}; Solved: {solved}");
+                return target + (reported - solved);
+            }
+
+            Coordinates correctedTarget = target.Shift(correction.X, correction.Y, 0, 1, 1, Coordinates.ProjectionType.Gnomonic);
+            if (!IsFinite(correctedTarget.RADegrees) || !IsFinite(correctedTarget.Dec)) {
+                Logger.Warning($"Centering correction produced invalid coordinates. Falling back to raw coordinate offset. Target: {target}; Reported: {reported}; Solved: {solved}");
+                return target + (reported - solved);
+            }
+
+            return correctedTarget;
+        }
+
+        private static bool IsFinite(double value) {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
         }
     }
 

--- a/NINA.Platesolving/CenteringSolver.cs
+++ b/NINA.Platesolving/CenteringSolver.cs
@@ -26,7 +26,6 @@ using NINA.Equipment.Interfaces;
 using NINA.Core.Utility.Notification;
 using NINA.Core.Model.Equipment;
 using System.Collections.Generic;
-using System.Windows;
 
 namespace NINA.PlateSolving {
 
@@ -188,16 +187,31 @@ namespace NINA.PlateSolving {
             Coordinates reported = reportedCoordinates.Transform(reportedCoordinates.Epoch);
             Coordinates solved = solvedCoordinates.Transform(reportedCoordinates.Epoch);
 
-            Point correction = reported.XYProjection(solved, new Point(0, 0), 1, 1, 0, Coordinates.ProjectionType.Gnomonic);
-            if (!IsFinite(correction.X) || !IsFinite(correction.Y)) {
-                Logger.Warning($"Centering correction projection returned an invalid vector. Falling back to raw coordinate offset. Reported: {reported}; Solved: {solved}");
-                return target + (reported - solved);
+            RectangularCoordinates solvedVector = RectangularCoordinates.FromPolar(solved);
+            RectangularCoordinates reportedVector = RectangularCoordinates.FromPolar(reported);
+            RectangularCoordinates targetVector = RectangularCoordinates.FromPolar(target);
+
+            RectangularCoordinates rotationAxis = solvedVector.Cross(reportedVector);
+            double sinAngle = rotationAxis.Distance;
+            double cosAngle = solvedVector.Dot(reportedVector);
+            if (!IsFinite(sinAngle) || !IsFinite(cosAngle)) {
+                Logger.Warning($"Centering correction rotation produced invalid values. Slewing to the requested target without measured correction. Reported: {reported}; Solved: {solved}");
+                return target;
             }
 
-            Coordinates correctedTarget = target.Shift(correction.X, correction.Y, 0, 1, 1, Coordinates.ProjectionType.Gnomonic);
+            if (sinAngle < 1e-12) {
+                if (cosAngle < 0) {
+                    Logger.Warning($"Centering correction rotation is ambiguous for nearly opposite coordinates. Slewing to the requested target without measured correction. Reported: {reported}; Solved: {solved}");
+                }
+
+                return target;
+            }
+
+            RectangularCoordinates correctedVector = targetVector.RotateAroundAxis(rotationAxis / sinAngle, Angle.ByRadians(Math.Atan2(sinAngle, cosAngle)));
+            Coordinates correctedTarget = correctedVector.ToPolar(target.Epoch);
             if (!IsFinite(correctedTarget.RADegrees) || !IsFinite(correctedTarget.Dec)) {
-                Logger.Warning($"Centering correction produced invalid coordinates. Falling back to raw coordinate offset. Target: {target}; Reported: {reported}; Solved: {solved}");
-                return target + (reported - solved);
+                Logger.Warning($"Centering correction produced invalid coordinates. Slewing to the requested target without measured correction. Target: {target}; Reported: {reported}; Solved: {solved}");
+                return target;
             }
 
             return correctedTarget;

--- a/NINA.Platesolving/PlateSolveResult.cs
+++ b/NINA.Platesolving/PlateSolveResult.cs
@@ -59,7 +59,7 @@ namespace NINA.PlateSolving {
         public bool Flipped { get; set; }
 
         public bool Success { get; set; }
-        
+
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(RaErrorString))]
         [NotifyPropertyChangedFor(nameof(RaPixError))]

--- a/NINA.Platesolving/Solvers/CLISolver.cs
+++ b/NINA.Platesolving/Solvers/CLISolver.cs
@@ -47,6 +47,8 @@ namespace NINA.PlateSolving.Solvers {
             PlateSolveParameter parameter,
             PlateSolveImageProperties imageProperties);
 
+        protected virtual TimeSpan SolverTimeout => TimeSpan.FromMinutes(10);
+
         protected override async Task<PlateSolveResult> SolveAsyncImpl(
             IImageData source,
             PlateSolveParameter parameter,
@@ -67,15 +69,15 @@ namespace NINA.PlateSolving.Solvers {
                 outputPath = GetOutputPath(imagePath);
 
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken)) {
-                    cts.CancelAfter(TimeSpan.FromMinutes(10));
-                    await StartCLI(imagePath, outputPath, parameter, imageProperties, progress, cancelToken);
+                    cts.CancelAfter(SolverTimeout);
+                    await StartCLI(imagePath, outputPath, parameter, imageProperties, progress, cts.Token);
                 }
 
                 //Extract solution coordinates
                 result = ReadResult(outputPath, parameter, imageProperties);
             } catch(OperationCanceledException) {
                 if (!cancelToken.IsCancellationRequested) {
-                    Logger.Error("Platesolver timed out after 10 minutes");
+                    Logger.Error($"Platesolver timed out after {SolverTimeout.TotalMinutes:0.##} minutes");
                 }
             } finally {
                 progress?.Report(new ApplicationStatus() { Status = string.Empty });
@@ -148,7 +150,7 @@ namespace NINA.PlateSolving.Solvers {
                 throw new FileNotFoundException("Platesolver executable not found. Please point to the correct platesolver executable in platsolving options.", executableLocation);
             }
 
-            System.Diagnostics.Process process = new System.Diagnostics.Process();
+            using System.Diagnostics.Process process = new System.Diagnostics.Process();
             System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo();
 
             startInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Normal;
@@ -171,7 +173,19 @@ namespace NINA.PlateSolving.Solvers {
             };
             Logger.Debug($"Starting process '{executableLocation}' with args '{startInfo.Arguments}'");
             process.Start();
-            await process.WaitForExitAsync(ct);
+            try {
+                await process.WaitForExitAsync(ct);
+            } catch (OperationCanceledException) {
+                if (!process.HasExited) {
+                    try {
+                        process.Kill(entireProcessTree: true);
+                        await process.WaitForExitAsync(CancellationToken.None);
+                    } catch (Exception ex) {
+                        Logger.Error(ex);
+                    }
+                }
+                throw;
+            }
         }
     }
 }

--- a/NINA.Sequencer/SequenceItem/Platesolving/Center.cs
+++ b/NINA.Sequencer/SequenceItem/Platesolving/Center.cs
@@ -116,7 +116,10 @@ namespace NINA.Sequencer.SequenceItem.Platesolving {
             }
 
             progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblSlew"] });
-            await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);            
+            bool slewSuccessful = await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+            if (!slewSuccessful) {
+                throw new SequenceEntityFailedException(Loc.Instance["LblSlewFailed"]);
+            }
 
             var domeInfo = domeMediator.GetInfo();
             if (domeInfo.Connected && domeInfo.CanSetAzimuth && !domeFollower.IsFollowing) {

--- a/NINA.Sequencer/SequenceItem/Platesolving/CenterAndRotate.cs
+++ b/NINA.Sequencer/SequenceItem/Platesolving/CenterAndRotate.cs
@@ -117,7 +117,10 @@ namespace NINA.Sequencer.SequenceItem.Platesolving {
 
                 stoppedGuiding = await guiderMediator.StopGuiding(token);
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblSlew"] });
-                await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+                bool slewSuccessful = await telescopeMediator.SlewToCoordinatesAsync(Coordinates.Coordinates, token);
+                if (!slewSuccessful) {
+                    throw new SequenceEntityFailedException(Loc.Instance["LblSlewFailed"]);
+                }
 
                 var domeInfo = domeMediator.GetInfo();
                 if (domeInfo.Connected && domeInfo.CanSetAzimuth && !domeFollower.IsFollowing) {
@@ -227,6 +230,7 @@ namespace NINA.Sequencer.SequenceItem.Platesolving {
                 new BinningMode(profileService.ActiveProfile.PlateSolveSettings.Binning, profileService.ActiveProfile.PlateSolveSettings.Binning),
                 1
             );
+            seq.Gain = profileService.ActiveProfile.PlateSolveSettings.Gain;
             return await solver.Solve(seq, parameter, PlateSolveStatusVM.Progress, progress, token);
         }
 

--- a/NINA.Sequencer/SequenceItem/Platesolving/SolveAndRotate.cs
+++ b/NINA.Sequencer/SequenceItem/Platesolving/SolveAndRotate.cs
@@ -214,6 +214,7 @@ namespace NINA.Sequencer.SequenceItem.Platesolving {
                 new BinningMode(profileService.ActiveProfile.PlateSolveSettings.Binning, profileService.ActiveProfile.PlateSolveSettings.Binning),
                 1
             );
+            seq.Gain = profileService.ActiveProfile.PlateSolveSettings.Gain;
             return await solver.Solve(seq, parameter, PlateSolveStatusVM.Progress, progress, token);
         }
 

--- a/NINA.Sequencer/SequenceItem/Platesolving/SolveAndSync.cs
+++ b/NINA.Sequencer/SequenceItem/Platesolving/SolveAndSync.cs
@@ -139,6 +139,7 @@ namespace NINA.Sequencer.SequenceItem.Platesolving {
                 new BinningMode(profileService.ActiveProfile.PlateSolveSettings.Binning, profileService.ActiveProfile.PlateSolveSettings.Binning),
                 1
             );
+            seq.Gain = profileService.ActiveProfile.PlateSolveSettings.Gain;
             return await solver.Solve(seq, parameter, PlateSolveStatusVM.Progress, progress, token);
         }
 

--- a/NINA.Test/AstrometryTest/CoordinatesProjectionTest.cs
+++ b/NINA.Test/AstrometryTest/CoordinatesProjectionTest.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using NINA.Astrometry;
+using System;
+using System.Windows;
+
+namespace NINA.Test.AstrometryTest {
+
+    [TestFixture]
+    public class CoordinatesProjectionTest {
+
+        [Test]
+        public void XYProjection_ViewportOverload_UsesRequestedProjectionType() {
+            Coordinates center = new Coordinates(Angle.ByDegree(40.0), Angle.ByDegree(70.0), Epoch.J2000);
+            Coordinates target = new Coordinates(Angle.ByDegree(43.0), Angle.ByDegree(72.0), Epoch.J2000);
+            ViewportFoV viewPort = new ViewportFoV(center, 10.0, 2000.0, 1500.0, 17.0);
+
+            Point actual = target.XYProjection(viewPort, Coordinates.ProjectionType.Gnomonic);
+            Point expectedGnomonic = target.XYProjection(
+                viewPort.CenterCoordinates,
+                viewPort.ViewPortCenterPoint,
+                viewPort.ArcSecWidth,
+                viewPort.ArcSecHeight,
+                viewPort.Rotation,
+                Coordinates.ProjectionType.Gnomonic);
+            Point expectedStereographic = target.XYProjection(
+                viewPort.CenterCoordinates,
+                viewPort.ViewPortCenterPoint,
+                viewPort.ArcSecWidth,
+                viewPort.ArcSecHeight,
+                viewPort.Rotation,
+                Coordinates.ProjectionType.Stereographic);
+
+            actual.X.Should().BeApproximately(expectedGnomonic.X, 1e-9);
+            actual.Y.Should().BeApproximately(expectedGnomonic.Y, 1e-9);
+            Math.Abs(expectedGnomonic.X - expectedStereographic.X).Should().BeGreaterThan(1e-6);
+        }
+    }
+}

--- a/NINA.Test/AstrometryTest/RectangularCoordinatesTest.cs
+++ b/NINA.Test/AstrometryTest/RectangularCoordinatesTest.cs
@@ -71,5 +71,35 @@ namespace NINA.Test.AstrometryTest {
             pv.Velocity.Should().BeSameAs(right);
             pv.ToString().Should().Contain(nameof(RectangularPV.Position));
         }
+
+        [Test]
+        public void RectangularCoordinates_FromPolarRoundTripsRaDec() {
+            Coordinates coordinates = new Coordinates(Angle.ByDegree(123.4), Angle.ByDegree(-45.6), Epoch.J2000);
+
+            Coordinates roundTrip = RectangularCoordinates.FromPolar(coordinates).ToPolar(coordinates.Epoch);
+
+            roundTrip.RADegrees.Should().BeApproximately(coordinates.RADegrees, AngleTolerance);
+            roundTrip.Dec.Should().BeApproximately(coordinates.Dec, AngleTolerance);
+        }
+
+        [Test]
+        public void RectangularCoordinates_DotCrossNormalizeAndAxisRotation_ReturnExpectedVectors() {
+            RectangularCoordinates xAxis = new RectangularCoordinates(1.0, 0.0, 0.0);
+            RectangularCoordinates yAxis = new RectangularCoordinates(0.0, 1.0, 0.0);
+            RectangularCoordinates zAxis = new RectangularCoordinates(0.0, 0.0, 1.0);
+
+            RectangularCoordinates cross = xAxis.Cross(yAxis);
+            RectangularCoordinates normalized = new RectangularCoordinates(3.0, 0.0, 4.0).Normalize();
+            RectangularCoordinates rotated = xAxis.RotateAroundAxis(zAxis, Angle.ByDegree(90.0));
+
+            xAxis.Dot(yAxis).Should().BeApproximately(0.0, AngleTolerance);
+            cross.X.Should().BeApproximately(0.0, AngleTolerance);
+            cross.Y.Should().BeApproximately(0.0, AngleTolerance);
+            cross.Z.Should().BeApproximately(1.0, AngleTolerance);
+            normalized.Distance.Should().BeApproximately(1.0, AngleTolerance);
+            rotated.X.Should().BeApproximately(0.0, AngleTolerance);
+            rotated.Y.Should().BeApproximately(1.0, AngleTolerance);
+            rotated.Z.Should().BeApproximately(0.0, AngleTolerance);
+        }
     }
 }

--- a/NINA.Test/PlateSolving/CaptureSolverTest.cs
+++ b/NINA.Test/PlateSolving/CaptureSolverTest.cs
@@ -197,5 +197,101 @@ namespace NINA.Test.PlateSolving {
             imagingMediatorMock.Verify(x => x.CaptureAndPrepareImage(seq, It.IsAny<PrepareImageParameters>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()), Times.Exactly(3));
             imageSolverMock.Verify(x => x.Solve(imageDataMock.Object, It.IsAny<PlateSolveParameter>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
+
+        [Test]
+        public async Task Solve_RestoresFilterWhenCaptureReturnsNull() {
+            var initialFilter = new FilterInfo() { Name = "L", Position = 1 };
+            filterMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = initialFilter });
+            var seq = new CaptureSequence();
+            var parameter = new CaptureSolverParameter() { FocalLength = 700, Attempts = 1 };
+            imagingMediatorMock
+                .Setup(x => x.CaptureAndPrepareImage(seq, It.IsAny<PrepareImageParameters>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .ReturnsAsync((IRenderedImage)null);
+
+            var sut = new CaptureSolver(plateSolverMock.Object, blindSolverMock.Object, imagingMediatorMock.Object, filterMediatorMock.Object);
+            sut.ImageSolver = imageSolverMock.Object;
+
+            PlateSolveResult result = await sut.Solve(seq, parameter, default, default, CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            filterMediatorMock.Verify(x => x.ChangeFilter(initialFilter, It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()), Times.Once());
+        }
+
+        [Test]
+        public async Task Solve_RestoresFilterWhenCaptureThrows() {
+            var initialFilter = new FilterInfo() { Name = "L", Position = 1 };
+            filterMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = initialFilter });
+            var seq = new CaptureSequence();
+            var parameter = new CaptureSolverParameter() { FocalLength = 700, Attempts = 1 };
+            imagingMediatorMock
+                .Setup(x => x.CaptureAndPrepareImage(seq, It.IsAny<PrepareImageParameters>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .ThrowsAsync(new InvalidOperationException("capture failed"));
+
+            var sut = new CaptureSolver(plateSolverMock.Object, blindSolverMock.Object, imagingMediatorMock.Object, filterMediatorMock.Object);
+            sut.ImageSolver = imageSolverMock.Object;
+
+            Func<Task> act = () => sut.Solve(seq, parameter, default, default, CancellationToken.None);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            filterMediatorMock.Verify(x => x.ChangeFilter(initialFilter, It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()), Times.Once());
+        }
+
+        [Test]
+        public async Task Solve_RestoresFilterWhenCaptureIsCanceled() {
+            var initialFilter = new FilterInfo() { Name = "L", Position = 1 };
+            filterMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = initialFilter });
+            var seq = new CaptureSequence();
+            var parameter = new CaptureSolverParameter() { FocalLength = 700, Attempts = 1 };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            imagingMediatorMock
+                .Setup(x => x.CaptureAndPrepareImage(seq, It.IsAny<PrepareImageParameters>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+            var sut = new CaptureSolver(plateSolverMock.Object, blindSolverMock.Object, imagingMediatorMock.Object, filterMediatorMock.Object);
+            sut.ImageSolver = imageSolverMock.Object;
+
+            Func<Task> act = () => sut.Solve(seq, parameter, default, default, cts.Token);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            filterMediatorMock.Verify(x => x.ChangeFilter(initialFilter, It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()), Times.Once());
+        }
+
+        [Test]
+        public async Task Solve_WaitsForFilterRestoreWhenImageSolverThrows() {
+            var imageDataMock = new Mock<IImageData>();
+            var renderedImageMock = new Mock<IRenderedImage>();
+            renderedImageMock.SetupGet(x => x.RawImageData).Returns(imageDataMock.Object);
+            var initialFilter = new FilterInfo() { Name = "L", Position = 1 };
+            var restoreStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseRestore = new TaskCompletionSource<FilterInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+            filterMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { SelectedFilter = initialFilter });
+            filterMediatorMock
+                .Setup(x => x.ChangeFilter(initialFilter, It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .Returns(async () => {
+                    restoreStarted.SetResult();
+                    return await releaseRestore.Task;
+                });
+            var seq = new CaptureSequence();
+            var parameter = new CaptureSolverParameter() { FocalLength = 700, Attempts = 1 };
+            imagingMediatorMock
+                .Setup(x => x.CaptureAndPrepareImage(seq, It.IsAny<PrepareImageParameters>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .ReturnsAsync(renderedImageMock.Object);
+            imageSolverMock
+                .Setup(x => x.Solve(imageDataMock.Object, It.IsAny<PlateSolveParameter>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("solve failed"));
+
+            var sut = new CaptureSolver(plateSolverMock.Object, blindSolverMock.Object, imagingMediatorMock.Object, filterMediatorMock.Object);
+            sut.ImageSolver = imageSolverMock.Object;
+
+            Task<PlateSolveResult> solveTask = sut.Solve(seq, parameter, default, default, CancellationToken.None);
+            await restoreStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await Task.Delay(50);
+
+            solveTask.IsCompleted.Should().BeFalse();
+            releaseRestore.SetResult(initialFilter);
+            Func<Task> act = async () => await solveTask;
+            await act.Should().ThrowAsync<InvalidOperationException>();
+        }
     }
 }

--- a/NINA.Test/PlateSolving/CenterSolverTest.cs
+++ b/NINA.Test/PlateSolving/CenterSolverTest.cs
@@ -113,6 +113,44 @@ namespace NINA.Test.PlateSolving {
         }
 
         [Test]
+        public async Task Successful_Centering_AfterEffectiveSync_SlewsToRequestedTargetWithoutMeasuredCorrection_Test() {
+            var seq = new CaptureSequence();
+            var solvedCoordinates = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.J2000);
+            var positionAfterSync = new Coordinates(Angle.ByDegree(4), Angle.ByDegree(3), Epoch.J2000);
+            var targetCoordinates = new Coordinates(Angle.ByDegree(5), Angle.ByDegree(3), Epoch.J2000);
+            var parameter = new CenterSolveParameter() {
+                Coordinates = targetCoordinates.Transform(Epoch.J2000),
+                FocalLength = 700,
+                Threshold = 1
+            };
+
+            captureSolverMock
+                .SetupSequence(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlateSolveResult() { Success = true, Coordinates = solvedCoordinates })
+                .ReturnsAsync(new PlateSolveResult() { Success = true, Coordinates = targetCoordinates });
+            telescopeMediatorMock
+                .SetupSequence(x => x.GetCurrentPosition())
+                .Returns(targetCoordinates)
+                .Returns(positionAfterSync)
+                .Returns(positionAfterSync)
+                .Returns(targetCoordinates);
+            telescopeMediatorMock
+                .SetupSequence(x => x.Sync(It.IsAny<Coordinates>()))
+                .ReturnsAsync(true);
+
+            var sut = new CenteringSolver(plateSolverMock.Object, blindSolverMock.Object, null, telescopeMediatorMock.Object, filterMediatorMock.Object, domeMediatorMock.Object, domeFollowerMock.Object);
+            sut.CaptureSolver = captureSolverMock.Object;
+
+            var result = await sut.Center(seq, parameter, default, default, default);
+
+            result.Success.Should().BeTrue();
+            telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
+            telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
+                It.Is<Coordinates>(c => IsWithinArcSeconds(c, targetCoordinates, 0.01)),
+                It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        [Test]
         public async Task Successful_Centering_AfterTwoCorrections_Test() {
             var seq = new CaptureSequence();
             var coordinates1 = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.JNOW);
@@ -157,7 +195,7 @@ namespace NINA.Test.PlateSolving {
         }
 
         [Test]
-        public async Task Successful_Centering_FailedSyncs_CenteringWithOffset_Test() {
+        public async Task Successful_Centering_FailedSyncs_CenteringWithMeasuredCorrection_Test() {
             var seq = new CaptureSequence();
             var coordinates1 = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.J2000);
             var coordinates2 = new Coordinates(Angle.ByDegree(4), Angle.ByDegree(3), Epoch.J2000);
@@ -191,7 +229,7 @@ namespace NINA.Test.PlateSolving {
             captureSolverMock.Verify(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
 
-            //Verify that the slew coordinates are using the offset
+            // Verify that the slew coordinates are using the measured correction.
             Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
                 It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),
@@ -199,7 +237,7 @@ namespace NINA.Test.PlateSolving {
         }
 
         [Test]
-        public async Task Successful_Centering_SkippedSyncs_CenteringWithOffset_Test() {
+        public async Task Successful_Centering_SkippedSyncs_CenteringWithMeasuredCorrection_Test() {
             var seq = new CaptureSequence();
             var coordinates1 = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.J2000);
             var coordinates2 = new Coordinates(Angle.ByDegree(4), Angle.ByDegree(3), Epoch.J2000);
@@ -233,7 +271,7 @@ namespace NINA.Test.PlateSolving {
             result.Success.Should().BeTrue();
             captureSolverMock.Verify(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(0));
-            //Verify that the slew coordinates are using the offset
+            // Verify that the slew coordinates are using the measured correction.
             Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
                 It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),
@@ -241,7 +279,7 @@ namespace NINA.Test.PlateSolving {
         }
 
         [Test]
-        public async Task Successful_Centering_SilentlyFailedSyncs_CenteringWithOffset_Test() {
+        public async Task Successful_Centering_SilentlyFailedSyncs_CenteringWithMeasuredCorrection_Test() {
             var seq = new CaptureSequence();
             var coordinates1 = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.J2000);
             var coordinates2 = new Coordinates(Angle.ByDegree(4), Angle.ByDegree(3), Epoch.J2000);
@@ -274,7 +312,7 @@ namespace NINA.Test.PlateSolving {
             result.Success.Should().BeTrue();
             captureSolverMock.Verify(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
-            //Verify that the slew coordinates are using the offset
+            // Verify that the slew coordinates are using the measured correction.
             Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
                 It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),

--- a/NINA.Test/PlateSolving/CenterSolverTest.cs
+++ b/NINA.Test/PlateSolving/CenterSolverTest.cs
@@ -21,6 +21,7 @@ using NINA.Equipment.Model;
 using NINA.Core.Model;
 using NINA.PlateSolving.Interfaces;
 using NINA.Equipment.Interfaces;
+using System.Windows;
 
 namespace NINA.Test.PlateSolving {
 
@@ -44,6 +45,7 @@ namespace NINA.Test.PlateSolving {
             domeMediatorMock = new Mock<IDomeMediator>();
             domeMediatorMock.Setup(m => m.GetInfo()).Returns(new NINA.Equipment.Equipment.MyDome.DomeInfo() { Connected = false });
             domeFollowerMock = new Mock<IDomeFollower>();
+            telescopeMediatorMock.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
         }
 
         [Test]
@@ -190,10 +192,9 @@ namespace NINA.Test.PlateSolving {
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
 
             //Verify that the slew coordinates are using the offset
+            Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
-                It.Is<Coordinates>(c => Math.Round(c.RA, 4) == Math.Round((coordinates3.RA + (coordinates3.RA - coordinates1.RA)), 4)
-                                        && Math.Round(c.Dec, 4) == Math.Round((coordinates3.Dec + (coordinates3.Dec - coordinates1.Dec)), 4)
-                                  ),
+                It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),
                 It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
 
@@ -233,10 +234,9 @@ namespace NINA.Test.PlateSolving {
             captureSolverMock.Verify(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(0));
             //Verify that the slew coordinates are using the offset
+            Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
-                It.Is<Coordinates>(c => Math.Round(c.RA, 4) == Math.Round((coordinates3.RA + (coordinates3.RA - coordinates1.RA)), 4)
-                                        && Math.Round(c.Dec, 4) == Math.Round((coordinates3.Dec + (coordinates3.Dec - coordinates1.Dec)), 4)
-                                  ),
+                It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),
                 It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
 
@@ -275,11 +275,19 @@ namespace NINA.Test.PlateSolving {
             captureSolverMock.Verify(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
             //Verify that the slew coordinates are using the offset
+            Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(coordinates3, coordinates3, coordinates1);
             telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
-                It.Is<Coordinates>(c => Math.Round(c.RA, 4) == Math.Round((coordinates3.RA + (coordinates3.RA - coordinates1.RA)), 4)
-                                        && Math.Round(c.Dec, 4) == Math.Round((coordinates3.Dec + (coordinates3.Dec - coordinates1.Dec)), 4)
-                                  ),
+                It.Is<Coordinates>(c => IsWithinArcSeconds(c, expectedSlewCoordinates, 0.01)),
                 It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        private static Coordinates ExpectedCorrectedTarget(Coordinates targetCoordinates, Coordinates reportedCoordinates, Coordinates solvedCoordinates) {
+            Point correction = reportedCoordinates.XYProjection(solvedCoordinates, new Point(0, 0), 1, 1, 0, Coordinates.ProjectionType.Gnomonic);
+            return targetCoordinates.Shift(correction.X, correction.Y, 0, 1, 1, Coordinates.ProjectionType.Gnomonic);
+        }
+
+        private static bool IsWithinArcSeconds(Coordinates actual, Coordinates expected, double arcSeconds) {
+            return Math.Abs((actual - expected).Distance.ArcSeconds) <= arcSeconds;
         }
     }
 }

--- a/NINA.Test/PlateSolving/CenterSolverTest.cs
+++ b/NINA.Test/PlateSolving/CenterSolverTest.cs
@@ -21,7 +21,6 @@ using NINA.Equipment.Model;
 using NINA.Core.Model;
 using NINA.PlateSolving.Interfaces;
 using NINA.Equipment.Interfaces;
-using System.Windows;
 
 namespace NINA.Test.PlateSolving {
 
@@ -195,6 +194,43 @@ namespace NINA.Test.PlateSolving {
         }
 
         [Test]
+        public async Task Successful_Centering_FailedSyncs_InvalidMeasuredCorrectionSlewsToRequestedTarget_Test() {
+            var seq = new CaptureSequence();
+            var solvedCoordinates = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(0), Epoch.J2000);
+            var targetCoordinates = new Coordinates(Angle.ByDegree(5), Angle.ByDegree(0), Epoch.J2000);
+            var invalidReportedCoordinates = new Coordinates(Angle.ByDegree(double.NaN), Angle.ByDegree(0), Epoch.J2000);
+            var parameter = new CenterSolveParameter() {
+                Coordinates = targetCoordinates.Transform(Epoch.J2000),
+                FocalLength = 700,
+                Threshold = 1
+            };
+
+            captureSolverMock
+                .SetupSequence(x => x.Solve(seq, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlateSolveResult() { Success = true, Coordinates = solvedCoordinates })
+                .ReturnsAsync(new PlateSolveResult() { Success = true, Coordinates = targetCoordinates });
+            telescopeMediatorMock
+                .SetupSequence(x => x.GetCurrentPosition())
+                .Returns(targetCoordinates)
+                .Returns(invalidReportedCoordinates)
+                .Returns(targetCoordinates);
+            telescopeMediatorMock
+                .SetupSequence(x => x.Sync(It.IsAny<Coordinates>()))
+                .ReturnsAsync(false);
+
+            var sut = new CenteringSolver(plateSolverMock.Object, blindSolverMock.Object, null, telescopeMediatorMock.Object, filterMediatorMock.Object, domeMediatorMock.Object, domeFollowerMock.Object);
+            sut.CaptureSolver = captureSolverMock.Object;
+
+            var result = await sut.Center(seq, parameter, default, default, default);
+
+            result.Success.Should().BeTrue();
+            telescopeMediatorMock.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Exactly(1));
+            telescopeMediatorMock.Verify(x => x.SlewToCoordinatesAsync(
+                It.Is<Coordinates>(c => IsWithinArcSeconds(c, targetCoordinates, 0.01)),
+                It.IsAny<CancellationToken>()), Times.Exactly(1));
+        }
+
+        [Test]
         public async Task Successful_Centering_FailedSyncs_CenteringWithMeasuredCorrection_Test() {
             var seq = new CaptureSequence();
             var coordinates1 = new Coordinates(Angle.ByDegree(3), Angle.ByDegree(3), Epoch.J2000);
@@ -320,8 +356,17 @@ namespace NINA.Test.PlateSolving {
         }
 
         private static Coordinates ExpectedCorrectedTarget(Coordinates targetCoordinates, Coordinates reportedCoordinates, Coordinates solvedCoordinates) {
-            Point correction = reportedCoordinates.XYProjection(solvedCoordinates, new Point(0, 0), 1, 1, 0, Coordinates.ProjectionType.Gnomonic);
-            return targetCoordinates.Shift(correction.X, correction.Y, 0, 1, 1, Coordinates.ProjectionType.Gnomonic);
+            RectangularCoordinates solved = RectangularCoordinates.FromPolar(solvedCoordinates);
+            RectangularCoordinates reported = RectangularCoordinates.FromPolar(reportedCoordinates);
+            RectangularCoordinates target = RectangularCoordinates.FromPolar(targetCoordinates);
+            RectangularCoordinates axis = solved.Cross(reported);
+            double sinAngle = axis.Distance;
+            if (sinAngle < 1e-12) {
+                return targetCoordinates;
+            }
+
+            double cosAngle = solved.Dot(reported);
+            return target.RotateAroundAxis(axis / sinAngle, Angle.ByRadians(Math.Atan2(sinAngle, cosAngle))).ToPolar(targetCoordinates.Epoch);
         }
 
         private static bool IsWithinArcSeconds(Coordinates actual, Coordinates expected, double arcSeconds) {

--- a/NINA.Test/PlateSolving/CenteringSolverBehaviorTest.cs
+++ b/NINA.Test/PlateSolving/CenteringSolverBehaviorTest.cs
@@ -147,10 +147,10 @@ namespace NINA.Test.PlateSolving {
         }
 
         /// <summary>
-        /// Verifies fallback correction slews use the tangent-plane correction instead of raw RA/Dec addition.
+        /// Verifies fallback correction slews use a spherical correction instead of raw RA/Dec addition.
         /// </summary>
         [Test]
-        public async Task Center_CorrectionSlewUsesTangentPlaneForHighDeclinationFallback() {
+        public async Task Center_CorrectionSlewUsesSphericalRotationForHighDeclinationFallback() {
             var harness = new CenteringHarness();
             var target = CreateCoordinates(25, 80);
             var offTarget = CreateCoordinates(20, 79.25);
@@ -183,60 +183,18 @@ namespace NINA.Test.PlateSolving {
         }
 
         private static Coordinates ExpectedCorrectedTarget(Coordinates targetCoordinates, Coordinates reportedCoordinates, Coordinates solvedCoordinates) {
-            TangentFrame solvedFrame = CreateTangentFrame(solvedCoordinates);
-            Vector3 reported = ToUnitVector(reportedCoordinates);
-            double denominator = Dot(reported, solvedFrame.Center);
-            double eastOffset = Dot(reported, solvedFrame.East) / denominator;
-            double northOffset = Dot(reported, solvedFrame.North) / denominator;
-
-            TangentFrame targetFrame = CreateTangentFrame(targetCoordinates);
-            Vector3 corrected = Normalize(new Vector3(
-                targetFrame.Center.X + eastOffset * targetFrame.East.X + northOffset * targetFrame.North.X,
-                targetFrame.Center.Y + eastOffset * targetFrame.East.Y + northOffset * targetFrame.North.Y,
-                targetFrame.Center.Z + eastOffset * targetFrame.East.Z + northOffset * targetFrame.North.Z));
-            return ToCoordinates(corrected, targetCoordinates.Epoch);
-        }
-
-        private static TangentFrame CreateTangentFrame(Coordinates coordinates) {
-            double ra = AstroUtil.ToRadians(coordinates.RADegrees);
-            double dec = AstroUtil.ToRadians(coordinates.Dec);
-            double cosRa = Math.Cos(ra);
-            double sinRa = Math.Sin(ra);
-            double cosDec = Math.Cos(dec);
-            double sinDec = Math.Sin(dec);
-
-            return new TangentFrame(
-                Center: new Vector3(cosDec * cosRa, cosDec * sinRa, sinDec),
-                East: new Vector3(-sinRa, cosRa, 0),
-                North: new Vector3(-sinDec * cosRa, -sinDec * sinRa, cosDec));
-        }
-
-        private static Vector3 ToUnitVector(Coordinates coordinates) {
-            return CreateTangentFrame(coordinates).Center;
-        }
-
-        private static Coordinates ToCoordinates(Vector3 vector, Epoch epoch) {
-            double ra = Math.Atan2(vector.Y, vector.X);
-            if (ra < 0) {
-                ra += 2 * Math.PI;
+            RectangularCoordinates solved = RectangularCoordinates.FromPolar(solvedCoordinates);
+            RectangularCoordinates reported = RectangularCoordinates.FromPolar(reportedCoordinates);
+            RectangularCoordinates target = RectangularCoordinates.FromPolar(targetCoordinates);
+            RectangularCoordinates axis = solved.Cross(reported);
+            double sinAngle = axis.Distance;
+            if (sinAngle < 1e-12) {
+                return targetCoordinates;
             }
 
-            double dec = Math.Asin(vector.Z);
-            return new Coordinates(Angle.ByRadians(ra), Angle.ByRadians(dec), epoch);
+            double cosAngle = solved.Dot(reported);
+            return target.RotateAroundAxis(axis / sinAngle, Angle.ByRadians(Math.Atan2(sinAngle, cosAngle))).ToPolar(targetCoordinates.Epoch);
         }
-
-        private static Vector3 Normalize(Vector3 vector) {
-            double length = Math.Sqrt(Dot(vector, vector));
-            return new Vector3(vector.X / length, vector.Y / length, vector.Z / length);
-        }
-
-        private static double Dot(Vector3 a, Vector3 b) {
-            return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
-        }
-
-        private readonly record struct TangentFrame(Vector3 Center, Vector3 East, Vector3 North);
-
-        private readonly record struct Vector3(double X, double Y, double Z);
 
         private sealed class CenteringHarness {
             public Mock<IPlateSolver> PlateSolver { get; } = new();

--- a/NINA.Test/PlateSolving/CenteringSolverBehaviorTest.cs
+++ b/NINA.Test/PlateSolving/CenteringSolverBehaviorTest.cs
@@ -22,6 +22,7 @@ using NINA.Equipment.Interfaces.Mediator;
 using NINA.Equipment.Model;
 using NINA.PlateSolving;
 using NINA.PlateSolving.Interfaces;
+using NINA.Core.Locale;
 
 namespace NINA.Test.PlateSolving {
 
@@ -115,9 +116,127 @@ namespace NINA.Test.PlateSolving {
             harness.TelescopeMediator.Verify(x => x.Sync(It.IsAny<Coordinates>()), Times.Never());
         }
 
+        /// <summary>
+        /// Verifies centering stops immediately when a correction slew is rejected by the mount.
+        /// </summary>
+        [Test]
+        public async Task Center_CorrectionSlewFailureStopsCenteringWithFailureReason() {
+            var harness = new CenteringHarness();
+            var target = CreateCoordinates(5, 3);
+            var offTarget = CreateCoordinates(3, 3);
+            var sequence = new CaptureSequence();
+            var parameter = new CenterSolveParameter {
+                Coordinates = target,
+                FocalLength = 700,
+                Threshold = 0.1,
+                NoSync = true
+            };
+            harness.CaptureSolver
+                .Setup(x => x.Solve(sequence, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = offTarget });
+            harness.TelescopeMediator.Setup(x => x.GetCurrentPosition()).Returns(target);
+            harness.TelescopeMediator.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            var sut = harness.CreateSolver();
+
+            CenteringSolveResult result = await sut.CenterWithMeasurements(sequence, parameter, default, default, CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            result.Attempts.Should().HaveCount(1);
+            harness.CaptureSolver.Verify(x => x.Solve(sequence, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once());
+            harness.TelescopeMediator.Verify(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        /// <summary>
+        /// Verifies fallback correction slews use the tangent-plane correction instead of raw RA/Dec addition.
+        /// </summary>
+        [Test]
+        public async Task Center_CorrectionSlewUsesTangentPlaneForHighDeclinationFallback() {
+            var harness = new CenteringHarness();
+            var target = CreateCoordinates(25, 80);
+            var offTarget = CreateCoordinates(20, 79.25);
+            var sequence = new CaptureSequence();
+            var parameter = new CenterSolveParameter {
+                Coordinates = target,
+                FocalLength = 700,
+                Threshold = 0.1,
+                NoSync = true
+            };
+            harness.CaptureSolver
+                .SetupSequence(x => x.Solve(sequence, It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = offTarget })
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = target });
+            harness.TelescopeMediator.Setup(x => x.GetCurrentPosition()).Returns(target);
+            harness.TelescopeMediator.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            var sut = harness.CreateSolver();
+
+            CenteringSolveResult result = await sut.CenterWithMeasurements(sequence, parameter, default, default, CancellationToken.None);
+
+            Coordinates expectedSlewCoordinates = ExpectedCorrectedTarget(target, target, offTarget);
+            result.Success.Should().BeTrue();
+            harness.TelescopeMediator.Verify(x => x.SlewToCoordinatesAsync(
+                It.Is<Coordinates>(c => Math.Abs((c - expectedSlewCoordinates).Distance.ArcSeconds) <= 0.01),
+                It.IsAny<CancellationToken>()), Times.Once());
+        }
+
         private static Coordinates CreateCoordinates(double raDegrees, double decDegrees) {
             return new Coordinates(Angle.ByDegree(raDegrees), Angle.ByDegree(decDegrees), Epoch.J2000);
         }
+
+        private static Coordinates ExpectedCorrectedTarget(Coordinates targetCoordinates, Coordinates reportedCoordinates, Coordinates solvedCoordinates) {
+            TangentFrame solvedFrame = CreateTangentFrame(solvedCoordinates);
+            Vector3 reported = ToUnitVector(reportedCoordinates);
+            double denominator = Dot(reported, solvedFrame.Center);
+            double eastOffset = Dot(reported, solvedFrame.East) / denominator;
+            double northOffset = Dot(reported, solvedFrame.North) / denominator;
+
+            TangentFrame targetFrame = CreateTangentFrame(targetCoordinates);
+            Vector3 corrected = Normalize(new Vector3(
+                targetFrame.Center.X + eastOffset * targetFrame.East.X + northOffset * targetFrame.North.X,
+                targetFrame.Center.Y + eastOffset * targetFrame.East.Y + northOffset * targetFrame.North.Y,
+                targetFrame.Center.Z + eastOffset * targetFrame.East.Z + northOffset * targetFrame.North.Z));
+            return ToCoordinates(corrected, targetCoordinates.Epoch);
+        }
+
+        private static TangentFrame CreateTangentFrame(Coordinates coordinates) {
+            double ra = AstroUtil.ToRadians(coordinates.RADegrees);
+            double dec = AstroUtil.ToRadians(coordinates.Dec);
+            double cosRa = Math.Cos(ra);
+            double sinRa = Math.Sin(ra);
+            double cosDec = Math.Cos(dec);
+            double sinDec = Math.Sin(dec);
+
+            return new TangentFrame(
+                Center: new Vector3(cosDec * cosRa, cosDec * sinRa, sinDec),
+                East: new Vector3(-sinRa, cosRa, 0),
+                North: new Vector3(-sinDec * cosRa, -sinDec * sinRa, cosDec));
+        }
+
+        private static Vector3 ToUnitVector(Coordinates coordinates) {
+            return CreateTangentFrame(coordinates).Center;
+        }
+
+        private static Coordinates ToCoordinates(Vector3 vector, Epoch epoch) {
+            double ra = Math.Atan2(vector.Y, vector.X);
+            if (ra < 0) {
+                ra += 2 * Math.PI;
+            }
+
+            double dec = Math.Asin(vector.Z);
+            return new Coordinates(Angle.ByRadians(ra), Angle.ByRadians(dec), epoch);
+        }
+
+        private static Vector3 Normalize(Vector3 vector) {
+            double length = Math.Sqrt(Dot(vector, vector));
+            return new Vector3(vector.X / length, vector.Y / length, vector.Z / length);
+        }
+
+        private static double Dot(Vector3 a, Vector3 b) {
+            return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+        }
+
+        private readonly record struct TangentFrame(Vector3 Center, Vector3 East, Vector3 North);
+
+        private readonly record struct Vector3(double X, double Y, double Z);
 
         private sealed class CenteringHarness {
             public Mock<IPlateSolver> PlateSolver { get; } = new();
@@ -131,6 +250,7 @@ namespace NINA.Test.PlateSolving {
 
             public CenteringHarness() {
                 DomeMediator.Setup(x => x.GetInfo()).Returns(new DomeInfo { Connected = false });
+                TelescopeMediator.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
             }
 
             public CenteringSolver CreateSolver() {

--- a/NINA.Test/PlateSolving/CliSolverBehaviorTest.cs
+++ b/NINA.Test/PlateSolving/CliSolverBehaviorTest.cs
@@ -83,6 +83,32 @@ namespace NINA.Test.PlateSolving {
             }
         }
 
+        /// <summary>
+        /// Verifies the solver-owned timeout token, not just the caller token, cancels a hung CLI process.
+        /// </summary>
+        [Test]
+        public async Task SolveAsync_TimeoutUsesLinkedSolverTimeoutToken() {
+            var solver = new TestableCliSolver {
+                ShouldSucceed = true,
+                Timeout = TimeSpan.FromMilliseconds(100),
+                ArgumentsToReturn = "/C ping 127.0.0.1 -n 6 > nul"
+            };
+            IImageData imageData = CreateImageData("CliTimeout", out _);
+            var parameter = new PlateSolveParameter {
+                FocalLength = 600,
+                PixelSize = 3.76,
+                Coordinates = null
+            };
+
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            PlateSolveResult result = await solver.SolveAsync(imageData, parameter, default, CancellationToken.None);
+            stopwatch.Stop();
+
+            result.Success.Should().BeFalse();
+            solver.ReadResultCalled.Should().BeFalse();
+            stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+        }
+
         private static IImageData CreateImageData(string targetName, out ImageMetaData metadata) {
             metadata = new ImageMetaData();
             metadata.Target.Name = targetName;
@@ -113,8 +139,11 @@ namespace NINA.Test.PlateSolving {
             }
 
             public bool ShouldSucceed { get; set; }
+            public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(10);
+            public string ArgumentsToReturn { get; set; } = "/C exit 0";
             public bool ArgumentsSeen { get; private set; }
             public bool OutputExistsDuringRead { get; private set; }
+            public bool ReadResultCalled { get; private set; }
             public string ImagePathSeen { get; private set; }
             public string OutputPathSeen { get; private set; }
             public string SidecarPathSeen { get; private set; }
@@ -125,15 +154,18 @@ namespace NINA.Test.PlateSolving {
                 return "test solver";
             }
 
+            protected override TimeSpan SolverTimeout => Timeout;
+
             protected override string GetArguments(string imageFilePath, string outputFilePath, PlateSolveParameter parameter, PlateSolveImageProperties imageProperties) {
                 ArgumentsSeen = true;
                 ImagePathSeen = imageFilePath;
                 OutputPathSeen = outputFilePath;
                 SidecarPathSeen = GetSideCarFilePaths(imageFilePath).Single();
-                return "/C exit 0";
+                return ArgumentsToReturn;
             }
 
             protected override PlateSolveResult ReadResult(string outputFilePath, PlateSolveParameter parameter, PlateSolveImageProperties imageProperties) {
+                ReadResultCalled = true;
                 File.WriteAllText(outputFilePath, "solver output");
                 File.WriteAllText(SidecarPathSeen, "sidecar output");
                 OutputExistsDuringRead = File.Exists(outputFilePath);

--- a/NINA.Test/Sequencer/SequenceItem/Platesolving/CenterAndRotateTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Platesolving/CenterAndRotateTest.cs
@@ -84,6 +84,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
             windowServiceFactoryMock.Reset();
 
             profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(new Mock<IPlateSolveSettings>().Object);
+            telescopeMediatorMock.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             sut = new CenterAndRotate(profileServiceMock.Object, telescopeMediatorMock.Object, imagingMediatorMock.Object, rotatorMediatorMock.Object, filterWheelMediatorMock.Object, guiderMediatorMock.Object, domeMediatorMock.Object, domeFollowerMock.Object, plateSolverFactoryMock.Object, windowServiceFactoryMock.Object);
         }
@@ -305,6 +306,76 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
 
             captureSolver.Verify(x => x.Solve(It.IsAny<CaptureSequence>(), It.IsAny<CaptureSolverParameter>(), It.Is<IProgress<PlateSolveProgress>>(p => p == sut.PlateSolveStatusVM.Progress), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
             centeringSolver.Verify(x => x.Center(It.IsAny<CaptureSequence>(), It.IsAny<CenterSolveParameter>(), It.Is<IProgress<PlateSolveProgress>>(p => p == sut.PlateSolveStatusVM.Progress), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Execute_InitialSlewFails_ThrowsFailedExceptionWithoutSolving() {
+            var service = new Mock<IWindowService>();
+            var captureSolver = new Mock<ICaptureSolver>();
+            var centeringSolver = new Mock<ICenteringSolver>();
+
+            windowServiceFactoryMock.Setup(x => x.Create()).Returns(service.Object);
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo { Connected = true, AtPark = false });
+            telescopeMediatorMock.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(new Mock<IPlateSolveSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.TelescopeSettings).Returns(new Mock<ITelescopeSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.CameraSettings).Returns(new Mock<ICameraSettings>().Object);
+
+            plateSolverFactoryMock.Setup(x => x.GetPlateSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetBlindSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetCaptureSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<IFilterWheelMediator>())).Returns(captureSolver.Object);
+            plateSolverFactoryMock.Setup(x => x.GetCenteringSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<ITelescopeMediator>(), It.IsAny<IFilterWheelMediator>(), It.IsAny<IDomeMediator>(), It.IsAny<IDomeFollower>())).Returns(centeringSolver.Object);
+
+            Func<Task> act = () => sut.Execute(default, default);
+
+            await act.Should().ThrowAsync<SequenceEntityFailedException>().WithMessage(Loc.Instance["LblSlewFailed"]);
+            captureSolver.Verify(x => x.Solve(It.IsAny<CaptureSequence>(), It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Never);
+            centeringSolver.Verify(x => x.Center(It.IsAny<CaptureSequence>(), It.IsAny<CenterSolveParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task Execute_PassesPlateSolveGainToRotationAndCenteringCaptures() {
+            var service = new Mock<IWindowService>();
+            var coordinates = new Coordinates(Angle.ByDegree(10), Angle.ByDegree(20), Epoch.J2000);
+            CaptureSequence rotationSequence = null;
+            CaptureSequence centeringSequence = null;
+
+            var captureSolver = new Mock<ICaptureSolver>();
+            captureSolver
+                .Setup(x => x.Solve(It.IsAny<CaptureSequence>(), It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .Callback<CaptureSequence, CaptureSolverParameter, IProgress<PlateSolveProgress>, IProgress<ApplicationStatus>, CancellationToken>((seq, _, _, _, _) => rotationSequence = seq)
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = coordinates, PositionAngle = 260 });
+
+            var centeringSolver = new Mock<ICenteringSolver>();
+            centeringSolver
+                .Setup(x => x.Center(It.IsAny<CaptureSequence>(), It.IsAny<CenterSolveParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .Callback<CaptureSequence, CenterSolveParameter, IProgress<PlateSolveProgress>, IProgress<ApplicationStatus>, CancellationToken>((seq, _, _, _, _) => centeringSequence = seq)
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = coordinates });
+
+            windowServiceFactoryMock.Setup(x => x.Create()).Returns(service.Object);
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo { Connected = true, AtPark = false });
+            rotatorMediatorMock.Setup(x => x.GetTargetPosition(It.IsAny<float>())).Returns(260);
+            guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.RotatorSettings.RangeType).Returns(RotatorRangeTypeEnum.FULL);
+            var plateSolveSettings = new Mock<IPlateSolveSettings>();
+            plateSolveSettings.SetupGet(x => x.Gain).Returns(321);
+            plateSolveSettings.SetupGet(x => x.RotationTolerance).Returns(1);
+            plateSolveSettings.SetupGet(x => x.NumberOfAttempts).Returns(1);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(plateSolveSettings.Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.TelescopeSettings).Returns(new Mock<ITelescopeSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.CameraSettings).Returns(new Mock<ICameraSettings>().Object);
+
+            plateSolverFactoryMock.Setup(x => x.GetPlateSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetBlindSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetCaptureSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<IFilterWheelMediator>())).Returns(captureSolver.Object);
+            plateSolverFactoryMock.Setup(x => x.GetCenteringSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<ITelescopeMediator>(), It.IsAny<IFilterWheelMediator>(), It.IsAny<IDomeMediator>(), It.IsAny<IDomeFollower>())).Returns(centeringSolver.Object);
+
+            sut.PositionAngle = 260;
+            await sut.Execute(default, CancellationToken.None);
+
+            rotationSequence.Gain.Should().Be(321);
+            centeringSequence.Gain.Should().Be(321);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/SequenceItem/Platesolving/CenterTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Platesolving/CenterTest.cs
@@ -80,6 +80,7 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
             windowServiceFactoryMock.Reset();
 
             profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(new Mock<IPlateSolveSettings>().Object);
+            telescopeMediatorMock.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             sut = new Center(profileServiceMock.Object, telescopeMediatorMock.Object, imagingMediatorMock.Object, filterWheelMediatorMock.Object, guiderMediatorMock.Object, domeMediatorMock.Object, domeFollowerMock.Object, plateSolverFactoryMock.Object, windowServiceFactoryMock.Object);
         }
@@ -174,6 +175,30 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
 
             guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Once);
             guiderMediatorMock.Verify(x => x.StartGuiding(It.IsAny<bool>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task Execute_InitialSlewFails_ThrowsFailedExceptionWithoutCentering() {
+            var service = new Mock<IWindowService>();
+            var centeringSolver = new Mock<ICenteringSolver>();
+
+            windowServiceFactoryMock.Setup(x => x.Create()).Returns(service.Object);
+
+            profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(new Mock<IPlateSolveSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.TelescopeSettings).Returns(new Mock<ITelescopeSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.CameraSettings).Returns(new Mock<ICameraSettings>().Object);
+
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo { Connected = true, AtPark = false });
+            telescopeMediatorMock.Setup(x => x.SlewToCoordinatesAsync(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+            plateSolverFactoryMock.Setup(x => x.GetPlateSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetBlindSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetCenteringSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<ITelescopeMediator>(), It.IsAny<IFilterWheelMediator>(), It.IsAny<IDomeMediator>(), It.IsAny<IDomeFollower>())).Returns(centeringSolver.Object);
+
+            Func<Task> act = () => sut.Execute(default, default);
+
+            await act.Should().ThrowAsync<SequenceEntityFailedException>().WithMessage(Loc.Instance["LblSlewFailed"]);
+            centeringSolver.Verify(x => x.Center(It.IsAny<CaptureSequence>(), It.IsAny<CenterSolveParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/SequenceItem/Platesolving/SolveAndRotateTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Platesolving/SolveAndRotateTest.cs
@@ -273,6 +273,42 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
         }
 
         [Test]
+        public async Task Execute_PassesPlateSolveGainToRotationCapture() {
+            var service = new Mock<IWindowService>();
+            var coordinates = new Coordinates(Angle.ByDegree(10), Angle.ByDegree(20), Epoch.J2000);
+            CaptureSequence rotationSequence = null;
+
+            var captureSolver = new Mock<ICaptureSolver>();
+            captureSolver
+                .Setup(x => x.Solve(It.IsAny<CaptureSequence>(), It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .Callback<CaptureSequence, CaptureSolverParameter, IProgress<PlateSolveProgress>, IProgress<ApplicationStatus>, CancellationToken>((seq, _, _, _, _) => rotationSequence = seq)
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = coordinates, PositionAngle = 260 });
+
+            windowServiceFactoryMock.Setup(x => x.Create()).Returns(service.Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.RotatorSettings.RangeType).Returns(RotatorRangeTypeEnum.FULL);
+            rotatorMediatorMock.Setup(x => x.GetTargetPosition(It.IsAny<float>())).Returns(260);
+            guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            telescopeMediatorMock.Setup(x => x.GetCurrentPosition()).Returns(coordinates);
+
+            var plateSolveSettings = new Mock<IPlateSolveSettings>();
+            plateSolveSettings.SetupGet(x => x.Gain).Returns(123);
+            plateSolveSettings.SetupGet(x => x.RotationTolerance).Returns(1);
+            plateSolveSettings.SetupGet(x => x.NumberOfAttempts).Returns(1);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(plateSolveSettings.Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.TelescopeSettings).Returns(new Mock<ITelescopeSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.CameraSettings).Returns(new Mock<ICameraSettings>().Object);
+
+            plateSolverFactoryMock.Setup(x => x.GetPlateSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetBlindSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetCaptureSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<IFilterWheelMediator>())).Returns(captureSolver.Object);
+
+            sut.PositionAngle = 260;
+            await sut.Execute(default, CancellationToken.None);
+
+            rotationSequence.Gain.Should().Be(123);
+        }
+
+        [Test]
         [TestCase(160, 260, -80)]
         [TestCase(160, 170, 10)]
         public async Task Execute_FullRotatorRange_PlateSolveSuccess_RotationOffOneTime_NoException(double first, double second, double movement) {

--- a/NINA.Test/Sequencer/SequenceItem/Platesolving/SolveAndSyncTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Platesolving/SolveAndSyncTest.cs
@@ -190,6 +190,37 @@ namespace NINA.Test.Sequencer.SequenceItem.Platesolving {
         }
 
         [Test]
+        public async Task Execute_PassesPlateSolveGainToSyncCapture() {
+            var service = new Mock<IWindowService>();
+            var captureSolver = new Mock<ICaptureSolver>();
+            var coordinates = new Coordinates(Angle.ByDegree(10), Angle.ByDegree(20), Epoch.J2000);
+            CaptureSequence captureSequence = null;
+            captureSolver
+                .Setup(x => x.Solve(It.IsAny<CaptureSequence>(), It.IsAny<CaptureSolverParameter>(), It.IsAny<IProgress<PlateSolveProgress>>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()))
+                .Callback<CaptureSequence, CaptureSolverParameter, IProgress<PlateSolveProgress>, IProgress<ApplicationStatus>, CancellationToken>((seq, _, _, _, _) => captureSequence = seq)
+                .ReturnsAsync(new PlateSolveResult { Success = true, Coordinates = coordinates });
+
+            windowServiceFactoryMock.Setup(x => x.Create()).Returns(service.Object);
+            var plateSolveSettings = new Mock<IPlateSolveSettings>();
+            plateSolveSettings.SetupGet(x => x.Gain).Returns(456);
+            plateSolveSettings.SetupGet(x => x.NumberOfAttempts).Returns(1);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.PlateSolveSettings).Returns(plateSolveSettings.Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.TelescopeSettings).Returns(new Mock<ITelescopeSettings>().Object);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.CameraSettings).Returns(new Mock<ICameraSettings>().Object);
+
+            plateSolverFactoryMock.Setup(x => x.GetPlateSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetBlindSolver(It.IsAny<IPlateSolveSettings>())).Returns(new Mock<IPlateSolver>().Object);
+            plateSolverFactoryMock.Setup(x => x.GetCaptureSolver(It.IsAny<IPlateSolver>(), It.IsAny<IPlateSolver>(), It.IsAny<IImagingMediator>(), It.IsAny<IFilterWheelMediator>())).Returns(captureSolver.Object);
+
+            telescopeMediatorMock.Setup(x => x.GetCurrentPosition()).Returns(coordinates);
+            telescopeMediatorMock.Setup(x => x.Sync(It.IsAny<Coordinates>())).ReturnsAsync(true);
+
+            await sut.Execute(default, CancellationToken.None);
+
+            captureSequence.Gain.Should().Be(456);
+        }
+
+        [Test]
         public void ToString_Test() {
             sut.Category = "TestCategory";
             sut.ToString().Should().Be("Category: TestCategory, Item: SolveAndSync");


### PR DESCRIPTION
## Purpose
- Use spherical coordinate correction for no-sync / failed-sync / silent-sync fallback slews instead of raw RA/Dec offsets.
- Keep successful sync behavior slewing directly to the requested target.
- Fix CLI solver timeout cancellation/cleanup.
- Propagate plate-solve gain in sequencer solve/rotate/sync paths.
- Fix Coordinates.XYProjection(ViewportFoV, ProjectionType) forwarding.

## How Was It Tested?
- Tested with simulators.

## AI / Tooling Disclosure
OpenAI Codex / GPT-5 assisted with implementation, tests, analysis.

## ✅ PR Checklist

- [ ] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (not applicable; no UI changes)
- [x] Plugin API compatibility reviewed
    - [x] No breaking changes to interfaces
    - [x] No changes to existing method/class signatures
- [ ] RELEASE_NOTES.md updated (if applicable)
- [x] Documentation (https://github.com/isbeorn/nina.docs) updated (not applicable)

## Related Issues

None.

## Screenshots

Not applicable.

## Additional Notes
