### PR TITLE
Fix sequencer expression migration for old sequences

### DIFF
--- a/NINA.Sequencer/Conditions/AboveHorizonCondition.cs
+++ b/NINA.Sequencer/Conditions/AboveHorizonCondition.cs
@@ -24,6 +24,7 @@ using NINA.Sequencer.SequenceItem.Utility;
 using NINA.Sequencer.Utility;
 using System;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Runtime.Serialization;
 using static NINA.Sequencer.Utility.ItemUtility;
 
@@ -67,13 +68,13 @@ namespace NINA.Sequencer.Conditions {
                 Coordinates c = Data.Coordinates.Coordinates;
                 if (c.RA != 0 || c.Dec != 0) {
                     // Fix up decimals
-                    RaExpression.Definition = Math.Round(c.RA, 7).ToString();
-                    DecExpression.Definition = Math.Round(c.Dec, 7).ToString();
-                    OffsetExpression.Definition = Data.Offset.ToString();
+                    RaExpression.Definition = Math.Round(c.RA, 7).ToString(CultureInfo.InvariantCulture);
+                    DecExpression.Definition = Math.Round(c.Dec, 7).ToString(CultureInfo.InvariantCulture);
+                    OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
                 }
             }
             if (OffsetExpression.Definition.Length == 0 && Data.Offset != OffsetExpression.Default) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -96,9 +97,9 @@ namespace NINA.Sequencer.Conditions {
             if (Protect) return;
 
             if (c.RA != lastRA) {
-                RaExpression.Definition = Math.Round(c.RA, 7).ToString();
+                RaExpression.Definition = Math.Round(c.RA, 7).ToString(CultureInfo.InvariantCulture);
             } else if (c.Dec != lastDec) {
-                DecExpression.Definition = Math.Round(c.Dec, 7).ToString();
+                DecExpression.Definition = Math.Round(c.Dec, 7).ToString(CultureInfo.InvariantCulture);
             }
 
             lastRA = c.RA;

--- a/NINA.Sequencer/Conditions/AltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/AltitudeCondition.cs
@@ -24,6 +24,7 @@ using NINA.Sequencer.Utility;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Runtime.Serialization;
 using static NINA.Sequencer.Utility.ItemUtility;
 
@@ -63,13 +64,13 @@ namespace NINA.Sequencer.Conditions {
                 Coordinates c = Data.Coordinates.Coordinates;
                 if (c.RA != 0 || c.Dec != 0) {
                     // Fix up decimals
-                    RaExpression.Definition = Math.Round(c.RA, 7).ToString();
-                    DecExpression.Definition = Math.Round(c.Dec, 7).ToString();
-                    OffsetExpression.Definition = Data.Offset.ToString();
+                    RaExpression.Definition = Math.Round(c.RA, 7).ToString(CultureInfo.InvariantCulture);
+                    DecExpression.Definition = Math.Round(c.Dec, 7).ToString(CultureInfo.InvariantCulture);
+                    OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
                 }
             }
             if (OffsetExpression.Definition.Length == 0 && Data.Offset != OffsetExpression.Default) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -91,9 +92,9 @@ namespace NINA.Sequencer.Conditions {
             if (Protect) return;
 
             if (c.RA != lastRA) {
-                RaExpression.Definition = Math.Round(c.RA, 7).ToString();
+                RaExpression.Definition = Math.Round(c.RA, 7).ToString(CultureInfo.InvariantCulture);
             } else if (c.Dec != lastDec) {
-                DecExpression.Definition = Math.Round(c.Dec, 7).ToString();
+                DecExpression.Definition = Math.Round(c.Dec, 7).ToString(CultureInfo.InvariantCulture);
             }
 
             lastRA = c.RA;

--- a/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/MoonAltitudeCondition.cs
@@ -26,6 +26,7 @@ using NINA.Sequencer.Generators;
 using System.Runtime.Serialization;
 using NINA.Sequencer.Logic;
 using System.Drawing;
+using System.Globalization;
 
 namespace NINA.Sequencer.Conditions {
 
@@ -56,7 +57,7 @@ namespace NINA.Sequencer.Conditions {
         public new void OnDeserialized(StreamingContext context) {
             base.OnDeserialized(context);
             if (OffsetExpression.Definition.Length == 0 && Data.Offset != OffsetExpression.Default) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
+++ b/NINA.Sequencer/Conditions/SunAltitudeCondition.cs
@@ -25,6 +25,7 @@ using NINA.Core.Locale;
 using NINA.Sequencer.Generators;
 using System.Runtime.Serialization;
 using NINA.Sequencer.Logic;
+using System.Globalization;
 
 namespace NINA.Sequencer.Conditions {
 
@@ -54,7 +55,7 @@ namespace NINA.Sequencer.Conditions {
         public new void OnDeserialized(StreamingContext context) {
             base.OnDeserialized(context);
             if (OffsetExpression.Definition.Length == 0 && Data.Offset != OffsetExpression.Default) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NINA.Sequencer/SequenceItem/Expressions/ResetVariable.cs
+++ b/NINA.Sequencer/SequenceItem/Expressions/ResetVariable.cs
@@ -4,6 +4,7 @@ using NINA.Sequencer.Validations;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Sequencer.Container;
@@ -99,7 +100,7 @@ namespace NINA.Sequencer.SequenceItem.Expressions {
                 sym.Expr.Error = null;
                 sym.Expr.Definition = "'" + Expr.StringValue + "'";
             } else {
-                sym.Expr.Definition = Expr.Value.ToString();
+                sym.Expr.Definition = Expr.Value.ToString(CultureInfo.InvariantCulture);
             }
 
             Logger.Info("SetVariable: " + Variable + " from " + oldDefinition + " to " + sym.Expr.Definition);

--- a/NINA.Sequencer/SequenceItem/Expressions/ResetVariableToDate.cs
+++ b/NINA.Sequencer/SequenceItem/Expressions/ResetVariableToDate.cs
@@ -4,6 +4,7 @@ using NINA.Sequencer.Validations;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Sequencer.Container;
@@ -123,7 +124,7 @@ namespace NINA.Sequencer.SequenceItem.Expressions {
                 sym.Expr.Error = null;
                 sym.Expr.Definition = "'" + Expr.StringValue + "'";
             } else {
-                sym.Expr.Definition = Expr.Value.ToString();
+                sym.Expr.Definition = Expr.Value.ToString(CultureInfo.InvariantCulture);
             }
 
             Logger.Info("SetVariableToDate: " + Variable + " from " + oldDefinition + " to " + sym.Expr.Definition);

--- a/NINA.Sequencer/SequenceItem/FilterWheel/SwitchFilter.cs
+++ b/NINA.Sequencer/SequenceItem/FilterWheel/SwitchFilter.cs
@@ -63,13 +63,6 @@ namespace NINA.Sequencer.SequenceItem.FilterWheel {
             }
         }
 
-        [OnSerializing]
-        public void Serializing(StreamingContext context) {
-            // We only save this in 3.2
-            filter = null;
-        }
-
-
         [ImportingConstructor]
         public SwitchFilter(IProfileService profileservice, IFilterWheelMediator filterWheelMediator) {
             this.profileService = profileservice;
@@ -136,7 +129,7 @@ namespace NINA.Sequencer.SequenceItem.FilterWheel {
 
         partial void AfterClone(SwitchFilter clone) {
             clone.comboBoxText = comboBoxText;
-            SetupFilter(comboBoxText);
+            clone.SetupFilter(comboBoxText);
         }
 
         [IsExpression]
@@ -270,7 +263,10 @@ namespace NINA.Sequencer.SequenceItem.FilterWheel {
             return $"Category: {Category}, Item: {nameof(SwitchFilter)}, Filter: {Filter?.Name}";
         }
 
-        // We don't want any of these serialized; only ComboBoxTest
+        // We don't want any of these serialized; only ComboBoxText
+        public bool ShouldSerializeFilter() {
+            return false;
+        }
         public bool ShouldSerializeXfilterExpression() {
             return false;
         }

--- a/NINA.Sequencer/SequenceItem/Imaging/SmartExposure.cs
+++ b/NINA.Sequencer/SequenceItem/Imaging/SmartExposure.cs
@@ -34,6 +34,7 @@ using NINA.Sequencer.Logic;
 using NINA.Sequencer.Validations;
 using NINA.Core.Model;
 using System.Threading;
+using System.Globalization;
 
 namespace NINA.Sequencer.SequenceItem.Imaging {
 
@@ -186,7 +187,19 @@ namespace NINA.Sequencer.SequenceItem.Imaging {
 
         public override void AfterParentChanged() {
             base.AfterParentChanged();
+            BackfillIterationsExpressionFromLoopCondition();
             Validate();
+        }
+
+        private void BackfillIterationsExpressionFromLoopCondition() {
+            LoopCondition loopCondition = GetLoopCondition();
+            if (loopCondition == null ||
+                    IterationsExpression.Definition.Length > 0 ||
+                    loopCondition.Iterations == Iterations) {
+                return;
+            }
+
+            IterationsExpression.Definition = loopCondition.Iterations.ToString(CultureInfo.InvariantCulture);
         }
 
         public override bool Validate() {

--- a/NINA.Sequencer/SequenceItem/Imaging/TakeManyExposures.cs
+++ b/NINA.Sequencer/SequenceItem/Imaging/TakeManyExposures.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -142,7 +143,19 @@ namespace NINA.Sequencer.SequenceItem.Imaging {
 
         public override void AfterParentChanged() {
             base.AfterParentChanged();
+            BackfillIterationsExpressionFromLoopCondition();
             Validate();
+        }
+
+        private void BackfillIterationsExpressionFromLoopCondition() {
+            LoopCondition loopCondition = GetLoopCondition();
+            if (loopCondition == null ||
+                    IterationsExpression.Definition.Length > 0 ||
+                    loopCondition.Iterations == Iterations) {
+                return;
+            }
+
+            IterationsExpression.Definition = loopCondition.Iterations.ToString(CultureInfo.InvariantCulture);
         }
 
         public override bool Validate() {

--- a/NINA.Sequencer/SequenceItem/Imaging/TakeSubframeExposure.cs
+++ b/NINA.Sequencer/SequenceItem/Imaging/TakeSubframeExposure.cs
@@ -126,7 +126,7 @@ namespace NINA.Sequencer.SequenceItem.Imaging {
             get => ROIPctExpression.Value / 100;
             set {
                 // When loaded, we set the expression
-                ROIPctExpression.Definition = (value * 100).ToString();
+                ROIPctExpression.Definition = (value * 100).ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
+++ b/NINA.Sequencer/SequenceItem/Telescope/SlewScopeToAltAz.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -72,10 +73,10 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
             // Fix up Ra and Dec Expressions (auto-update to existing sequences)
             TopocentricCoordinates c = Coordinates.Coordinates;
             if (AltExpression.Definition.Length == 0 && c.Altitude.Degree != 0) {
-                AltExpression.Definition = c.Altitude.Degree.ToString();
+                AltExpression.Definition = c.Altitude.Degree.ToString(CultureInfo.InvariantCulture);
             }
             if (AzExpression.Definition.Length == 0 && c.Azimuth.Degree != 0) {
-                AzExpression.Definition = c.Azimuth.Degree.ToString();
+                AzExpression.Definition = c.Azimuth.Degree.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -167,9 +168,9 @@ namespace NINA.Sequencer.SequenceItem.Telescope {
             if (Protect) return;
 
             if (c.Altitude != lastAlt) {
-                AltExpression.Definition = Math.Round(c.Altitude.Degree, 7).ToString();
+                AltExpression.Definition = Math.Round(c.Altitude.Degree, 7).ToString(CultureInfo.InvariantCulture);
             } else if (c.Azimuth != lastAz) {
-                AzExpression.Definition = Math.Round(c.Azimuth.Degree, 7).ToString();
+                AzExpression.Definition = Math.Round(c.Azimuth.Degree, 7).ToString(CultureInfo.InvariantCulture);
             }
 
             lastAlt = c.Altitude;

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForAltitude.cs
@@ -21,6 +21,7 @@ using NINA.Core.Enum;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Core.Locale;
@@ -66,7 +67,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         public new void OnDeserialized(StreamingContext context) {
             Coordinates = Data.Coordinates.Clone();
             if (OffsetExpression.Definition.Length == 0) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
             base.OnDeserialized(context);
         }

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForMoonAltitude.cs
@@ -20,6 +20,7 @@ using NINA.Core.Utility;
 using NINA.Astrometry;
 using System;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Core.Locale;
@@ -49,7 +50,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         [OnDeserialized]
         public void OnDeserialized(StreamingContext context) {
             if (OffsetExpression.Definition.Length == 0) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NINA.Sequencer/SequenceItem/Utility/WaitForSunAltitude.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitForSunAltitude.cs
@@ -20,6 +20,7 @@ using NINA.Core.Utility;
 using NINA.Astrometry;
 using System;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Core.Locale;
@@ -54,7 +55,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         [OnDeserialized]
         public void OnDeserialized(StreamingContext context) {
             if (OffsetExpression.Definition.Length == 0) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/NINA.Sequencer/SequenceItem/Utility/WaitUntilAboveHorizon.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/WaitUntilAboveHorizon.cs
@@ -20,6 +20,7 @@ using NINA.Astrometry;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Core.Locale;
@@ -63,7 +64,7 @@ namespace NINA.Sequencer.SequenceItem.Utility {
         public new void OnDeserialized(StreamingContext context) {
             Coordinates = Data.Coordinates.Clone();
             if (OffsetExpression.Definition.Length == 0) {
-                OffsetExpression.Definition = Data.Offset.ToString();
+                OffsetExpression.Definition = Data.Offset.ToString(CultureInfo.InvariantCulture);
             }
             base.OnDeserialized(context);
         }

--- a/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
+++ b/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
@@ -114,7 +114,7 @@ namespace NINA.Sequencer.Trigger.Platesolving {
         [JsonProperty]
         public InputCoordinates Coordinates { get; set; }
 
-        [IsExpression (Default = 10, Range = [0, 60, ExpressionRange.MIN_EXCLUSIVE], HasValidator = true)]
+        [IsExpression (Default = 10, Range = [0, ExpressionRange.NO_MAXIMUM, ExpressionRange.MIN_EXCLUSIVE], HasValidator = true)]
         public partial double DistanceArcMinutes { get; set; }
 
         partial void DistanceArcMinutesExpressionValidator(Expression expr) {

--- a/NINA.Test/NINA.Test.csproj
+++ b/NINA.Test/NINA.Test.csproj
@@ -72,6 +72,9 @@
     <None Update="Autofocus\TestImage_Jelly.xisf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Sequencer\Serialization\LegacySequences\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/NINA.Test/Sequencer/Logic/ExpressionCultureMigrationTest.cs
+++ b/NINA.Test/Sequencer/Logic/ExpressionCultureMigrationTest.cs
@@ -1,0 +1,164 @@
+﻿#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Astrometry;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.Logic;
+using NINA.Sequencer.SequenceItem.Imaging;
+using NINA.Sequencer.SequenceItem.Telescope;
+using NINA.Sequencer.SequenceItem.Utility;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using System.Globalization;
+
+namespace NINA.Test.Sequencer.Logic {
+
+    [TestFixture]
+    public class ExpressionCultureMigrationTest {
+
+        [Test]
+        public void LegacyNumericExpressionBackfills_UseInvariantCulture_WhenCurrentCultureUsesDecimalComma() {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+            try {
+                CultureInfo commaDecimalCulture = CultureInfo.GetCultureInfo("de-DE");
+                CultureInfo.CurrentCulture = commaDecimalCulture;
+                CultureInfo.CurrentUICulture = commaDecimalCulture;
+
+                IProfileService profileService = CreateProfileService();
+
+                WaitForAltitude waitForAltitude = new WaitForAltitude(profileService);
+                waitForAltitude.Data.Offset = 12.5;
+                waitForAltitude.OffsetExpression = new Expression(string.Empty, waitForAltitude);
+
+                waitForAltitude.OnDeserialized(default);
+
+                waitForAltitude.OffsetExpression.Definition.Should().Be("12.5");
+
+                WaitUntilAboveHorizon waitUntilAboveHorizon = new WaitUntilAboveHorizon(profileService);
+                waitUntilAboveHorizon.Data.Offset = 12.5;
+                waitUntilAboveHorizon.OffsetExpression = new Expression(string.Empty, waitUntilAboveHorizon);
+
+                waitUntilAboveHorizon.OnDeserialized(default);
+
+                waitUntilAboveHorizon.OffsetExpression.Definition.Should().Be("12.5");
+
+                WaitForMoonAltitude waitForMoonAltitude = new WaitForMoonAltitude(profileService);
+                waitForMoonAltitude.Data.Offset = 12.5;
+                waitForMoonAltitude.OffsetExpression = new Expression(string.Empty, waitForMoonAltitude);
+
+                waitForMoonAltitude.OnDeserialized(default);
+
+                waitForMoonAltitude.OffsetExpression.Definition.Should().Be("12.5");
+
+                WaitForSunAltitude waitForSunAltitude = new WaitForSunAltitude(profileService);
+                waitForSunAltitude.Data.Offset = 12.5;
+                waitForSunAltitude.OffsetExpression = new Expression(string.Empty, waitForSunAltitude);
+
+                waitForSunAltitude.OnDeserialized(default);
+
+                waitForSunAltitude.OffsetExpression.Definition.Should().Be("12.5");
+
+                TakeSubframeExposure subframeExposure = new TakeSubframeExposure(
+                    profileService,
+                    new Mock<ICameraMediator>().Object,
+                    new Mock<IImagingMediator>().Object,
+                    new Mock<IImageSaveMediator>().Object,
+                    new Mock<IImageHistoryVM>().Object);
+
+                subframeExposure.ROI = 0.125;
+
+                subframeExposure.ROIPctExpression.Definition.Should().Be("12.5");
+                subframeExposure.ROI.Should().BeApproximately(0.125, 1e-10);
+
+                SlewScopeToAltAz slewScopeToAltAz = new SlewScopeToAltAz(
+                    profileService,
+                    new Mock<ITelescopeMediator>().Object,
+                    new Mock<IGuiderMediator>().Object);
+                slewScopeToAltAz.Coordinates.Coordinates = new TopocentricCoordinates(
+                    Angle.ByDegree(123.5),
+                    Angle.ByDegree(12.5),
+                    Angle.Zero,
+                    Angle.Zero,
+                    0);
+
+                slewScopeToAltAz.OnDeserialized(default);
+
+                slewScopeToAltAz.AltExpression.Definition.Should().Be("12.5");
+                slewScopeToAltAz.AzExpression.Definition.Should().Be("123.5");
+
+                AltitudeCondition altitudeCondition = new AltitudeCondition(profileService);
+                altitudeCondition.Data.Coordinates.Coordinates = new Coordinates(
+                    Angle.ByHours(1.25),
+                    Angle.ByDegree(-12.5),
+                    Epoch.J2000);
+                altitudeCondition.Data.Offset = 12.5;
+
+                altitudeCondition.OnDeserialized(default);
+
+                altitudeCondition.RaExpression.Definition.Should().Be("1.25");
+                altitudeCondition.DecExpression.Definition.Should().Be("-12.5");
+                altitudeCondition.OffsetExpression.Definition.Should().Be("12.5");
+
+                AboveHorizonCondition aboveHorizonCondition = new AboveHorizonCondition(profileService);
+                aboveHorizonCondition.Data.Coordinates.Coordinates = new Coordinates(
+                    Angle.ByHours(1.25),
+                    Angle.ByDegree(-12.5),
+                    Epoch.J2000);
+                aboveHorizonCondition.Data.Offset = 12.5;
+
+                aboveHorizonCondition.OnDeserialized(default);
+
+                aboveHorizonCondition.RaExpression.Definition.Should().Be("1.25");
+                aboveHorizonCondition.DecExpression.Definition.Should().Be("-12.5");
+                aboveHorizonCondition.OffsetExpression.Definition.Should().Be("12.5");
+
+                MoonAltitudeCondition moonAltitudeCondition = new MoonAltitudeCondition(profileService);
+                moonAltitudeCondition.Data.Offset = 12.5;
+                moonAltitudeCondition.OffsetExpression = new Expression(string.Empty, moonAltitudeCondition);
+
+                moonAltitudeCondition.OnDeserialized(default);
+
+                moonAltitudeCondition.OffsetExpression.Definition.Should().Be("12.5");
+
+                SunAltitudeCondition sunAltitudeCondition = new SunAltitudeCondition(profileService);
+                sunAltitudeCondition.Data.Offset = 12.5;
+                sunAltitudeCondition.OffsetExpression = new Expression(string.Empty, sunAltitudeCondition);
+
+                sunAltitudeCondition.OnDeserialized(default);
+
+                sunAltitudeCondition.OffsetExpression.Definition.Should().Be("12.5");
+            } finally {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
+        }
+
+        private static IProfileService CreateProfileService() {
+            NINA.Profile.Profile profile = new NINA.Profile.Profile();
+            profile.AstrometrySettings.Latitude = 0;
+            profile.AstrometrySettings.Longitude = 0;
+            profile.ImageFileSettings.FilePath = TestContext.CurrentContext.TestDirectory;
+
+            Mock<IProfileService> profileServiceMock = new Mock<IProfileService>();
+            profileServiceMock.SetupGet(x => x.ActiveProfile).Returns(profile);
+            return profileServiceMock.Object;
+        }
+    }
+}

--- a/NINA.Test/Sequencer/Logic/ExpressionCultureMigrationTest.cs
+++ b/NINA.Test/Sequencer/Logic/ExpressionCultureMigrationTest.cs
@@ -15,6 +15,9 @@
 using FluentAssertions;
 using Moq;
 using NINA.Astrometry;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyFilterWheel;
+using NINA.Equipment.Equipment.MyGuider;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Conditions;
@@ -150,6 +153,49 @@ namespace NINA.Test.Sequencer.Logic {
             }
         }
 
+        /// <summary>
+        /// Verifies immutable imaging containers backfill their generated IterationsExpression from a legacy nested LoopCondition value.
+        /// Without this, old imported sequences could execute the legacy loop count while the container-level expression still showed default 1.
+        /// </summary>
+        [Test]
+        public void LegacyImagingContainerLoopIterations_BackfillContainerIterationsExpressions() {
+            IProfileService profileService = CreateProfileService();
+
+            SmartExposure smartExposure = new SmartExposure(
+                profileService,
+                CreateCameraMediator(),
+                new Mock<IImagingMediator>().Object,
+                new Mock<IImageSaveMediator>().Object,
+                new Mock<IImageHistoryVM>().Object,
+                CreateFilterWheelMediator(),
+                CreateGuiderMediator(),
+                new Mock<ISafetyMonitorMediator>().Object);
+            smartExposure.GetLoopCondition().Iterations = 5;
+
+            smartExposure.AfterParentChanged();
+
+            smartExposure.Iterations.Should().Be(5);
+            smartExposure.IterationsExpression.Definition.Should().Be("5");
+            smartExposure.GetLoopCondition().Iterations.Should().Be(5);
+
+            TakeManyExposures takeManyExposures = new TakeManyExposures(
+                profileService,
+                CreateCameraMediator(),
+                new Mock<IImagingMediator>().Object,
+                new Mock<IImageSaveMediator>().Object,
+                new Mock<IImageHistoryVM>().Object);
+            takeManyExposures.GetLoopCondition().Iterations = 6;
+
+            takeManyExposures.AfterParentChanged();
+
+            takeManyExposures.Iterations.Should().Be(6);
+            takeManyExposures.IterationsExpression.Definition.Should().Be("6");
+            takeManyExposures.GetLoopCondition().Iterations.Should().Be(6);
+        }
+
+        /// <summary>
+        /// Creates a profile with only the settings needed by the migration backfill tests.
+        /// </summary>
         private static IProfileService CreateProfileService() {
             NINA.Profile.Profile profile = new NINA.Profile.Profile();
             profile.AstrometrySettings.Latitude = 0;
@@ -159,6 +205,33 @@ namespace NINA.Test.Sequencer.Logic {
             Mock<IProfileService> profileServiceMock = new Mock<IProfileService>();
             profileServiceMock.SetupGet(x => x.ActiveProfile).Returns(profile);
             return profileServiceMock.Object;
+        }
+
+        /// <summary>
+        /// Creates a disconnected camera mediator so imaging containers can be constructed without hardware.
+        /// </summary>
+        private static ICameraMediator CreateCameraMediator() {
+            Mock<ICameraMediator> cameraMediator = new Mock<ICameraMediator>();
+            cameraMediator.Setup(x => x.GetInfo()).Returns(new CameraInfo { Connected = false });
+            return cameraMediator.Object;
+        }
+
+        /// <summary>
+        /// Creates a disconnected filter wheel mediator for SmartExposure construction.
+        /// </summary>
+        private static IFilterWheelMediator CreateFilterWheelMediator() {
+            Mock<IFilterWheelMediator> filterWheelMediator = new Mock<IFilterWheelMediator>();
+            filterWheelMediator.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo { Connected = false });
+            return filterWheelMediator.Object;
+        }
+
+        /// <summary>
+        /// Creates a disconnected guider mediator for SmartExposure construction.
+        /// </summary>
+        private static IGuiderMediator CreateGuiderMediator() {
+            Mock<IGuiderMediator> guiderMediator = new Mock<IGuiderMediator>();
+            guiderMediator.Setup(x => x.GetInfo()).Returns(new GuiderInfo { Connected = false });
+            return guiderMediator.Object;
         }
     }
 }

--- a/NINA.Test/Sequencer/SequenceItem/Expressions/UserSymbolInstructionTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Expressions/UserSymbolInstructionTest.cs
@@ -23,6 +23,7 @@ using NINA.Sequencer.Utility.DateTimeProvider;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using SequencerExpression = NINA.Sequencer.Logic.Expression;
@@ -215,6 +216,32 @@ namespace NINA.Test.Sequencer.SequenceItem.Expressions {
 
             variable.Expr.Definition.Should().Be("42");
             consumer.Dirty.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ResetVariable_Execute_FormatsNumericDefinitionWithInvariantCulture() {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+            try {
+                CultureInfo commaDecimalCulture = CultureInfo.GetCultureInfo("de-DE");
+                CultureInfo.CurrentCulture = commaDecimalCulture;
+                CultureInfo.CurrentUICulture = commaDecimalCulture;
+
+                SequenceRootContainer root = CreateRoot();
+                Variable variable = CreateVariable("target", "1", root);
+                await variable.Execute(default, CancellationToken.None);
+
+                ResetVariable sut = CreateResetVariable("target", "12.5", root);
+
+                sut.Validate().Should().BeTrue();
+                await sut.Execute(default, CancellationToken.None);
+
+                variable.Expr.Definition.Should().Be("12.5");
+            } finally {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
         }
 
         /// <summary>

--- a/NINA.Test/Sequencer/SequenceItem/FilterWheel/SwitchFilterTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/FilterWheel/SwitchFilterTest.cs
@@ -14,6 +14,7 @@
 
 using FluentAssertions;
 using Moq;
+using Newtonsoft.Json;
 using NINA.Equipment.Equipment.MyFilterWheel;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer;
@@ -52,6 +53,19 @@ namespace NINA.Test.Sequencer.SequenceItem.FilterWheel {
 
         private delegate void TryGetValueCallback(string key, out object value);
 
+        private void SetupProfileFilters(params FilterInfo[] filters) {
+            var filterCollection = new Core.Utility.ObserveAllCollection<FilterInfo>();
+            foreach (FilterInfo filter in filters) {
+                filterCollection.Add(filter);
+            }
+
+            var profileMock = new Mock<IProfile>();
+            var filterWheelSettingsMock = new Mock<NINA.Profile.Interfaces.IFilterWheelSettings>();
+            filterWheelSettingsMock.Setup(x => x.FilterWheelFilters).Returns(filterCollection);
+            profileMock.Setup(x => x.FilterWheelSettings).Returns(filterWheelSettingsMock.Object);
+            profileServiceMock.Setup(x => x.ActiveProfile).Returns(profileMock.Object);
+        }
+
         [Test]
         public void Clone_ItemClonedProperly() {
             var sut = new SwitchFilter(profileServiceMock.Object, fwMediatorMock.Object);
@@ -65,6 +79,53 @@ namespace NINA.Test.Sequencer.SequenceItem.FilterWheel {
             item2.Description.Should().BeSameAs(sut.Description);
             item2.Icon.Should().BeSameAs(sut.Icon);
             item2.Filter.Should().BeSameAs(sut.Filter);
+        }
+
+        /// <summary>
+        /// Verifies that cloning resolves the selected filter on the clone instance.
+        /// This covers the regression where AfterClone resolved the source instance instead,
+        /// leaving cloned sequences with ComboBoxText set but Filter unset.
+        /// </summary>
+        [Test]
+        public void Clone_ResolvesSelectedFilterOnClone() {
+            var redFilter = new FilterInfo("Red", 0, 1);
+            var greenFilter = new FilterInfo("Green", 0, 2);
+            SetupProfileFilters(redFilter, greenFilter);
+            fwMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { Connected = true });
+
+            var sut = new SwitchFilter(profileServiceMock.Object, fwMediatorMock.Object);
+            sut.ComboBoxText = "Green";
+
+            var clone = (SwitchFilter)sut.Clone();
+
+            clone.Should().NotBeSameAs(sut);
+            clone.ComboBoxText.Should().Be("Green");
+            clone.Filter.Should().NotBeNull();
+            clone.Filter.Name.Should().Be("Green");
+            clone.Filter.Position.Should().Be(2);
+        }
+
+        /// <summary>
+        /// Verifies that serialization suppresses the legacy Filter payload without mutating live state.
+        /// This protects old 3.2 sequence migration support while avoiding the regression where saving
+        /// cleared the resolved in-memory filter value.
+        /// </summary>
+        [Test]
+        public void Serialize_DoesNotMutateResolvedFilterOrWriteLegacyFilter() {
+            var redFilter = new FilterInfo("Red", 0, 1);
+            var greenFilter = new FilterInfo("Green", 0, 2);
+            SetupProfileFilters(redFilter, greenFilter);
+            fwMediatorMock.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo() { Connected = true });
+
+            var sut = new SwitchFilter(profileServiceMock.Object, fwMediatorMock.Object);
+            sut.ComboBoxText = "Green";
+
+            string json = JsonConvert.SerializeObject(sut);
+
+            sut.Filter.Should().NotBeNull();
+            sut.Filter.Name.Should().Be("Green");
+            json.Should().Contain("\"ComboBoxText\"");
+            json.Should().NotContain("\"Filter\"");
         }
 
         [Test]

--- a/NINA.Test/Sequencer/Serialization/LegacySequenceMigrationCorpusTest.cs
+++ b/NINA.Test/Sequencer/Serialization/LegacySequenceMigrationCorpusTest.cs
@@ -465,6 +465,12 @@ namespace NINA.Test.Sequencer.Serialization {
                 AddNumericExpressionExpectation(expectations, "OffsetExpression", "Data.Offset", dataOffset);
             }
 
+            if (expressionPropertyNames.Contains("IterationsExpression") &&
+                    !TryReadNumberPath(legacyJson, "Iterations", out _) &&
+                    TryReadFirstLoopConditionIterations(legacyJson, out double loopIterations)) {
+                AddNumericExpressionExpectation(expectations, "IterationsExpression", "Conditions[0].Iterations", loopIterations);
+            }
+
             if (expressionPropertyNames.Contains("XfilterExpression") &&
                     TryReadStringPath(legacyJson, "Filter._name", out string filterName)) {
                 AddStringExpressionExpectation(expectations, "XfilterExpression", "Filter._name", SymbolBroker.SanitizeIdentifier(filterName));
@@ -631,6 +637,21 @@ namespace NINA.Test.Sequencer.Serialization {
 
             value = Convert.ToDouble(jValue.Value, CultureInfo.InvariantCulture);
             return true;
+        }
+
+        /// <summary>
+        /// Reads the legacy nested loop count used by immutable imaging containers before they gained their own IterationsExpression.
+        /// </summary>
+        private static bool TryReadFirstLoopConditionIterations(JObject root, out double value) {
+            value = 0;
+            if (root["Conditions"] is not JObject conditions ||
+                    conditions["$values"] is not JArray values ||
+                    values.Count == 0 ||
+                    values[0] is not JObject loopConditionJson) {
+                return false;
+            }
+
+            return TryReadNumberPath(loopConditionJson, "Iterations", out value);
         }
 
         /// <summary>

--- a/NINA.Test/Sequencer/Serialization/LegacySequenceMigrationCorpusTest.cs
+++ b/NINA.Test/Sequencer/Serialization/LegacySequenceMigrationCorpusTest.cs
@@ -1,0 +1,1245 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NINA.Astrometry.Interfaces;
+using NINA.Core.Interfaces;
+using NINA.Core.Model.Equipment;
+using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyDome;
+using NINA.Equipment.Equipment.MyFilterWheel;
+using NINA.Equipment.Equipment.MyFlatDevice;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyGuider;
+using NINA.Equipment.Equipment.MyRotator;
+using NINA.Equipment.Equipment.MySafetyMonitor;
+using NINA.Equipment.Equipment.MySwitch;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Equipment.MyWeatherData;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Image.ImageAnalysis;
+using NINA.Image.Interfaces;
+using NINA.PlateSolving.Interfaces;
+using NINA.Plugin.Interfaces;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces.Mediator;
+using NINA.Sequencer.Logic;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.FilterWheel;
+using NINA.Sequencer.Serialization;
+using NINA.Sequencer.Trigger;
+using NINA.Sequencer.Utility.DateTimeProvider;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Media;
+
+namespace NINA.Test.Sequencer.Serialization {
+
+    [TestFixture]
+    [NonParallelizable]
+    public class LegacySequenceMigrationCorpusTest {
+        private const string Master32Commit = "2393eae581145ed5b8114bf07c48ca2580540fd5";
+        private static readonly string[] CorpusPathParts = { "Sequencer", "Serialization", "LegacySequences", "v3.2" };
+
+        private static readonly ISet<string> IgnoredJsonProperties = new HashSet<string>(StringComparer.Ordinal) {
+            "$id",
+            "$type",
+            "$values",
+            "Conditions",
+            "DropIntoCommand",
+            "DropIntoConditionsCommand",
+            "DropIntoTriggersCommand",
+            "HasChanged",
+            "HasDsoParent",
+            "Icon",
+            "Issues",
+            "Items",
+            "Parent",
+            "ResetProgressCommand",
+            "ShowMenu",
+            "Strategy",
+            "Status",
+            "SymbolBroker",
+            "Triggers",
+            "TriggerRunner"
+        };
+
+        /// <summary>
+        /// Guards the golden input itself: this corpus must remain a complete 3.2 master snapshot,
+        /// otherwise the migration test can pass while silently dropping an old sequencer export.
+        /// </summary>
+        [Test]
+        public void LegacyMasterCorpus_CoversEveryMasterSequencerExportWithDefaultAndPopulatedVariants() {
+            foreach (LegacyCorpusFile corpus in LoadCorpusFiles()) {
+                JObject legacyJson = ReadJsonObject(corpus.SequencePath);
+                LegacyManifest manifest = ReadManifest(corpus.ManifestPath);
+                ISet<string> serializedEntityTypes = TraverseJsonEntities(legacyJson)
+                    .Select(x => ExtractTypeName(x.Json))
+                    .Where(x => x != null)
+                    .Select(x => x!)
+                    .ToHashSet(StringComparer.Ordinal);
+
+                manifest.SourceBranch.Should().Be("master");
+                manifest.SourceCommit.Should().Be(Master32Commit);
+                manifest.Items.Should().HaveCount(65);
+                manifest.Conditions.Should().HaveCount(10);
+                manifest.Triggers.Should().HaveCount(12);
+                manifest.Containers.Should().HaveCount(14);
+                manifest.Entities.Should().HaveCount(200);
+
+                manifest.Items
+                    .Concat(manifest.Conditions)
+                    .Concat(manifest.Triggers)
+                    .Concat(manifest.Containers)
+                    .Except(serializedEntityTypes, StringComparer.Ordinal)
+                    .Should()
+                    .BeEmpty("the legacy sequence JSON must contain every exported 3.2 sequencer entity from the manifest");
+
+                manifest.Entities
+                    .GroupBy(x => $"{x.Kind}:{x.Type}", StringComparer.Ordinal)
+                    .Select(x => new { Entity = x.Key, Variants = x.Select(y => y.Variant).ToHashSet(StringComparer.Ordinal) })
+                    .Where(x => !x.Variants.SetEquals(new[] { "Default", "Populated" }))
+                    .Should()
+                    .BeEmpty("each non-root master entity in the corpus should have both a default and a populated-value permutation");
+            }
+        }
+
+        /// <summary>
+        /// Exercises the compatibility contract that existing 3.2 user sequence files migrate through
+        /// the current symbol-aware serializers without culture-dependent parsing, unknown fallbacks,
+        /// scalar value drift, or expression-definition drift after a current-version save round-trip.
+        /// </summary>
+        [Test]
+        public void LegacyMasterCorpus_MigratesUnderNonInvariantCultureWithoutUnknownEntitiesOrValueDrift() {
+            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+            CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+
+                using CurrentSequencerCatalog catalog = CurrentSequencerCatalog.Create();
+                SequenceJsonConverter converter = new SequenceJsonConverter(catalog.Factory);
+
+                foreach (LegacyCorpusFile corpus in LoadCorpusFiles()) {
+                    string legacyJsonText = File.ReadAllText(corpus.SequencePath);
+                    JObject legacyJson = ReadJsonObject(corpus.SequencePath);
+                    IReadOnlyList<JsonEntityNode> legacyNodes = TraverseJsonEntities(legacyJson).ToList();
+
+                    ISequenceContainer migrated = converter.Deserialize(legacyJsonText, corpus.SequencePath);
+                    IReadOnlyList<EntityNode> migratedNodes = TraverseEntities(migrated).ToList();
+
+                    AssertNoUnknownEntities(migratedNodes, "every built-in 3.2 entity should resolve to a current sequencer type");
+
+                    FindValueMismatches(legacyNodes, migratedNodes)
+                        .Should()
+                        .BeEmpty("old scalar JSON values must survive migration unchanged");
+
+                    FindExpressionMismatches(legacyNodes, migratedNodes)
+                        .Should()
+                        .BeEmpty("old scalar JSON values must also hydrate expression definitions and evaluated expression values");
+
+                    AssertPopulatedSwitchFilterWasMigrated(migratedNodes);
+
+                    string currentJsonText = converter.Serialize(migrated);
+                    ISequenceContainer roundTripped = converter.Deserialize(currentJsonText, corpus.SequencePath);
+                    IReadOnlyList<EntityNode> roundTrippedNodes = TraverseEntities(roundTripped).ToList();
+
+                    AssertNoUnknownEntities(roundTrippedNodes, "current-version serialization should not introduce unknown entities");
+
+                    CreateEntityTypeDigest(roundTrippedNodes)
+                        .Should()
+                        .Equal(CreateEntityTypeDigest(migratedNodes), "current-version serialization should preserve the migrated sequence structure");
+
+                    FindExpressionMismatches(legacyNodes, roundTrippedNodes)
+                        .Should()
+                        .BeEmpty("expression-backed migrated values must survive current-version serialization");
+
+                    AssertPopulatedSwitchFilterWasMigrated(roundTrippedNodes);
+                }
+            } finally {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+        }
+
+        /// <summary>
+        /// Finds the copied legacy corpus manifests in the test output and pairs each manifest with its sequence JSON file.
+        /// </summary>
+        private static IReadOnlyList<LegacyCorpusFile> LoadCorpusFiles() {
+            string corpusDirectory = Path.Combine(new[] { TestContext.CurrentContext.TestDirectory }.Concat(CorpusPathParts).ToArray());
+            Directory.Exists(corpusDirectory).Should().BeTrue("legacy sequence corpus files must be copied to the test output");
+
+            IReadOnlyList<LegacyCorpusFile> corpusFiles = Directory
+                .EnumerateFiles(corpusDirectory, "*.manifest.json")
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .Select(x => new LegacyCorpusFile(
+                    x,
+                    Path.Combine(Path.GetDirectoryName(x)!, ReadManifest(x).SequenceFile)))
+                .ToList();
+
+            corpusFiles.Should().NotBeEmpty("at least one legacy sequence migration corpus is expected");
+            return corpusFiles;
+        }
+
+        /// <summary>
+        /// Reads the generated corpus manifest so the test can assert the source commit and entity coverage.
+        /// </summary>
+        private static LegacyManifest ReadManifest(string path) {
+            return JsonConvert.DeserializeObject<LegacyManifest>(File.ReadAllText(path))!;
+        }
+
+        /// <summary>
+        /// Loads legacy JSON without automatic date parsing so persisted scalar values are compared in their original shape.
+        /// </summary>
+        private static JObject ReadJsonObject(string path) {
+            using StringReader stringReader = new StringReader(File.ReadAllText(path));
+            using JsonTextReader jsonReader = new JsonTextReader(stringReader) {
+                DateParseHandling = DateParseHandling.None
+            };
+            return JObject.Load(jsonReader);
+        }
+
+        /// <summary>
+        /// Starts a path-preserving walk of a legacy sequence JSON entity tree from the root container.
+        /// </summary>
+        private static IEnumerable<JsonEntityNode> TraverseJsonEntities(JObject entityJson) {
+            return TraverseJsonEntities(entityJson, "$");
+        }
+
+        /// <summary>
+        /// Walks legacy JSON entities in the same structural order as the current object graph traversal.
+        /// </summary>
+        private static IEnumerable<JsonEntityNode> TraverseJsonEntities(JObject entityJson, string path) {
+            if (entityJson.ContainsKey("$ref")) {
+                yield break;
+            }
+
+            yield return new JsonEntityNode(path, entityJson);
+
+            foreach (JsonEntityNode condition in TraverseJsonCollection(entityJson["Conditions"], $"{path}.Conditions")) {
+                yield return condition;
+            }
+
+            foreach (JsonEntityNode trigger in TraverseJsonCollection(entityJson["Triggers"], $"{path}.Triggers")) {
+                yield return trigger;
+            }
+
+            if (entityJson["TriggerRunner"] is JObject triggerRunner) {
+                foreach (JsonEntityNode triggerRunnerNode in TraverseJsonEntities(triggerRunner, $"{path}.TriggerRunner")) {
+                    yield return triggerRunnerNode;
+                }
+            }
+
+            foreach (JsonEntityNode item in TraverseJsonCollection(entityJson["Items"], $"{path}.Items")) {
+                yield return item;
+            }
+        }
+
+        /// <summary>
+        /// Expands a Json.NET-preserved collection node so child entities receive stable comparison paths.
+        /// </summary>
+        private static IEnumerable<JsonEntityNode> TraverseJsonCollection(JToken? token, string path) {
+            if (token is not JObject collection || collection["$values"] is not JArray values) {
+                yield break;
+            }
+
+            for (int index = 0; index < values.Count; index++) {
+                if (values[index] is JObject child) {
+                    foreach (JsonEntityNode node in TraverseJsonEntities(child, $"{path}[{index}]")) {
+                        yield return node;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts a path-preserving walk of the migrated current sequencer object graph.
+        /// </summary>
+        private static IEnumerable<EntityNode> TraverseEntities(ISequenceEntity entity) {
+            return TraverseEntities(entity, "$");
+        }
+
+        /// <summary>
+        /// Walks the current sequencer object graph in the same structural order as the legacy JSON traversal.
+        /// </summary>
+        private static IEnumerable<EntityNode> TraverseEntities(ISequenceEntity entity, string path) {
+            yield return new EntityNode(path, entity);
+
+            if (entity is IConditionable conditionable) {
+                for (int index = 0; index < conditionable.Conditions.Count; index++) {
+                    foreach (EntityNode condition in TraverseEntities(conditionable.Conditions[index], $"{path}.Conditions[{index}]")) {
+                        yield return condition;
+                    }
+                }
+            }
+
+            if (entity is ITriggerable triggerable) {
+                for (int index = 0; index < triggerable.Triggers.Count; index++) {
+                    foreach (EntityNode trigger in TraverseEntities(triggerable.Triggers[index], $"{path}.Triggers[{index}]")) {
+                        yield return trigger;
+                    }
+                }
+            }
+
+            PropertyInfo? triggerRunnerProperty = entity.GetType().GetProperty("TriggerRunner", BindingFlags.Instance | BindingFlags.Public);
+            if (triggerRunnerProperty?.GetValue(entity) is ISequenceEntity triggerRunner) {
+                foreach (EntityNode triggerRunnerNode in TraverseEntities(triggerRunner, $"{path}.TriggerRunner")) {
+                    yield return triggerRunnerNode;
+                }
+            }
+
+            if (entity is ISequenceContainer container) {
+                for (int index = 0; index < container.Items.Count; index++) {
+                    foreach (EntityNode item in TraverseEntities(container.Items[index], $"{path}.Items[{index}]")) {
+                        yield return item;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Extracts the unqualified assembly type name from legacy JSON so manifest coverage ignores assembly details.
+        /// </summary>
+        private static string? ExtractTypeName(JObject entityJson) {
+            string? assemblyQualifiedName = entityJson["$type"]?.Value<string>();
+            return assemblyQualifiedName?.Split(',')[0];
+        }
+
+        /// <summary>
+        /// Compares every comparable persisted legacy scalar against the migrated entity property at the same path.
+        /// </summary>
+        private static IReadOnlyList<string> FindValueMismatches(
+                IReadOnlyList<JsonEntityNode> legacyNodes,
+                IReadOnlyList<EntityNode> migratedNodes
+        ) {
+            IDictionary<string, EntityNode> migratedByPath = migratedNodes.ToDictionary(x => x.Path, StringComparer.Ordinal);
+            List<string> mismatches = new List<string>();
+            int comparedValues = 0;
+
+            foreach (JsonEntityNode legacyNode in legacyNodes) {
+                if (!migratedByPath.TryGetValue(legacyNode.Path, out EntityNode? migratedNode)) {
+                    mismatches.Add($"{legacyNode.Path}: migrated entity is missing");
+                    continue;
+                }
+
+                foreach (ComparableJsonValue expectedValue in GetComparableValues(legacyNode.Json)) {
+                    comparedValues++;
+                    if (!TryGetCurrentComparableValue(migratedNode.Entity, expectedValue, out string actualValue)) {
+                        mismatches.Add($"{legacyNode.Path}.{expectedValue.DisplayPath}: migrated entity no longer exposes this persisted value");
+                        continue;
+                    }
+
+                    if (!StringComparer.Ordinal.Equals(expectedValue.NormalizedValue, actualValue)) {
+                        mismatches.Add($"{legacyNode.Path}.{expectedValue.DisplayPath}: expected {expectedValue.NormalizedValue}, got {actualValue}");
+                    }
+                }
+            }
+
+            comparedValues.Should().BeGreaterThan(400, "the corpus should compare a broad set of migrated sequence values");
+            return mismatches;
+        }
+
+        /// <summary>
+        /// Verifies legacy scalar and nested values also hydrate current expression objects, not only scalar getters.
+        /// </summary>
+        private static IReadOnlyList<string> FindExpressionMismatches(
+                IReadOnlyList<JsonEntityNode> legacyNodes,
+                IReadOnlyList<EntityNode> currentNodes
+        ) {
+            IDictionary<string, EntityNode> currentByPath = currentNodes.ToDictionary(x => x.Path, StringComparer.Ordinal);
+            List<string> mismatches = new List<string>();
+            int checkedExpressions = 0;
+            int checkedDefinitions = 0;
+
+            foreach (JsonEntityNode legacyNode in legacyNodes) {
+                if (!currentByPath.TryGetValue(legacyNode.Path, out EntityNode? currentNode)) {
+                    continue;
+                }
+
+                foreach (ExpressionExpectation expectation in CreateExpressionExpectations(legacyNode.Json, currentNode.Entity)) {
+                    checkedExpressions++;
+                    string location = $"{legacyNode.Path}.{expectation.ExpressionPropertyName} <= {expectation.SourcePath}";
+
+                    if (!TryGetExpression(currentNode.Entity, expectation.ExpressionPropertyName, out Expression expression)) {
+                        mismatches.Add($"{location}: current entity does not expose the expected expression");
+                        continue;
+                    }
+
+                    if (expectation.NumericValue.HasValue) {
+                        expression.Evaluate(true);
+                        if (HasHardExpressionError(expression)) {
+                            mismatches.Add($"{location}: expression has error '{expression.Error}'");
+                        }
+
+                        double expectedValue = expectation.NumericValue.Value;
+                        if (!NumbersApproximatelyEqual(expression.Value, expectedValue)) {
+                            mismatches.Add($"{location}: expected evaluated value {FormatInvariant(expectedValue)}, got {FormatInvariant(expression.Value)}");
+                        }
+
+                        bool definitionRequired = RequiresExpressionDefinition(expression, expectedValue);
+                        if (definitionRequired) {
+                            checkedDefinitions++;
+                        }
+
+                        if (definitionRequired || !string.IsNullOrWhiteSpace(expression.Definition)) {
+                            FindNumericDefinitionMismatches(location, expression.Definition, expectedValue, definitionRequired, mismatches);
+                        }
+                    } else if (expectation.StringValue != null) {
+                        checkedDefinitions++;
+                        if (string.IsNullOrWhiteSpace(expression.Definition)) {
+                            mismatches.Add($"{location}: expected expression definition '{expectation.StringValue}', got an empty definition");
+                        } else if (!StringComparer.Ordinal.Equals(expression.Definition, expectation.StringValue)) {
+                            mismatches.Add($"{location}: expected expression definition '{expectation.StringValue}', got '{expression.Definition}'");
+                        }
+                    }
+                }
+            }
+
+            checkedExpressions.Should().BeGreaterThan(50, "the corpus should cover expression-backed migrated values across many sequencer entities");
+            checkedDefinitions.Should().BeGreaterThan(10, "the populated corpus variants should force non-default expression backfills");
+            return mismatches;
+        }
+
+        /// <summary>
+        /// Builds expression expectations from legacy JSON, including special nested fields that map to generated expressions.
+        /// </summary>
+        private static IReadOnlyList<ExpressionExpectation> CreateExpressionExpectations(JObject legacyJson, ISequenceEntity entity) {
+            ISet<string> expressionPropertyNames = GetExpressionPropertyNames(entity.GetType());
+            if (expressionPropertyNames.Count == 0) {
+                return Array.Empty<ExpressionExpectation>();
+            }
+
+            Dictionary<string, ExpressionExpectation> expectations = new Dictionary<string, ExpressionExpectation>(StringComparer.Ordinal);
+
+            foreach (string expressionPropertyName in expressionPropertyNames) {
+                string valuePropertyName = expressionPropertyName[..^"Expression".Length];
+                if (TryReadNumberPath(legacyJson, valuePropertyName, out double numericValue)) {
+                    AddNumericExpressionExpectation(expectations, expressionPropertyName, valuePropertyName, numericValue);
+                } else if (TryReadStringPath(legacyJson, valuePropertyName, out string stringValue)) {
+                    AddStringExpressionExpectation(expectations, expressionPropertyName, valuePropertyName, stringValue);
+                }
+            }
+
+            if (expressionPropertyNames.Contains("ROIPctExpression") &&
+                    TryReadNumberPath(legacyJson, "ROI", out double roiValue)) {
+                AddNumericExpressionExpectation(expectations, "ROIPctExpression", "ROI", roiValue * 100d);
+            }
+
+            if (expressionPropertyNames.Contains("OffsetExpression") &&
+                    TryReadNumberPath(legacyJson, "Data.Offset", out double dataOffset)) {
+                AddNumericExpressionExpectation(expectations, "OffsetExpression", "Data.Offset", dataOffset);
+            }
+
+            if (expressionPropertyNames.Contains("XfilterExpression") &&
+                    TryReadStringPath(legacyJson, "Filter._name", out string filterName)) {
+                AddStringExpressionExpectation(expectations, "XfilterExpression", "Filter._name", SymbolBroker.SanitizeIdentifier(filterName));
+            }
+
+            AddEquatorialCoordinateExpectations(expressionPropertyNames, legacyJson, expectations, "InputCoordinates");
+            AddEquatorialCoordinateExpectations(expressionPropertyNames, legacyJson, expectations, "Coordinates");
+            AddEquatorialCoordinateExpectations(expressionPropertyNames, legacyJson, expectations, "Data.Coordinates");
+            AddTopocentricCoordinateExpectations(expressionPropertyNames, legacyJson, expectations, "Coordinates");
+
+            return expectations.Values.ToList();
+        }
+
+        /// <summary>
+        /// Discovers generated expression properties on a current entity without depending on the source generator internals.
+        /// </summary>
+        private static ISet<string> GetExpressionPropertyNames(Type entityType) {
+            return entityType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(x => x.PropertyType == typeof(Expression) &&
+                            x.Name.EndsWith("Expression", StringComparison.Ordinal) &&
+                            x.GetIndexParameters().Length == 0)
+                .Select(x => x.Name)
+                .ToHashSet(StringComparer.Ordinal);
+        }
+
+        /// <summary>
+        /// Adds RA/Dec expression expectations for legacy coordinate objects that used component fields.
+        /// </summary>
+        private static void AddEquatorialCoordinateExpectations(
+                ISet<string> expressionPropertyNames,
+                JObject legacyJson,
+                IDictionary<string, ExpressionExpectation> expectations,
+                string sourcePath
+        ) {
+            if (!TryReadEquatorialCoordinates(legacyJson, sourcePath, out double rightAscension, out double declination)) {
+                return;
+            }
+
+            if (expressionPropertyNames.Contains("RaExpression")) {
+                AddNumericExpressionExpectation(expectations, "RaExpression", $"{sourcePath}.RA", rightAscension);
+            }
+
+            if (expressionPropertyNames.Contains("DecExpression")) {
+                AddNumericExpressionExpectation(expectations, "DecExpression", $"{sourcePath}.Dec", declination);
+            }
+        }
+
+        /// <summary>
+        /// Adds Alt/Az expression expectations for legacy topocentric coordinate objects that used component fields.
+        /// </summary>
+        private static void AddTopocentricCoordinateExpectations(
+                ISet<string> expressionPropertyNames,
+                JObject legacyJson,
+                IDictionary<string, ExpressionExpectation> expectations,
+                string sourcePath
+        ) {
+            if (!TryReadTopocentricCoordinates(legacyJson, sourcePath, out double azimuth, out double altitude)) {
+                return;
+            }
+
+            if (expressionPropertyNames.Contains("AzExpression")) {
+                AddNumericExpressionExpectation(expectations, "AzExpression", $"{sourcePath}.Az", azimuth);
+            }
+
+            if (expressionPropertyNames.Contains("AltExpression")) {
+                AddNumericExpressionExpectation(expectations, "AltExpression", $"{sourcePath}.Alt", altitude);
+            }
+        }
+
+        /// <summary>
+        /// Stores a numeric expression expectation keyed by expression property so special mappings can override generic ones.
+        /// </summary>
+        private static void AddNumericExpressionExpectation(
+                IDictionary<string, ExpressionExpectation> expectations,
+                string expressionPropertyName,
+                string sourcePath,
+                double value
+        ) {
+            expectations[expressionPropertyName] = new ExpressionExpectation(expressionPropertyName, sourcePath, value, null);
+        }
+
+        /// <summary>
+        /// Stores a string expression expectation for migrated symbol-style expressions such as filter names.
+        /// </summary>
+        private static void AddStringExpressionExpectation(
+                IDictionary<string, ExpressionExpectation> expectations,
+                string expressionPropertyName,
+                string sourcePath,
+                string value
+        ) {
+            expectations[expressionPropertyName] = new ExpressionExpectation(expressionPropertyName, sourcePath, null, value);
+        }
+
+        /// <summary>
+        /// Reads a generated expression property from the current entity when the migrated type exposes one.
+        /// </summary>
+        private static bool TryGetExpression(ISequenceEntity entity, string expressionPropertyName, out Expression expression) {
+            PropertyInfo? property = entity.GetType().GetProperty(expressionPropertyName, BindingFlags.Instance | BindingFlags.Public);
+            if (property?.GetValue(entity) is Expression resolvedExpression) {
+                expression = resolvedExpression;
+                return true;
+            }
+
+            expression = null!;
+            return false;
+        }
+
+        /// <summary>
+        /// Converts legacy RA/Dec component fields into the decimal values stored by current RA/Dec expressions.
+        /// </summary>
+        private static bool TryReadEquatorialCoordinates(JObject root, string path, out double rightAscension, out double declination) {
+            rightAscension = 0;
+            declination = 0;
+
+            if (!TryReadObjectPath(root, path, out JObject coordinates) ||
+                    !TryReadNumberPath(coordinates, "RAHours", out double hours) ||
+                    !TryReadNumberPath(coordinates, "RAMinutes", out double minutes) ||
+                    !TryReadNumberPath(coordinates, "RASeconds", out double seconds) ||
+                    !TryReadNumberPath(coordinates, "DecDegrees", out double degrees) ||
+                    !TryReadNumberPath(coordinates, "DecMinutes", out double decMinutes) ||
+                    !TryReadNumberPath(coordinates, "DecSeconds", out double decSeconds)) {
+                return false;
+            }
+
+            bool negativeDeclination = degrees < 0 || coordinates["NegativeDec"]?.Value<bool>() == true;
+            rightAscension = hours + (minutes / 60d) + (seconds / 3600d);
+            declination = ApplySign(Math.Abs(degrees), decMinutes, decSeconds, negativeDeclination);
+            return true;
+        }
+
+        /// <summary>
+        /// Converts legacy Alt/Az component fields into the decimal values stored by current Alt/Az expressions.
+        /// </summary>
+        private static bool TryReadTopocentricCoordinates(JObject root, string path, out double azimuth, out double altitude) {
+            azimuth = 0;
+            altitude = 0;
+
+            if (!TryReadObjectPath(root, path, out JObject coordinates) ||
+                    !TryReadNumberPath(coordinates, "AzDegrees", out double azimuthDegrees) ||
+                    !TryReadNumberPath(coordinates, "AzMinutes", out double azimuthMinutes) ||
+                    !TryReadNumberPath(coordinates, "AzSeconds", out double azimuthSeconds) ||
+                    !TryReadNumberPath(coordinates, "AltDegrees", out double altitudeDegrees) ||
+                    !TryReadNumberPath(coordinates, "AltMinutes", out double altitudeMinutes) ||
+                    !TryReadNumberPath(coordinates, "AltSeconds", out double altitudeSeconds)) {
+                return false;
+            }
+
+            azimuth = ApplySign(Math.Abs(azimuthDegrees), azimuthMinutes, azimuthSeconds, azimuthDegrees < 0);
+            altitude = ApplySign(Math.Abs(altitudeDegrees), altitudeMinutes, altitudeSeconds, altitudeDegrees < 0);
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a numeric token by dotted JSON path using invariant conversion for culture-stable expectations.
+        /// </summary>
+        private static bool TryReadNumberPath(JObject root, string path, out double value) {
+            value = 0;
+            if (!TryReadTokenPath(root, path, out JToken? token) ||
+                    token is not JValue jValue ||
+                    (jValue.Type != JTokenType.Integer && jValue.Type != JTokenType.Float)) {
+                return false;
+            }
+
+            value = Convert.ToDouble(jValue.Value, CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a string token by dotted JSON path for expression definitions that are symbol identifiers.
+        /// </summary>
+        private static bool TryReadStringPath(JObject root, string path, out string value) {
+            value = string.Empty;
+            if (!TryReadTokenPath(root, path, out JToken? token) ||
+                    token is not JValue jValue ||
+                    jValue.Type != JTokenType.String) {
+                return false;
+            }
+
+            value = jValue.Value<string>() ?? string.Empty;
+            return true;
+        }
+
+        /// <summary>
+        /// Reads an object token by dotted JSON path when special migration checks need nested legacy data.
+        /// </summary>
+        private static bool TryReadObjectPath(JObject root, string path, out JObject value) {
+            if (!TryReadTokenPath(root, path, out JToken? token) || token is not JObject jObject) {
+                value = null!;
+                return false;
+            }
+
+            value = jObject;
+            return true;
+        }
+
+        /// <summary>
+        /// Resolves a simple dotted path inside a single legacy entity JSON object.
+        /// </summary>
+        private static bool TryReadTokenPath(JObject root, string path, out JToken? value) {
+            value = root;
+            foreach (string part in path.Split('.')) {
+                if (value is not JObject currentObject || !currentObject.TryGetValue(part, out value)) {
+                    value = null;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Adds failures for missing or culture-dependent numeric expression definitions after migration.
+        /// </summary>
+        private static void FindNumericDefinitionMismatches(
+                string location,
+                string definition,
+                double expectedValue,
+                bool definitionRequired,
+                IList<string> mismatches
+        ) {
+            if (string.IsNullOrWhiteSpace(definition)) {
+                if (definitionRequired) {
+                    mismatches.Add($"{location}: expected a non-empty expression definition for {FormatInvariant(expectedValue)}");
+                }
+                return;
+            }
+
+            if (definition.Contains(',')) {
+                mismatches.Add($"{location}: expression definition '{definition}' is not invariant-culture formatted");
+                return;
+            }
+
+            if (!double.TryParse(definition, NumberStyles.Float, CultureInfo.InvariantCulture, out double definitionValue)) {
+                mismatches.Add($"{location}: expression definition '{definition}' is not an invariant numeric literal");
+                return;
+            }
+
+            if (!NumbersApproximatelyEqual(definitionValue, expectedValue)) {
+                mismatches.Add($"{location}: expected expression definition {FormatInvariant(expectedValue)}, got '{definition}'");
+            }
+        }
+
+        /// <summary>
+        /// Decides whether an expression should carry an explicit definition instead of relying on default or auto values.
+        /// </summary>
+        private static bool RequiresExpressionDefinition(Expression expression, double expectedValue) {
+            if (!double.IsNaN(expression.Default) && NumbersApproximatelyEqual(expectedValue, expression.Default)) {
+                return false;
+            }
+
+            if (!double.IsNaN(expression.AutoValue) && NumbersApproximatelyEqual(expectedValue, expression.AutoValue)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Distinguishes blocking expression errors from warnings so migration does not accept invalid current expressions.
+        /// </summary>
+        private static bool HasHardExpressionError(Expression expression) {
+            return !string.IsNullOrWhiteSpace(expression.Error) && !Expression.JustWarnings(expression.Error);
+        }
+
+        /// <summary>
+        /// Applies a legacy coordinate sign after combining degree, minute, and second components.
+        /// </summary>
+        private static double ApplySign(double degrees, double minutes, double seconds, bool isNegative) {
+            double value = degrees + (minutes / 60d) + (seconds / 3600d);
+            return isNegative ? -value : value;
+        }
+
+        /// <summary>
+        /// Compares decimalized legacy coordinate and expression values with tolerance for component conversion rounding.
+        /// </summary>
+        private static bool NumbersApproximatelyEqual(double actual, double expected) {
+            return Math.Abs(actual - expected) <= 0.000001d;
+        }
+
+        /// <summary>
+        /// Formats diagnostic numeric values with invariant culture so failures are readable under non-invariant tests.
+        /// </summary>
+        private static string FormatInvariant(double value) {
+            return value.ToString("G17", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Enumerates persisted legacy scalar values while ignoring runtime-only serialization infrastructure.
+        /// </summary>
+        private static IEnumerable<ComparableJsonValue> GetComparableValues(JObject entityJson) {
+            foreach (JProperty property in entityJson.Properties()) {
+                if (IgnoredJsonProperties.Contains(property.Name)) {
+                    continue;
+                }
+
+                foreach (ComparableJsonValue value in GetComparableValues(property.Name, property.Name, property.Value, depth: 0)) {
+                    yield return value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively flattens shallow legacy value objects so nested settings are compared against current properties.
+        /// </summary>
+        private static IEnumerable<ComparableJsonValue> GetComparableValues(string propertyName, string displayPath, JToken token, int depth) {
+            if (token is JValue jValue && TryNormalizeJValue(jValue, out string normalized)) {
+                yield return new ComparableJsonValue(propertyName, displayPath, normalized);
+                yield break;
+            }
+
+            if (depth >= 4 || token is not JObject jObject || jObject.ContainsKey("$ref") || jObject["$values"] != null) {
+                yield break;
+            }
+
+            foreach (JProperty childProperty in jObject.Properties()) {
+                if (IgnoredJsonProperties.Contains(childProperty.Name)) {
+                    continue;
+                }
+
+                foreach (ComparableJsonValue value in GetComparableValues(
+                             propertyName,
+                             $"{displayPath}.{childProperty.Name}",
+                             childProperty.Value,
+                             depth + 1)) {
+                    yield return value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads the migrated current property corresponding to a legacy JSON value, including renamed private fields.
+        /// </summary>
+        private static bool TryGetCurrentComparableValue(ISequenceEntity entity, ComparableJsonValue expectedValue, out string normalizedValue) {
+            object? current = entity;
+            string[] propertyPath = expectedValue.DisplayPath.Split('.');
+
+            foreach (string propertyName in propertyPath) {
+                if (current == null) {
+                    normalizedValue = NormalizeNull();
+                    return true;
+                }
+
+                PropertyInfo? property = current.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+                    ?? current.GetType().GetProperty(GetPublicPropertyNameForLegacyField(propertyName), BindingFlags.Instance | BindingFlags.Public);
+                if (property == null || property.GetIndexParameters().Length > 0) {
+                    normalizedValue = string.Empty;
+                    return false;
+                }
+
+                current = property.GetValue(current);
+            }
+
+            return TryNormalizeObject(current, out normalizedValue);
+        }
+
+        /// <summary>
+        /// Maps legacy serialized private backing fields such as _name onto their current public property names.
+        /// </summary>
+        private static string GetPublicPropertyNameForLegacyField(string propertyName) {
+            return propertyName.Length > 1 && propertyName[0] == '_'
+                ? $"{char.ToUpperInvariant(propertyName[1])}{propertyName[2..]}"
+                : propertyName;
+        }
+
+        /// <summary>
+        /// Normalizes legacy JSON scalar values to type-tagged strings for culture-stable equality checks.
+        /// </summary>
+        private static bool TryNormalizeJValue(JValue value, out string normalized) {
+            if (value.Type == JTokenType.Null) {
+                normalized = NormalizeNull();
+                return true;
+            }
+
+            if (value.Type == JTokenType.Integer || value.Type == JTokenType.Float) {
+                normalized = NormalizeNumber(Convert.ToDouble(value.Value, CultureInfo.InvariantCulture));
+                return true;
+            }
+
+            if (value.Type == JTokenType.Boolean) {
+                normalized = $"Boolean:{value.Value<bool>()}";
+                return true;
+            }
+
+            if (value.Type == JTokenType.String) {
+                string? stringValue = value.Value<string>();
+                normalized = Guid.TryParse(stringValue, out Guid guid)
+                    ? NormalizeGuid(guid)
+                    : $"String:{stringValue}";
+                return true;
+            }
+
+            normalized = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Normalizes current object property values to the same type-tagged representation used for legacy JSON.
+        /// </summary>
+        private static bool TryNormalizeObject(object? value, out string normalized) {
+            if (value == null) {
+                normalized = NormalizeNull();
+                return true;
+            }
+
+            Type type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+            if (type.IsEnum) {
+                normalized = NormalizeNumber(Convert.ToDouble(value, CultureInfo.InvariantCulture));
+                return true;
+            }
+
+            if (type == typeof(string)) {
+                normalized = $"String:{value}";
+                return true;
+            }
+
+            if (type == typeof(Guid)) {
+                normalized = NormalizeGuid((Guid)value);
+                return true;
+            }
+
+            if (type == typeof(bool)) {
+                normalized = $"Boolean:{value}";
+                return true;
+            }
+
+            if (type == typeof(byte) ||
+                    type == typeof(sbyte) ||
+                    type == typeof(short) ||
+                    type == typeof(ushort) ||
+                    type == typeof(int) ||
+                    type == typeof(uint) ||
+                    type == typeof(long) ||
+                    type == typeof(ulong) ||
+                    type == typeof(float) ||
+                    type == typeof(double) ||
+                    type == typeof(decimal)) {
+                normalized = NormalizeNumber(Convert.ToDouble(value, CultureInfo.InvariantCulture));
+                return true;
+            }
+
+            if (type == typeof(TimeSpan)) {
+                normalized = $"TimeSpan:{((TimeSpan)value).Ticks}";
+                return true;
+            }
+
+            if (type == typeof(DateTime)) {
+                normalized = $"DateTime:{((DateTime)value).ToString("O", CultureInfo.InvariantCulture)}";
+                return true;
+            }
+
+            normalized = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Produces the shared sentinel used when legacy and current values are both null.
+        /// </summary>
+        private static string NormalizeNull() {
+            return "<null>";
+        }
+
+        /// <summary>
+        /// Formats numbers with full precision and invariant culture so value comparisons are not locale-dependent.
+        /// </summary>
+        private static string NormalizeNumber(double value) {
+            return $"Number:{value.ToString("G17", CultureInfo.InvariantCulture)}";
+        }
+
+        /// <summary>
+        /// Formats GUIDs consistently because legacy JSON stores them as strings while current properties may expose Guid.
+        /// </summary>
+        private static string NormalizeGuid(Guid value) {
+            return $"Guid:{value:D}";
+        }
+
+        /// <summary>
+        /// Fails the test when a legacy entity fell back to an unknown placeholder instead of a current sequencer type.
+        /// </summary>
+        private static void AssertNoUnknownEntities(IEnumerable<EntityNode> nodes, string because) {
+            nodes
+                .Where(x => x.Entity.GetType().Name.StartsWith("UnknownSequence", StringComparison.Ordinal))
+                .Select(x => $"{x.Path}: {x.Entity.GetType().FullName} ({x.Entity.Name})")
+                .Should()
+                .BeEmpty(because);
+        }
+
+        /// <summary>
+        /// Checks the known populated SwitchFilter case because it exercises filter lookup and symbol-definition migration.
+        /// </summary>
+        private static void AssertPopulatedSwitchFilterWasMigrated(IReadOnlyList<EntityNode> nodes) {
+            SwitchFilter switchFilter = nodes
+                .Single(x => x.Path == "$.Items[1].Items[22]")
+                .Entity
+                .Should()
+                .BeOfType<SwitchFilter>()
+                .Subject;
+
+            switchFilter.ComboBoxText.Should().Be("Green");
+            switchFilter.Filter.Name.Should().Be("Green");
+            switchFilter.Filter.Position.Should().Be(2);
+        }
+
+        /// <summary>
+        /// Captures the migrated entity structure so current-version serialization can be checked for type/path stability.
+        /// </summary>
+        private static IReadOnlyList<string> CreateEntityTypeDigest(IEnumerable<EntityNode> nodes) {
+            return nodes
+                .Select(node => $"{node.Path}:Type={node.Entity.GetType().FullName}")
+                .ToList();
+        }
+
+        private sealed record LegacyCorpusFile(string ManifestPath, string SequencePath);
+
+        private sealed record JsonEntityNode(string Path, JObject Json);
+
+        private sealed record EntityNode(string Path, ISequenceEntity Entity);
+
+        private sealed record ComparableJsonValue(string PropertyName, string DisplayPath, string NormalizedValue);
+
+        private sealed record ExpressionExpectation(string ExpressionPropertyName, string SourcePath, double? NumericValue, string? StringValue);
+
+        private sealed class LegacyManifest {
+            public string SourceBranch { get; set; } = string.Empty;
+            public string SourceCommit { get; set; } = string.Empty;
+            public string GeneratedBy { get; set; } = string.Empty;
+            public string SequenceFile { get; set; } = string.Empty;
+            public IList<string> Items { get; set; } = new List<string>();
+            public IList<string> Conditions { get; set; } = new List<string>();
+            public IList<string> Triggers { get; set; } = new List<string>();
+            public IList<string> Containers { get; set; } = new List<string>();
+            public IList<ManifestEntity> Entities { get; set; } = new List<ManifestEntity>();
+        }
+
+        private sealed class ManifestEntity {
+            public string Kind { get; set; } = string.Empty;
+            public string Variant { get; set; } = string.Empty;
+            public string Type { get; set; } = string.Empty;
+            public string Name { get; set; } = string.Empty;
+        }
+
+        private sealed class CurrentSequencerCatalog : IDisposable {
+            private readonly CompositionContainer container;
+            private readonly NINA.Profile.Profile profile;
+
+            /// <summary>
+            /// Keeps the MEF container and profile alive for the duration of a corpus import and exposes the factory under test.
+            /// </summary>
+            private CurrentSequencerCatalog(CompositionContainer container, NINA.Profile.Profile profile, ISequencerFactory factory) {
+                this.container = container;
+                this.profile = profile;
+                Factory = factory;
+            }
+
+            public ISequencerFactory Factory { get; }
+
+            /// <summary>
+            /// Builds the current sequencer catalog with representative mocked services so legacy entities deserialize normally.
+            /// </summary>
+            public static CurrentSequencerCatalog Create() {
+                NINA.Profile.Profile profile = new NINA.Profile.Profile();
+                profile.FilterWheelSettings.FilterWheelFilters = new ObserveAllCollection<FilterInfo> {
+                    new FilterInfo("Red", 0, 1),
+                    new FilterInfo("Green", 0, 2),
+                    new FilterInfo("Blue", 0, 3)
+                };
+
+                Mock<IProfileService> profileService = new Mock<IProfileService>();
+                profileService.SetupGet(x => x.ActiveProfile).Returns(profile);
+                profileService.SetupGet(x => x.Profiles).Returns(new AsyncObservableCollection<ProfileMeta> {
+                    new ProfileMeta {
+                        Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                        Name = "Legacy Profile",
+                        Description = "Generated corpus profile",
+                        LastUsed = new DateTime(2024, 1, 2, 3, 4, 5),
+                        IsActive = true
+                    }
+                });
+
+                Mock<ICameraMediator> cameraMediator = new Mock<ICameraMediator>();
+                cameraMediator.Setup(x => x.GetInfo()).Returns(new CameraInfo {
+                    Connected = false,
+                    CanSetTemperature = true,
+                    XSize = 8000,
+                    YSize = 6000,
+                    CanSetGain = true,
+                    GainMin = 0,
+                    GainMax = 300,
+                    CanSetOffset = true,
+                    OffsetMin = 0,
+                    OffsetMax = 100,
+                    BinningModes = new AsyncObservableCollection<BinningMode> {
+                        new BinningMode(1, 1),
+                        new BinningMode(2, 2)
+                    },
+                    ReadoutModes = new AsyncObservableCollection<string> {
+                        "Default",
+                        "High Gain"
+                    }
+                });
+
+                Mock<IFilterWheelMediator> filterWheelMediator = new Mock<IFilterWheelMediator>();
+                filterWheelMediator.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo {
+                    Connected = false,
+                    SelectedFilter = profile.FilterWheelSettings.FilterWheelFilters[1]
+                });
+
+                Mock<ITelescopeMediator> telescopeMediator = new Mock<ITelescopeMediator>();
+                telescopeMediator.Setup(x => x.GetInfo()).Returns(new TelescopeInfo { Connected = false });
+
+                Mock<IFocuserMediator> focuserMediator = new Mock<IFocuserMediator>();
+                focuserMediator.Setup(x => x.GetInfo()).Returns(new FocuserInfo { Connected = false });
+
+                Mock<IGuiderMediator> guiderMediator = new Mock<IGuiderMediator>();
+                guiderMediator.Setup(x => x.GetInfo()).Returns(new GuiderInfo { Connected = false });
+
+                Mock<IRotatorMediator> rotatorMediator = new Mock<IRotatorMediator>();
+                rotatorMediator.Setup(x => x.GetInfo()).Returns(new RotatorInfo { Connected = false });
+
+                Mock<IFlatDeviceMediator> flatDeviceMediator = new Mock<IFlatDeviceMediator>();
+                flatDeviceMediator.Setup(x => x.GetInfo()).Returns(new FlatDeviceInfo { Connected = false });
+
+                Mock<IWeatherDataMediator> weatherDataMediator = new Mock<IWeatherDataMediator>();
+                weatherDataMediator.Setup(x => x.GetInfo()).Returns(new WeatherDataInfo { Connected = false });
+
+                Mock<IDomeMediator> domeMediator = new Mock<IDomeMediator>();
+                domeMediator.Setup(x => x.GetInfo()).Returns(new DomeInfo { Connected = false });
+
+                Mock<ISwitchMediator> switchMediator = new Mock<ISwitchMediator>();
+                switchMediator.Setup(x => x.GetInfo()).Returns(new SwitchInfo { Connected = false });
+
+                Mock<ISafetyMonitorMediator> safetyMonitorMediator = new Mock<ISafetyMonitorMediator>();
+                safetyMonitorMediator.Setup(x => x.GetInfo()).Returns(new SafetyMonitorInfo { Connected = false });
+
+                Mock<INighttimeCalculator> nighttimeCalculator = new Mock<INighttimeCalculator>();
+                IList<IDateTimeProvider> dateTimeProviders = new List<IDateTimeProvider> {
+                    new NINA.Sequencer.Utility.DateTimeProvider.TimeProvider(nighttimeCalculator.Object),
+                    new SunsetProvider(nighttimeCalculator.Object),
+                    new CivilDuskProvider(nighttimeCalculator.Object),
+                    new NauticalDuskProvider(nighttimeCalculator.Object),
+                    new DuskProvider(nighttimeCalculator.Object),
+                    new DawnProvider(nighttimeCalculator.Object),
+                    new NauticalDawnProvider(nighttimeCalculator.Object),
+                    new CivilDawnProvider(nighttimeCalculator.Object),
+                    new SunriseProvider(nighttimeCalculator.Object),
+                    new MeridianProvider(profileService.Object)
+                };
+
+                Mock<IApplicationResourceDictionary> resourceDictionary = new Mock<IApplicationResourceDictionary>();
+                resourceDictionary.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+
+                CompositionContainer container = new CompositionContainer(
+                    new AssemblyCatalog(typeof(ISequenceItem).Assembly),
+                    CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe);
+                container.ComposeExportedValue<IProfileService>(profileService.Object);
+                container.ComposeExportedValue<ICameraMediator>(cameraMediator.Object);
+                container.ComposeExportedValue<ITelescopeMediator>(telescopeMediator.Object);
+                container.ComposeExportedValue<IFocuserMediator>(focuserMediator.Object);
+                container.ComposeExportedValue<IFilterWheelMediator>(filterWheelMediator.Object);
+                container.ComposeExportedValue<IGuiderMediator>(guiderMediator.Object);
+                container.ComposeExportedValue<IRotatorMediator>(rotatorMediator.Object);
+                container.ComposeExportedValue<IFlatDeviceMediator>(flatDeviceMediator.Object);
+                container.ComposeExportedValue<IWeatherDataMediator>(weatherDataMediator.Object);
+                container.ComposeExportedValue<IImagingMediator>(Mock.Of<IImagingMediator>());
+                container.ComposeExportedValue<IApplicationStatusMediator>(Mock.Of<IApplicationStatusMediator>());
+                container.ComposeExportedValue<INighttimeCalculator>(nighttimeCalculator.Object);
+                container.ComposeExportedValue<IPlanetariumFactory>(Mock.Of<IPlanetariumFactory>());
+                container.ComposeExportedValue<IImageHistoryVM>(Mock.Of<IImageHistoryVM>());
+                container.ComposeExportedValue<IDeepSkyObjectSearchVM>(Mock.Of<IDeepSkyObjectSearchVM>());
+                container.ComposeExportedValue<IDomeMediator>(domeMediator.Object);
+                container.ComposeExportedValue<IImageSaveMediator>(Mock.Of<IImageSaveMediator>());
+                container.ComposeExportedValue<ISwitchMediator>(switchMediator.Object);
+                container.ComposeExportedValue<IApplicationResourceDictionary>(resourceDictionary.Object);
+                container.ComposeExportedValue<IList<IDateTimeProvider>>(dateTimeProviders);
+                container.ComposeExportedValue<ISafetyMonitorMediator>(safetyMonitorMediator.Object);
+                container.ComposeExportedValue<IApplicationMediator>(Mock.Of<IApplicationMediator>());
+                container.ComposeExportedValue<IFramingAssistantVM>(Mock.Of<IFramingAssistantVM>());
+                container.ComposeExportedValue<IPlateSolverFactory>(Mock.Of<IPlateSolverFactory>());
+                container.ComposeExportedValue<IWindowServiceFactory>(Mock.Of<IWindowServiceFactory>());
+                container.ComposeExportedValue<IDomeFollower>(Mock.Of<IDomeFollower>());
+                container.ComposeExportedValue<IPluggableBehaviorSelector<IStarDetection>>(Mock.Of<IPluggableBehaviorSelector<IStarDetection>>());
+                container.ComposeExportedValue<IPluggableBehaviorSelector<IStarAnnotator>>(Mock.Of<IPluggableBehaviorSelector<IStarAnnotator>>());
+                container.ComposeExportedValue<IImageDataFactory>(Mock.Of<IImageDataFactory>());
+                container.ComposeExportedValue<IAutoFocusVMFactory>(Mock.Of<IAutoFocusVMFactory>());
+                container.ComposeExportedValue<IMeridianFlipVMFactory>(Mock.Of<IMeridianFlipVMFactory>());
+                container.ComposeExportedValue<IImageControlVM>(Mock.Of<IImageControlVM>());
+                container.ComposeExportedValue<IImageStatisticsVM>(Mock.Of<IImageStatisticsVM>());
+                container.ComposeExportedValue<IDomeSynchronization>(Mock.Of<IDomeSynchronization>());
+                container.ComposeExportedValue<ISequenceMediator>(Mock.Of<ISequenceMediator>());
+                container.ComposeExportedValue<IOptionsVM>(Mock.Of<IOptionsVM>());
+                container.ComposeExportedValue<IExposureDataFactory>(Mock.Of<IExposureDataFactory>());
+                container.ComposeExportedValue<ITwilightCalculator>(Mock.Of<ITwilightCalculator>());
+                container.ComposeExportedValue<IMessageBroker>(Mock.Of<IMessageBroker>());
+                container.ComposeExportedValue<ISymbolBroker>(Mock.Of<ISymbolBroker>());
+
+                IList<ISequenceItem> items = container.GetExports<ISequenceItem, IDictionary<string, object>>().Select(x => x.Value).ToList();
+                IList<ISequenceCondition> conditions = container.GetExports<ISequenceCondition, IDictionary<string, object>>().Select(x => x.Value).ToList();
+                IList<ISequenceTrigger> triggers = container.GetExports<ISequenceTrigger, IDictionary<string, object>>().Select(x => x.Value).ToList();
+                IList<ISequenceContainer> containers = container.GetExports<ISequenceContainer, IDictionary<string, object>>().Select(x => x.Value).ToList();
+                IList<ISequenceEntityUpgrader> upgraders = container.GetExports<ISequenceEntityUpgrader, IDictionary<string, object>>().Select(x => x.Value).ToList();
+
+                return new CurrentSequencerCatalog(
+                    container,
+                    profile,
+                    new CorpusSequencerFactory(items, conditions, triggers, containers, dateTimeProviders, upgraders));
+            }
+
+            /// <summary>
+            /// Releases the composed catalog resources after the migration test has finished importing the corpus.
+            /// </summary>
+            public void Dispose() {
+                container.Dispose();
+                profile.Dispose();
+            }
+        }
+
+        private sealed class CorpusSequencerFactory : ISequencerFactory {
+            /// <summary>
+            /// Provides the factory surface SequenceJsonConverter needs while keeping the test catalog limited to MEF exports.
+            /// </summary>
+            public CorpusSequencerFactory(
+                    IList<ISequenceItem> items,
+                    IList<ISequenceCondition> conditions,
+                    IList<ISequenceTrigger> triggers,
+                    IList<ISequenceContainer> containers,
+                    IList<IDateTimeProvider> dateTimeProviders,
+                    IList<ISequenceEntityUpgrader> upgraders
+            ) {
+                Items = items;
+                Conditions = conditions;
+                Triggers = triggers;
+                Container = containers;
+                DateTimeProviders = dateTimeProviders;
+                Upgraders = upgraders;
+            }
+
+            public IList<ISequenceCondition> Conditions { get; }
+            public IList<ISequenceContainer> Container { get; }
+            public IList<ISequenceItem> Items { get; }
+            public ICollectionView ItemsView => null!;
+            public ICollectionView InstructionsView => null!;
+            public ICollectionView ConditionsView => null!;
+            public ICollectionView TriggersView => null!;
+            public IList<ISequenceTrigger> Triggers { get; }
+            public IList<IDateTimeProvider> DateTimeProviders { get; }
+            public IList<ISequenceEntityUpgrader> Upgraders { get; }
+            public string ViewFilter { get; set; } = string.Empty;
+
+            /// <summary>
+            /// Returns a clone of the requested condition prototype so deserialization uses current entity construction rules.
+            /// </summary>
+            public T GetCondition<T>() where T : ISequenceCondition {
+                return (T?)Conditions.FirstOrDefault(x => x.GetType() == typeof(T))?.Clone() ?? default!;
+            }
+
+            /// <summary>
+            /// Returns a clone of the requested container prototype so deserialization uses current entity construction rules.
+            /// </summary>
+            public T GetContainer<T>() where T : ISequenceContainer {
+                return (T?)Container.FirstOrDefault(x => x.GetType() == typeof(T))?.Clone() ?? default!;
+            }
+
+            /// <summary>
+            /// Returns a clone of the requested item prototype so deserialization uses current entity construction rules.
+            /// </summary>
+            public T GetItem<T>() where T : ISequenceItem {
+                return (T?)Items.FirstOrDefault(x => x.GetType() == typeof(T))?.Clone() ?? default!;
+            }
+
+            /// <summary>
+            /// Returns a clone of the requested trigger prototype so deserialization uses current entity construction rules.
+            /// </summary>
+            public T GetTrigger<T>() where T : ISequenceTrigger {
+                return (T?)Triggers.FirstOrDefault(x => x.GetType() == typeof(T))?.Clone() ?? default!;
+            }
+        }
+    }
+}

--- a/NINA.Test/Sequencer/Serialization/LegacySequences/README.md
+++ b/NINA.Test/Sequencer/Serialization/LegacySequences/README.md
@@ -1,0 +1,7 @@
+# Legacy Sequence Migration Corpus
+
+This folder contains immutable sequence JSON generated from released `master` branches. The files are not examples for users and should not be hand-edited.
+
+`v3.2/master-3.2-all-sequence-entities.sequence.json` was generated from `master` commit `2393eae581145ed5b8114bf07c48ca2580540fd5`. It includes every built-in sequencer item, condition, trigger, and container export discovered by the 3.2 sequencer assembly. For each exported entity the corpus keeps a default instance and a populated scalar-value instance when the entity is not the root container.
+
+The paired manifest records the source branch, source commit, entity export lists, and the concrete default/populated variants in the sequence file. Treat these JSON files as golden old-version inputs: regenerate them only from the original release branch when intentionally adding a new legacy corpus version.

--- a/NINA.Test/Sequencer/Serialization/LegacySequences/v3.2/master-3.2-all-sequence-entities.manifest.json
+++ b/NINA.Test/Sequencer/Serialization/LegacySequences/v3.2/master-3.2-all-sequence-entities.manifest.json
@@ -1,0 +1,1317 @@
+{
+  "SourceBranch": "master",
+  "SourceCommit": "2393eae581145ed5b8114bf07c48ca2580540fd5",
+  "GeneratedBy": "LegacySequenceCorpusGenerator",
+  "SequenceFile": "master-3.2-all-sequence-entities.sequence.json",
+  "Items": [
+    "NINA.Sequencer.Container.DeepSkyObjectContainer",
+    "NINA.Sequencer.Container.ParallelContainer",
+    "NINA.Sequencer.Container.SequentialContainer",
+    "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus",
+    "NINA.Sequencer.SequenceItem.Camera.CoolCamera",
+    "NINA.Sequencer.SequenceItem.Camera.DewHeater",
+    "NINA.Sequencer.SequenceItem.Camera.SetReadoutMode",
+    "NINA.Sequencer.SequenceItem.Camera.SetUSBLimit",
+    "NINA.Sequencer.SequenceItem.Camera.WarmCamera",
+    "NINA.Sequencer.SequenceItem.Connect.ConnectAllEquipment",
+    "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment",
+    "NINA.Sequencer.SequenceItem.Connect.DisconnectAllEquipment",
+    "NINA.Sequencer.SequenceItem.Connect.DisconnectEquipment",
+    "NINA.Sequencer.SequenceItem.Connect.SwitchProfile",
+    "NINA.Sequencer.SequenceItem.Dome.CloseDomeShutter",
+    "NINA.Sequencer.SequenceItem.Dome.DisableDomeSynchronization",
+    "NINA.Sequencer.SequenceItem.Dome.EnableDomeSynchronization",
+    "NINA.Sequencer.SequenceItem.Dome.FindHomeDome",
+    "NINA.Sequencer.SequenceItem.Dome.OpenDomeShutter",
+    "NINA.Sequencer.SequenceItem.Dome.ParkDome",
+    "NINA.Sequencer.SequenceItem.Dome.SlewDomeAzimuth",
+    "NINA.Sequencer.SequenceItem.Dome.SynchronizeDome",
+    "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter",
+    "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover",
+    "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover",
+    "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness",
+    "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight",
+    "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+    "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+    "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserAbsolute",
+    "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserByTemperature",
+    "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserRelative",
+    "NINA.Sequencer.SequenceItem.Guider.Dither",
+    "NINA.Sequencer.SequenceItem.Guider.StartGuiding",
+    "NINA.Sequencer.SequenceItem.Guider.StopGuiding",
+    "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+    "NINA.Sequencer.SequenceItem.Imaging.TakeExposure",
+    "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures",
+    "NINA.Sequencer.SequenceItem.Imaging.TakeSubframeExposure",
+    "NINA.Sequencer.SequenceItem.Platesolving.Center",
+    "NINA.Sequencer.SequenceItem.Platesolving.CenterAndRotate",
+    "NINA.Sequencer.SequenceItem.Platesolving.SolveAndRotate",
+    "NINA.Sequencer.SequenceItem.Platesolving.SolveAndSync",
+    "NINA.Sequencer.SequenceItem.Rotator.MoveRotatorMechanical",
+    "NINA.Sequencer.SequenceItem.SafetyMonitor.WaitUntilSafe",
+    "NINA.Sequencer.SequenceItem.Switch.SetSwitchValue",
+    "NINA.Sequencer.SequenceItem.Telescope.FindHome",
+    "NINA.Sequencer.SequenceItem.Telescope.ParkScope",
+    "NINA.Sequencer.SequenceItem.Telescope.SetTracking",
+    "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToAltAz",
+    "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToRaDec",
+    "NINA.Sequencer.SequenceItem.Telescope.UnparkScope",
+    "NINA.Sequencer.SequenceItem.Utility.Annotation",
+    "NINA.Sequencer.SequenceItem.Utility.ExternalScript",
+    "NINA.Sequencer.SequenceItem.Utility.MessageBox",
+    "NINA.Sequencer.SequenceItem.Utility.SaveSequence",
+    "NINA.Sequencer.SequenceItem.Utility.WaitForAltitude",
+    "NINA.Sequencer.SequenceItem.Utility.WaitForMoonAltitude",
+    "NINA.Sequencer.SequenceItem.Utility.WaitForSunAltitude",
+    "NINA.Sequencer.SequenceItem.Utility.WaitForTime",
+    "NINA.Sequencer.SequenceItem.Utility.WaitForTimeSpan",
+    "NINA.Sequencer.SequenceItem.Utility.WaitUntilAboveHorizon"
+  ],
+  "Conditions": [
+    "NINA.Sequencer.Conditions.AboveHorizonCondition",
+    "NINA.Sequencer.Conditions.AltitudeCondition",
+    "NINA.Sequencer.Conditions.LoopCondition",
+    "NINA.Sequencer.Conditions.LoopWhileUnsafe",
+    "NINA.Sequencer.Conditions.MoonAltitudeCondition",
+    "NINA.Sequencer.Conditions.MoonIlluminationCondition",
+    "NINA.Sequencer.Conditions.SafetyMonitorCondition",
+    "NINA.Sequencer.Conditions.SunAltitudeCondition",
+    "NINA.Sequencer.Conditions.TimeCondition",
+    "NINA.Sequencer.Conditions.TimeSpanCondition"
+  ],
+  "Triggers": [
+    "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterExposures",
+    "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterFilterChange",
+    "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger",
+    "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTemperatureChangeTrigger",
+    "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTimeTrigger",
+    "NINA.Sequencer.Trigger.Connect.ReconnectOnDownloadFailure",
+    "NINA.Sequencer.Trigger.Connect.ReconnectTrigger",
+    "NINA.Sequencer.Trigger.Dome.SynchronizeDomeTrigger",
+    "NINA.Sequencer.Trigger.Guider.DitherAfterExposures",
+    "NINA.Sequencer.Trigger.Guider.RestoreGuiding",
+    "NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger",
+    "NINA.Sequencer.Trigger.Platesolving.CenterAfterDriftTrigger"
+  ],
+  "Containers": [
+    "NINA.Sequencer.Container.DeepSkyObjectContainer",
+    "NINA.Sequencer.Container.EndAreaContainer",
+    "NINA.Sequencer.Container.ParallelContainer",
+    "NINA.Sequencer.Container.SequenceRootContainer",
+    "NINA.Sequencer.Container.SequentialContainer",
+    "NINA.Sequencer.Container.StartAreaContainer",
+    "NINA.Sequencer.Container.TargetAreaContainer",
+    "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+    "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+    "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+    "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+    "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures"
+  ],
+  "Entities": [
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.DeepSkyObjectContainer",
+      "Name": "Legacy Default Item DeepSkyObjectContainer 001"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.DeepSkyObjectContainer",
+      "Name": "Legacy Name 001"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.ParallelContainer",
+      "Name": "Legacy Default Item ParallelContainer 002"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.ParallelContainer",
+      "Name": "Legacy Name 002"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.SequentialContainer",
+      "Name": "Legacy Default Item SequentialContainer 003"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.SequentialContainer",
+      "Name": "Legacy Name 003"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus",
+      "Name": "Legacy Default Item RunAutofocus 004"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus",
+      "Name": "Legacy Name 004"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.CoolCamera",
+      "Name": "Legacy Default Item CoolCamera 005"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.CoolCamera",
+      "Name": "Legacy Name 005"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.DewHeater",
+      "Name": "Legacy Default Item DewHeater 006"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.DewHeater",
+      "Name": "Legacy Name 006"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.SetReadoutMode",
+      "Name": "Legacy Default Item SetReadoutMode 007"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.SetReadoutMode",
+      "Name": "Legacy Name 007"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.SetUSBLimit",
+      "Name": "Legacy Default Item SetUSBLimit 008"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.SetUSBLimit",
+      "Name": "Legacy Name 008"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.WarmCamera",
+      "Name": "Legacy Default Item WarmCamera 009"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Camera.WarmCamera",
+      "Name": "Legacy Name 009"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.ConnectAllEquipment",
+      "Name": "Legacy Default Item ConnectAllEquipment 010"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.ConnectAllEquipment",
+      "Name": "Legacy Name 010"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment",
+      "Name": "Legacy Default Item ConnectEquipment 011"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment",
+      "Name": "Legacy Name 011"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.DisconnectAllEquipment",
+      "Name": "Legacy Default Item DisconnectAllEquipment 012"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.DisconnectAllEquipment",
+      "Name": "Legacy Name 012"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.DisconnectEquipment",
+      "Name": "Legacy Default Item DisconnectEquipment 013"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.DisconnectEquipment",
+      "Name": "Legacy Name 013"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.SwitchProfile",
+      "Name": "Legacy Default Item SwitchProfile 014"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Connect.SwitchProfile",
+      "Name": "Legacy Name 014"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.CloseDomeShutter",
+      "Name": "Legacy Default Item CloseDomeShutter 015"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.CloseDomeShutter",
+      "Name": "Legacy Name 015"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.DisableDomeSynchronization",
+      "Name": "Legacy Default Item DisableDomeSynchronization 016"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.DisableDomeSynchronization",
+      "Name": "Legacy Name 016"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.EnableDomeSynchronization",
+      "Name": "Legacy Default Item EnableDomeSynchronization 017"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.EnableDomeSynchronization",
+      "Name": "Legacy Name 017"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.FindHomeDome",
+      "Name": "Legacy Default Item FindHomeDome 018"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.FindHomeDome",
+      "Name": "Legacy Name 018"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.OpenDomeShutter",
+      "Name": "Legacy Default Item OpenDomeShutter 019"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.OpenDomeShutter",
+      "Name": "Legacy Name 019"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.ParkDome",
+      "Name": "Legacy Default Item ParkDome 020"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.ParkDome",
+      "Name": "Legacy Name 020"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.SlewDomeAzimuth",
+      "Name": "Legacy Default Item SlewDomeAzimuth 021"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.SlewDomeAzimuth",
+      "Name": "Legacy Name 021"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.SynchronizeDome",
+      "Name": "Legacy Default Item SynchronizeDome 022"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Dome.SynchronizeDome",
+      "Name": "Legacy Name 022"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter",
+      "Name": "Legacy Default Item SwitchFilter 023"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter",
+      "Name": "Legacy Name 023"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+      "Name": "Legacy Default Item AutoBrightnessFlat 024"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+      "Name": "Legacy Name 024"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+      "Name": "Legacy Default Item AutoExposureFlat 025"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+      "Name": "Legacy Name 025"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover",
+      "Name": "Legacy Default Item CloseCover 026"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover",
+      "Name": "Legacy Name 026"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover",
+      "Name": "Legacy Default Item OpenCover 027"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover",
+      "Name": "Legacy Name 027"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness",
+      "Name": "Legacy Default Item SetBrightness 028"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness",
+      "Name": "Legacy Name 028"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+      "Name": "Legacy Default Item SkyFlat 029"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+      "Name": "Legacy Name 029"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight",
+      "Name": "Legacy Default Item ToggleLight 030"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight",
+      "Name": "Legacy Name 030"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+      "Name": "Legacy Default Item TrainedDarkFlatExposure 031"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+      "Name": "Legacy Name 031"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+      "Name": "Legacy Default Item TrainedFlatExposure 032"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+      "Name": "Legacy Name 032"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserAbsolute",
+      "Name": "Legacy Default Item MoveFocuserAbsolute 033"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserAbsolute",
+      "Name": "Legacy Name 033"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserByTemperature",
+      "Name": "Legacy Default Item MoveFocuserByTemperature 034"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserByTemperature",
+      "Name": "Legacy Name 034"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserRelative",
+      "Name": "Legacy Default Item MoveFocuserRelative 035"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserRelative",
+      "Name": "Legacy Name 035"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.Dither",
+      "Name": "Legacy Default Item Dither 036"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.Dither",
+      "Name": "Legacy Name 036"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding",
+      "Name": "Legacy Default Item StartGuiding 037"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding",
+      "Name": "Legacy Name 037"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.StopGuiding",
+      "Name": "Legacy Default Item StopGuiding 038"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Guider.StopGuiding",
+      "Name": "Legacy Name 038"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+      "Name": "Legacy Default Item SmartExposure 039"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+      "Name": "Legacy Name 039"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure",
+      "Name": "Legacy Default Item TakeExposure 040"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure",
+      "Name": "Legacy Name 040"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures",
+      "Name": "Legacy Default Item TakeManyExposures 041"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures",
+      "Name": "Legacy Name 041"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeSubframeExposure",
+      "Name": "Legacy Default Item TakeSubframeExposure 042"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeSubframeExposure",
+      "Name": "Legacy Name 042"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.Center",
+      "Name": "Legacy Default Item Center 043"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.Center",
+      "Name": "Legacy Name 043"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.CenterAndRotate",
+      "Name": "Legacy Default Item CenterAndRotate 044"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.CenterAndRotate",
+      "Name": "Legacy Name 044"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndRotate",
+      "Name": "Legacy Default Item SolveAndRotate 045"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndRotate",
+      "Name": "Legacy Name 045"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndSync",
+      "Name": "Legacy Default Item SolveAndSync 046"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndSync",
+      "Name": "Legacy Name 046"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Rotator.MoveRotatorMechanical",
+      "Name": "Legacy Default Item MoveRotatorMechanical 047"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Rotator.MoveRotatorMechanical",
+      "Name": "Legacy Name 047"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.SafetyMonitor.WaitUntilSafe",
+      "Name": "Legacy Default Item WaitUntilSafe 048"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.SafetyMonitor.WaitUntilSafe",
+      "Name": "Legacy Name 048"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Switch.SetSwitchValue",
+      "Name": "Legacy Default Item SetSwitchValue 049"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Switch.SetSwitchValue",
+      "Name": "Legacy Name 049"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.FindHome",
+      "Name": "Legacy Default Item FindHome 050"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.FindHome",
+      "Name": "Legacy Name 050"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.ParkScope",
+      "Name": "Legacy Default Item ParkScope 051"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.ParkScope",
+      "Name": "Legacy Name 051"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SetTracking",
+      "Name": "Legacy Default Item SetTracking 052"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SetTracking",
+      "Name": "Legacy Name 052"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToAltAz",
+      "Name": "Legacy Default Item SlewScopeToAltAz 053"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToAltAz",
+      "Name": "Legacy Name 053"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToRaDec",
+      "Name": "Legacy Default Item SlewScopeToRaDec 054"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToRaDec",
+      "Name": "Legacy Name 054"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.UnparkScope",
+      "Name": "Legacy Default Item UnparkScope 055"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Telescope.UnparkScope",
+      "Name": "Legacy Name 055"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.Annotation",
+      "Name": "Legacy Default Item Annotation 056"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.Annotation",
+      "Name": "Legacy Name 056"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.ExternalScript",
+      "Name": "Legacy Default Item ExternalScript 057"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.ExternalScript",
+      "Name": "Legacy Name 057"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.MessageBox",
+      "Name": "Legacy Default Item MessageBox 058"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.MessageBox",
+      "Name": "Legacy Name 058"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.SaveSequence",
+      "Name": "Legacy Default Item SaveSequence 059"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.SaveSequence",
+      "Name": "Legacy Name 059"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForAltitude",
+      "Name": "Legacy Default Item WaitForAltitude 060"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForAltitude",
+      "Name": "Legacy Name 060"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForMoonAltitude",
+      "Name": "Legacy Default Item WaitForMoonAltitude 061"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForMoonAltitude",
+      "Name": "Legacy Name 061"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForSunAltitude",
+      "Name": "Legacy Default Item WaitForSunAltitude 062"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForSunAltitude",
+      "Name": "Legacy Name 062"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForTime",
+      "Name": "Legacy Default Item WaitForTime 063"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForTime",
+      "Name": "Legacy Name 063"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForTimeSpan",
+      "Name": "Legacy Default Item WaitForTimeSpan 064"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitForTimeSpan",
+      "Name": "Legacy Name 064"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitUntilAboveHorizon",
+      "Name": "Legacy Default Item WaitUntilAboveHorizon 065"
+    },
+    {
+      "Kind": "Item",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Utility.WaitUntilAboveHorizon",
+      "Name": "Legacy Name 065"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.AboveHorizonCondition",
+      "Name": "Legacy Default Condition AboveHorizonCondition 066"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.AboveHorizonCondition",
+      "Name": "Legacy Name 066"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.AltitudeCondition",
+      "Name": "Legacy Default Condition AltitudeCondition 067"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.AltitudeCondition",
+      "Name": "Legacy Name 067"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.LoopCondition",
+      "Name": "Legacy Default Condition LoopCondition 068"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.LoopCondition",
+      "Name": "Legacy Name 068"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.LoopWhileUnsafe",
+      "Name": "Legacy Default Condition LoopWhileUnsafe 069"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.LoopWhileUnsafe",
+      "Name": "Legacy Name 069"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.MoonAltitudeCondition",
+      "Name": "Legacy Default Condition MoonAltitudeCondition 070"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.MoonAltitudeCondition",
+      "Name": "Legacy Name 070"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.MoonIlluminationCondition",
+      "Name": "Legacy Default Condition MoonIlluminationCondition 071"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.MoonIlluminationCondition",
+      "Name": "Legacy Name 071"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.SafetyMonitorCondition",
+      "Name": "Legacy Default Condition SafetyMonitorCondition 072"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.SafetyMonitorCondition",
+      "Name": "Legacy Name 072"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.SunAltitudeCondition",
+      "Name": "Legacy Default Condition SunAltitudeCondition 073"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.SunAltitudeCondition",
+      "Name": "Legacy Name 073"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.TimeCondition",
+      "Name": "Legacy Default Condition TimeCondition 074"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.TimeCondition",
+      "Name": "Legacy Name 074"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Conditions.TimeSpanCondition",
+      "Name": "Legacy Default Condition TimeSpanCondition 075"
+    },
+    {
+      "Kind": "Condition",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Conditions.TimeSpanCondition",
+      "Name": "Legacy Name 075"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterExposures",
+      "Name": "Legacy Default Trigger AutofocusAfterExposures 076"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterExposures",
+      "Name": "Legacy Name 076"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterFilterChange",
+      "Name": "Legacy Default Trigger AutofocusAfterFilterChange 077"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterFilterChange",
+      "Name": "Legacy Name 077"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger",
+      "Name": "Legacy Default Trigger AutofocusAfterHFRIncreaseTrigger 078"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger",
+      "Name": "Legacy Name 078"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTemperatureChangeTrigger",
+      "Name": "Legacy Default Trigger AutofocusAfterTemperatureChangeTrigger 079"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTemperatureChangeTrigger",
+      "Name": "Legacy Name 079"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTimeTrigger",
+      "Name": "Legacy Default Trigger AutofocusAfterTimeTrigger 080"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTimeTrigger",
+      "Name": "Legacy Name 080"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Connect.ReconnectOnDownloadFailure",
+      "Name": "Legacy Default Trigger ReconnectOnDownloadFailure 081"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Connect.ReconnectOnDownloadFailure",
+      "Name": "Legacy Name 081"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Connect.ReconnectTrigger",
+      "Name": "Legacy Default Trigger ReconnectTrigger 082"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Connect.ReconnectTrigger",
+      "Name": "Legacy Name 082"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Dome.SynchronizeDomeTrigger",
+      "Name": "Legacy Default Trigger SynchronizeDomeTrigger 083"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Dome.SynchronizeDomeTrigger",
+      "Name": "Legacy Name 083"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures",
+      "Name": "Legacy Default Trigger DitherAfterExposures 084"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures",
+      "Name": "Legacy Name 084"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Guider.RestoreGuiding",
+      "Name": "Legacy Default Trigger RestoreGuiding 085"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Guider.RestoreGuiding",
+      "Name": "Legacy Name 085"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger",
+      "Name": "Legacy Default Trigger MeridianFlipTrigger 086"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger",
+      "Name": "Legacy Name 086"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Trigger.Platesolving.CenterAfterDriftTrigger",
+      "Name": "Legacy Default Trigger CenterAfterDriftTrigger 087"
+    },
+    {
+      "Kind": "Trigger",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Trigger.Platesolving.CenterAfterDriftTrigger",
+      "Name": "Legacy Name 087"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.DeepSkyObjectContainer",
+      "Name": "Legacy Default Container DeepSkyObjectContainer 088"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.DeepSkyObjectContainer",
+      "Name": "Legacy Name 088"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.EndAreaContainer",
+      "Name": "Legacy Default Container EndAreaContainer 089"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.EndAreaContainer",
+      "Name": "Legacy Name 089"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.ParallelContainer",
+      "Name": "Legacy Default Container ParallelContainer 090"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.ParallelContainer",
+      "Name": "Legacy Name 090"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.SequentialContainer",
+      "Name": "Legacy Default Container SequentialContainer 091"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.SequentialContainer",
+      "Name": "Legacy Name 091"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.StartAreaContainer",
+      "Name": "Legacy Default Container StartAreaContainer 092"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.StartAreaContainer",
+      "Name": "Legacy Name 092"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.Container.TargetAreaContainer",
+      "Name": "Legacy Default Container TargetAreaContainer 093"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.Container.TargetAreaContainer",
+      "Name": "Legacy Name 093"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+      "Name": "Legacy Default Container AutoBrightnessFlat 094"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat",
+      "Name": "Legacy Name 094"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+      "Name": "Legacy Default Container AutoExposureFlat 095"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat",
+      "Name": "Legacy Name 095"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+      "Name": "Legacy Default Container SkyFlat 096"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat",
+      "Name": "Legacy Name 096"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+      "Name": "Legacy Default Container TrainedDarkFlatExposure 097"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure",
+      "Name": "Legacy Name 097"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+      "Name": "Legacy Default Container TrainedFlatExposure 098"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure",
+      "Name": "Legacy Name 098"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+      "Name": "Legacy Default Container SmartExposure 099"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure",
+      "Name": "Legacy Name 099"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Default",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures",
+      "Name": "Legacy Default Container TakeManyExposures 100"
+    },
+    {
+      "Kind": "Container",
+      "Variant": "Populated",
+      "Type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures",
+      "Name": "Legacy Name 100"
+    }
+  ]
+}

--- a/NINA.Test/Sequencer/Serialization/LegacySequences/v3.2/master-3.2-all-sequence-entities.sequence.json
+++ b/NINA.Test/Sequencer/Serialization/LegacySequences/v3.2/master-3.2-all-sequence-entities.sequence.json
@@ -1,0 +1,7226 @@
+{
+  "$id": "1",
+  "$type": "NINA.Sequencer.Container.SequenceRootContainer, NINA.Sequencer",
+  "Strategy": {
+    "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+  },
+  "Name": "Legacy Master 3.2 All Sequencer Entities",
+  "Conditions": {
+    "$id": "2",
+    "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+    "$values": []
+  },
+  "IsExpanded": true,
+  "Items": {
+    "$id": "3",
+    "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+    "$values": [
+      {
+        "$id": "4",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Items - master defaults",
+        "Conditions": {
+          "$id": "5",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "6",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "7",
+              "$type": "NINA.Sequencer.Container.DeepSkyObjectContainer, NINA.Sequencer",
+              "Target": {
+                "$id": "8",
+                "$type": "NINA.Astrometry.InputTarget, NINA.Astrometry",
+                "Expanded": true,
+                "TargetName": null,
+                "PositionAngle": 0.0,
+                "InputCoordinates": {
+                  "$id": "9",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                }
+              },
+              "ExposureInfoListExpanded": false,
+              "ExposureInfoList": {
+                "$id": "10",
+                "$type": "NINA.Core.Utility.AsyncObservableCollection`1[[NINA.Sequencer.Utility.ExposureInfo, NINA.Sequencer]], NINA.Core",
+                "$values": []
+              },
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item DeepSkyObjectContainer 001",
+              "Conditions": {
+                "$id": "11",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "12",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "13",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "14",
+              "$type": "NINA.Sequencer.Container.ParallelContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.ParallelStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item ParallelContainer 002",
+              "Conditions": {
+                "$id": "15",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "16",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "17",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "18",
+              "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item SequentialContainer 003",
+              "Conditions": {
+                "$id": "19",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "20",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "21",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "22",
+              "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "23",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.CoolCamera, NINA.Sequencer",
+              "Temperature": 0.0,
+              "Duration": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "24",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.DewHeater, NINA.Sequencer",
+              "OnOff": false,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "25",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.SetReadoutMode, NINA.Sequencer",
+              "Mode": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "26",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.SetUSBLimit, NINA.Sequencer",
+              "USBLimit": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "27",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.WarmCamera, NINA.Sequencer",
+              "Duration": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "28",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectAllEquipment, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "29",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment, NINA.Sequencer",
+              "SelectedDevice": "Camera",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "30",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.DisconnectAllEquipment, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "31",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.DisconnectEquipment, NINA.Sequencer",
+              "SelectedDevice": "Camera",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "32",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.SwitchProfile, NINA.Sequencer",
+              "SelectedProfileId": "11111111-1111-1111-1111-111111111111",
+              "Reconnect": true,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "33",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.CloseDomeShutter, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "34",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.DisableDomeSynchronization, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "35",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.EnableDomeSynchronization, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "36",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.FindHomeDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "37",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.OpenDomeShutter, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "38",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.ParkDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "39",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.SlewDomeAzimuth, NINA.Sequencer",
+              "AzimuthDegrees": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "40",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.SynchronizeDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "41",
+              "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+              "Filter": null,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "42",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "MinBrightness": 20,
+              "MaxBrightness": 100,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item AutoBrightnessFlat 024",
+              "Conditions": {
+                "$id": "43",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "44",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "45",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "46",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "47",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "48",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "49",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "50",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "51",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "49"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "52",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "53",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 1.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "54",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "49"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "55",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "56",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "57",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "42"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "58",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "59",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "MinExposure": 0.0,
+              "MaxExposure": 10.0,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item AutoExposureFlat 025",
+              "Conditions": {
+                "$id": "60",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "61",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "62",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "63",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "64",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "65",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 50,
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "66",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "67",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "68",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "66"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "69",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "70",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "71",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "66"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "72",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "73",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "74",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "59"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "75",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "76",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "77",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "78",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+              "Brightness": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "79",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "MinExposure": 0.0,
+              "MaxExposure": 10.0,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "ShouldDither": false,
+              "DitherPixels": 5.0,
+              "DitherSettleTime": 10.0,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item SkyFlat 029",
+              "Conditions": {
+                "$id": "80",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "81",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "82",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "79"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "83",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "79"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "84",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "79"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "85",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "79"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "86",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "87",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "88",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "86"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "89",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "90",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "91",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "86"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "92",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "79"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "93",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "94",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+              "OnOff": false,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "95",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item TrainedDarkFlatExposure 031",
+              "Conditions": {
+                "$id": "96",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "97",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "98",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "99",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "100",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "101",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "102",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "103",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "104",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "102"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "105",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "106",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "107",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "DARK",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "102"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "108",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "109",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "95"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "110",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "111",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item TrainedFlatExposure 032",
+              "Conditions": {
+                "$id": "112",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "113",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "114",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "115",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "116",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "117",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "118",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "119",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "120",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "118"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "121",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "122",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "123",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "118"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "124",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "125",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "126",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "111"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "127",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "128",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserAbsolute, NINA.Sequencer",
+              "Position": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "129",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserByTemperature, NINA.Sequencer",
+              "Slope": 1.0,
+              "Absolute": true,
+              "Intercept": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "130",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserRelative, NINA.Sequencer",
+              "RelativePosition": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "131",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "132",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding, NINA.Sequencer",
+              "ForceCalibration": false,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "133",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.StopGuiding, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "134",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item SmartExposure 039",
+              "Conditions": {
+                "$id": "135",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "136",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 2,
+                    "Parent": {
+                      "$ref": "134"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "137",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "138",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "134"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "139",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "140",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "134"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "141",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "142",
+                    "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+                    "AfterExposures": 1,
+                    "Parent": {
+                      "$ref": "134"
+                    },
+                    "TriggerRunner": {
+                      "$id": "143",
+                      "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                      "Strategy": {
+                        "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                      },
+                      "Name": null,
+                      "Conditions": {
+                        "$id": "144",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "IsExpanded": true,
+                      "Items": {
+                        "$id": "145",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                        "$values": [
+                          {
+                            "$id": "146",
+                            "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                            "Parent": {
+                              "$ref": "143"
+                            },
+                            "ErrorBehavior": 0,
+                            "Attempts": 1
+                          }
+                        ]
+                      },
+                      "Triggers": {
+                        "$id": "147",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "Parent": null,
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  }
+                ]
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "148",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+              "ExposureTime": 0.0,
+              "Gain": -1,
+              "Offset": -1,
+              "Binning": {
+                "$id": "149",
+                "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                "X": 1,
+                "Y": 1
+              },
+              "ImageType": "LIGHT",
+              "ExposureCount": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "150",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Item TakeManyExposures 041",
+              "Conditions": {
+                "$id": "151",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "152",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 1,
+                    "Parent": {
+                      "$ref": "150"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "153",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "154",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "155",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "150"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "156",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "4"
+              }
+            },
+            {
+              "$id": "157",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeSubframeExposure, NINA.Sequencer",
+              "ROI": 1.0,
+              "ExposureTime": 0.0,
+              "Gain": -1,
+              "Offset": -1,
+              "Binning": {
+                "$id": "158",
+                "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                "X": 1,
+                "Y": 1
+              },
+              "ImageType": "LIGHT",
+              "ExposureCount": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "159",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.Center, NINA.Sequencer",
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "160",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 0,
+                "RAMinutes": 0,
+                "RASeconds": 0.0,
+                "NegativeDec": false,
+                "DecDegrees": 0,
+                "DecMinutes": 0,
+                "DecSeconds": 0.0
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "161",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.CenterAndRotate, NINA.Sequencer",
+              "PositionAngle": 0.0,
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "162",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 0,
+                "RAMinutes": 0,
+                "RASeconds": 0.0,
+                "NegativeDec": false,
+                "DecDegrees": 0,
+                "DecMinutes": 0,
+                "DecSeconds": 0.0
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "163",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndRotate, NINA.Sequencer",
+              "Inherited": false,
+              "PositionAngle": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "164",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndSync, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "165",
+              "$type": "NINA.Sequencer.SequenceItem.Rotator.MoveRotatorMechanical, NINA.Sequencer",
+              "MechanicalPosition": 0.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "166",
+              "$type": "NINA.Sequencer.SequenceItem.SafetyMonitor.WaitUntilSafe, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "167",
+              "$type": "NINA.Sequencer.SequenceItem.Switch.SetSwitchValue, NINA.Sequencer",
+              "Value": 0.0,
+              "SwitchIndex": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "168",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.FindHome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "169",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.ParkScope, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "170",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SetTracking, NINA.Sequencer",
+              "TrackingMode": 0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "171",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToAltAz, NINA.Sequencer",
+              "Coordinates": {
+                "$id": "172",
+                "$type": "NINA.Astrometry.InputTopocentricCoordinates, NINA.Astrometry",
+                "AzDegrees": 0,
+                "AzMinutes": 0,
+                "AzSeconds": 0.0,
+                "AltDegrees": 0,
+                "AltMinutes": 0,
+                "AltSeconds": 0.0
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "173",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToRaDec, NINA.Sequencer",
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "174",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 0,
+                "RAMinutes": 0,
+                "RASeconds": 0.0,
+                "NegativeDec": false,
+                "DecDegrees": 0,
+                "DecMinutes": 0,
+                "DecSeconds": 0.0
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "175",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.UnparkScope, NINA.Sequencer",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "176",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+              "Text": null,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "177",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.ExternalScript, NINA.Sequencer",
+              "Script": null,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "178",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.MessageBox, NINA.Sequencer",
+              "Text": null,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "179",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.SaveSequence, NINA.Sequencer",
+              "FilePath": "",
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "180",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForAltitude, NINA.Sequencer",
+              "AboveOrBelow": ">",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "181",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "182",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 30.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "183",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForMoonAltitude, NINA.Sequencer",
+              "Data": {
+                "$id": "184",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "185",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "186",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForSunAltitude, NINA.Sequencer",
+              "Data": {
+                "$id": "187",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "188",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "189",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForTime, NINA.Sequencer",
+              "Hours": 0,
+              "Minutes": 0,
+              "MinutesOffset": 0,
+              "Seconds": 0,
+              "SelectedProvider": {
+                "$id": "190",
+                "$type": "NINA.Sequencer.Utility.DateTimeProvider.TimeProvider, NINA.Sequencer"
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "191",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForTimeSpan, NINA.Sequencer",
+              "Time": 1.0,
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "192",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitUntilAboveHorizon, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "193",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "194",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "4"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            }
+          ]
+        },
+        "Triggers": {
+          "$id": "195",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "196",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Items - populated scalar values",
+        "Conditions": {
+          "$id": "197",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "198",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "199",
+              "$type": "NINA.Sequencer.Container.DeepSkyObjectContainer, NINA.Sequencer",
+              "Target": {
+                "$id": "200",
+                "$type": "NINA.Astrometry.InputTarget, NINA.Astrometry",
+                "Expanded": true,
+                "TargetName": null,
+                "PositionAngle": 0.0,
+                "InputCoordinates": {
+                  "$id": "201",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                }
+              },
+              "ExposureInfoListExpanded": true,
+              "ExposureInfoList": {
+                "$id": "202",
+                "$type": "NINA.Core.Utility.AsyncObservableCollection`1[[NINA.Sequencer.Utility.ExposureInfo, NINA.Sequencer]], NINA.Core",
+                "$values": []
+              },
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 001",
+              "Conditions": {
+                "$id": "203",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "204",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "205",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "206",
+              "$type": "NINA.Sequencer.Container.ParallelContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.ParallelStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 002",
+              "Conditions": {
+                "$id": "207",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "208",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "209",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "210",
+              "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 003",
+              "Conditions": {
+                "$id": "211",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "212",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "213",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "214",
+              "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "215",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.CoolCamera, NINA.Sequencer",
+              "Temperature": -12.5,
+              "Duration": 4.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "216",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.DewHeater, NINA.Sequencer",
+              "OnOff": true,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "217",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.SetReadoutMode, NINA.Sequencer",
+              "Mode": 4,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "218",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.SetUSBLimit, NINA.Sequencer",
+              "USBLimit": 2,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "219",
+              "$type": "NINA.Sequencer.SequenceItem.Camera.WarmCamera, NINA.Sequencer",
+              "Duration": 4.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "220",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectAllEquipment, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "221",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment, NINA.Sequencer",
+              "SelectedDevice": "Legacy SelectedDevice 011",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "222",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.DisconnectAllEquipment, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "223",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.DisconnectEquipment, NINA.Sequencer",
+              "SelectedDevice": "Legacy SelectedDevice 013",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "224",
+              "$type": "NINA.Sequencer.SequenceItem.Connect.SwitchProfile, NINA.Sequencer",
+              "SelectedProfileId": "11111111-1111-1111-1111-111111111111",
+              "Reconnect": true,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "225",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.CloseDomeShutter, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "226",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.DisableDomeSynchronization, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "227",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.EnableDomeSynchronization, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "228",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.FindHomeDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "229",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.OpenDomeShutter, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "230",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.ParkDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "231",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.SlewDomeAzimuth, NINA.Sequencer",
+              "AzimuthDegrees": 123.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "232",
+              "$type": "NINA.Sequencer.SequenceItem.Dome.SynchronizeDome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "233",
+              "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+              "Filter": {
+                "$id": "234",
+                "$type": "NINA.Core.Model.Equipment.FilterInfo, NINA.Core",
+                "_name": "Green",
+                "_focusOffset": 0,
+                "_position": 2,
+                "_autoFocusExposureTime": -1.0,
+                "_autoFocusFilter": false,
+                "FlatWizardFilterSettings": {
+                  "$id": "235",
+                  "$type": "NINA.Core.Model.Equipment.FlatWizardFilterSettings, NINA.Core",
+                  "FlatWizardMode": 0,
+                  "HistogramMeanTarget": 0.5,
+                  "HistogramTolerance": 0.1,
+                  "MaxFlatExposureTime": 30.0,
+                  "MinFlatExposureTime": 0.01,
+                  "MaxAbsoluteFlatDeviceBrightness": 32767,
+                  "MinAbsoluteFlatDeviceBrightness": 0,
+                  "Gain": -1,
+                  "Offset": -1,
+                  "Binning": {
+                    "$id": "236",
+                    "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                    "X": 1,
+                    "Y": 1
+                  }
+                },
+                "_autoFocusBinning": {
+                  "$id": "237",
+                  "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                  "X": 1,
+                  "Y": 1
+                },
+                "_autoFocusGain": -1,
+                "_autoFocusOffset": -1
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "238",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 4,
+              "KeepPanelClosed": true,
+              "MinBrightness": 4,
+              "MaxBrightness": 4,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 024",
+              "Conditions": {
+                "$id": "239",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "240",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "241",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "242",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "243",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "244",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "245",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "246",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "247",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "245"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "248",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "249",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 1.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "250",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "245"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "251",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "252",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "253",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "238"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "254",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "255",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 5,
+              "KeepPanelClosed": true,
+              "MinExposure": 12.75,
+              "MaxExposure": 12.75,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 025",
+              "Conditions": {
+                "$id": "256",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "257",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "258",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "259",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "260",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "261",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 50,
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "262",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "263",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "264",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "262"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "265",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "266",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "267",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "262"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "268",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "269",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "270",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "255"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "271",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "272",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "273",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "274",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+              "Brightness": 1,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "275",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 2,
+              "MinExposure": 12.75,
+              "MaxExposure": 12.75,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "ShouldDither": true,
+              "DitherPixels": 29.5,
+              "DitherSettleTime": 29.5,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 029",
+              "Conditions": {
+                "$id": "276",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "277",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "278",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "275"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  },
+                  {
+                    "$id": "279",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "275"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  },
+                  {
+                    "$id": "280",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "275"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  },
+                  {
+                    "$id": "281",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "275"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  },
+                  {
+                    "$id": "282",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "283",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "284",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "282"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "285",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "286",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "287",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "282"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "288",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "275"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "289",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "290",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+              "OnOff": true,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "291",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 4,
+              "KeepPanelClosed": true,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 031",
+              "Conditions": {
+                "$id": "292",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "293",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "294",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "295",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "296",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "297",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "298",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "299",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "300",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "298"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "301",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "302",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "303",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "DARK",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "298"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "304",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "305",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "291"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "306",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "307",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 5,
+              "KeepPanelClosed": true,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 032",
+              "Conditions": {
+                "$id": "308",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "309",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "310",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "311",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "312",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "313",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "314",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "315",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "316",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "314"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "317",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "318",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "319",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "314"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "320",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "321",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "322",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "307"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "323",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "324",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserAbsolute, NINA.Sequencer",
+              "Position": 6,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "325",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserByTemperature, NINA.Sequencer",
+              "Slope": 34.5,
+              "Absolute": true,
+              "Intercept": 34.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "326",
+              "$type": "NINA.Sequencer.SequenceItem.Focuser.MoveFocuserRelative, NINA.Sequencer",
+              "RelativePosition": 1,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "327",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "328",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding, NINA.Sequencer",
+              "ForceCalibration": true,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "329",
+              "$type": "NINA.Sequencer.SequenceItem.Guider.StopGuiding, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "330",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 5,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 039",
+              "Conditions": {
+                "$id": "331",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "332",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 2,
+                    "Parent": {
+                      "$ref": "330"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "333",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "334",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "330"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "335",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "336",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "330"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "337",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "338",
+                    "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+                    "AfterExposures": 1,
+                    "Parent": {
+                      "$ref": "330"
+                    },
+                    "TriggerRunner": {
+                      "$id": "339",
+                      "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                      "Strategy": {
+                        "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                      },
+                      "Name": null,
+                      "Conditions": {
+                        "$id": "340",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "IsExpanded": true,
+                      "Items": {
+                        "$id": "341",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                        "$values": [
+                          {
+                            "$id": "342",
+                            "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                            "Parent": {
+                              "$ref": "339"
+                            },
+                            "ErrorBehavior": 0,
+                            "Attempts": 1
+                          }
+                        ]
+                      },
+                      "Triggers": {
+                        "$id": "343",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "Parent": null,
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  }
+                ]
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "344",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+              "ExposureTime": 12.75,
+              "Gain": 6,
+              "Offset": 6,
+              "Binning": {
+                "$id": "345",
+                "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                "X": 2,
+                "Y": 2
+              },
+              "ImageType": "DARK",
+              "ExposureCount": 3,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "346",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 7,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 041",
+              "Conditions": {
+                "$id": "347",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "348",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 1,
+                    "Parent": {
+                      "$ref": "346"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "349",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "350",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "351",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "346"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "352",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "196"
+              }
+            },
+            {
+              "$id": "353",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeSubframeExposure, NINA.Sequencer",
+              "ROI": 1.0,
+              "ExposureTime": 12.75,
+              "Gain": 1,
+              "Offset": 1,
+              "Binning": {
+                "$id": "354",
+                "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                "X": 2,
+                "Y": 2
+              },
+              "ImageType": "DARK",
+              "ExposureCount": 3,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "355",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.Center, NINA.Sequencer",
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "356",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 12,
+                "RAMinutes": 20,
+                "RASeconds": 42.0,
+                "NegativeDec": true,
+                "DecDegrees": -45,
+                "DecMinutes": 40,
+                "DecSeconds": 40.8
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "357",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.CenterAndRotate, NINA.Sequencer",
+              "PositionAngle": 44.5,
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "358",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 12,
+                "RAMinutes": 20,
+                "RASeconds": 42.0,
+                "NegativeDec": true,
+                "DecDegrees": -45,
+                "DecMinutes": 40,
+                "DecSeconds": 40.8
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "359",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndRotate, NINA.Sequencer",
+              "Inherited": false,
+              "PositionAngle": 45.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "360",
+              "$type": "NINA.Sequencer.SequenceItem.Platesolving.SolveAndSync, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "361",
+              "$type": "NINA.Sequencer.SequenceItem.Rotator.MoveRotatorMechanical, NINA.Sequencer",
+              "MechanicalPosition": 0.0,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "362",
+              "$type": "NINA.Sequencer.SequenceItem.SafetyMonitor.WaitUntilSafe, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "363",
+              "$type": "NINA.Sequencer.SequenceItem.Switch.SetSwitchValue, NINA.Sequencer",
+              "Value": 49.5,
+              "SwitchIndex": 2,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "364",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.FindHome, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "365",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.ParkScope, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "366",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SetTracking, NINA.Sequencer",
+              "TrackingMode": 1,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "367",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToAltAz, NINA.Sequencer",
+              "Coordinates": {
+                "$id": "368",
+                "$type": "NINA.Astrometry.InputTopocentricCoordinates, NINA.Astrometry",
+                "AzDegrees": 123,
+                "AzMinutes": 27,
+                "AzSeconds": 30.5,
+                "AltDegrees": 54,
+                "AltMinutes": 12,
+                "AltSeconds": 10.25
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "369",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.SlewScopeToRaDec, NINA.Sequencer",
+              "Inherited": false,
+              "Coordinates": {
+                "$id": "370",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 12,
+                "RAMinutes": 20,
+                "RASeconds": 42.0,
+                "NegativeDec": true,
+                "DecDegrees": -45,
+                "DecMinutes": 40,
+                "DecSeconds": 40.8
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "371",
+              "$type": "NINA.Sequencer.SequenceItem.Telescope.UnparkScope, NINA.Sequencer",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "372",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+              "Text": "Legacy text value 056",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "373",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.ExternalScript, NINA.Sequencer",
+              "Script": "Legacy Script 057",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "374",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.MessageBox, NINA.Sequencer",
+              "Text": "Legacy text value 058",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "375",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.SaveSequence, NINA.Sequencer",
+              "FilePath": "C:\\LegacySequences\\script-059.ps1",
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 4
+            },
+            {
+              "$id": "376",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForAltitude, NINA.Sequencer",
+              "AboveOrBelow": "Legacy AboveOrBelow 060",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "377",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "378",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 30.0,
+                "Comparator": 2
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "379",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForMoonAltitude, NINA.Sequencer",
+              "Data": {
+                "$id": "380",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "381",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "382",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForSunAltitude, NINA.Sequencer",
+              "Data": {
+                "$id": "383",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "384",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "385",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForTime, NINA.Sequencer",
+              "Hours": 1,
+              "Minutes": 1,
+              "MinutesOffset": 1,
+              "Seconds": 1,
+              "SelectedProvider": {
+                "$ref": "190"
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "386",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitForTimeSpan, NINA.Sequencer",
+              "Time": 64.5,
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "387",
+              "$type": "NINA.Sequencer.SequenceItem.Utility.WaitUntilAboveHorizon, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "388",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "389",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "196"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            }
+          ]
+        },
+        "Triggers": {
+          "$id": "390",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "391",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Conditions - master defaults",
+        "Conditions": {
+          "$id": "392",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "393",
+              "$type": "NINA.Sequencer.Conditions.AboveHorizonCondition, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "394",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "395",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "396",
+              "$type": "NINA.Sequencer.Conditions.AltitudeCondition, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "397",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "398",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 30.0,
+                "Comparator": 1
+              },
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "399",
+              "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+              "CompletedIterations": 0,
+              "Iterations": 2,
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "400",
+              "$type": "NINA.Sequencer.Conditions.LoopWhileUnsafe, NINA.Sequencer",
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "401",
+              "$type": "NINA.Sequencer.Conditions.MoonAltitudeCondition, NINA.Sequencer",
+              "Data": {
+                "$id": "402",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "403",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "404",
+              "$type": "NINA.Sequencer.Conditions.MoonIlluminationCondition, NINA.Sequencer",
+              "UserMoonIllumination": 0.0,
+              "Comparator": 3,
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "405",
+              "$type": "NINA.Sequencer.Conditions.SafetyMonitorCondition, NINA.Sequencer",
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "406",
+              "$type": "NINA.Sequencer.Conditions.SunAltitudeCondition, NINA.Sequencer",
+              "Data": {
+                "$id": "407",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "408",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "409",
+              "$type": "NINA.Sequencer.Conditions.TimeCondition, NINA.Sequencer",
+              "Hours": 0,
+              "Minutes": 0,
+              "MinutesOffset": 0,
+              "Seconds": 0,
+              "SelectedProvider": {
+                "$ref": "190"
+              },
+              "Parent": {
+                "$ref": "391"
+              }
+            },
+            {
+              "$id": "410",
+              "$type": "NINA.Sequencer.Conditions.TimeSpanCondition, NINA.Sequencer",
+              "Hours": 0,
+              "Minutes": 1,
+              "Seconds": 0,
+              "Parent": {
+                "$ref": "391"
+              }
+            }
+          ]
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "411",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Triggers": {
+          "$id": "412",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "413",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Conditions - populated scalar values",
+        "Conditions": {
+          "$id": "414",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "415",
+              "$type": "NINA.Sequencer.Conditions.AboveHorizonCondition, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "416",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "417",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "418",
+              "$type": "NINA.Sequencer.Conditions.AltitudeCondition, NINA.Sequencer",
+              "HasDsoParent": false,
+              "Data": {
+                "$id": "419",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "420",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 30.0,
+                "Comparator": 1
+              },
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "421",
+              "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+              "CompletedIterations": 6,
+              "Iterations": 6,
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "422",
+              "$type": "NINA.Sequencer.Conditions.LoopWhileUnsafe, NINA.Sequencer",
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "423",
+              "$type": "NINA.Sequencer.Conditions.MoonAltitudeCondition, NINA.Sequencer",
+              "Data": {
+                "$id": "424",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "425",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "426",
+              "$type": "NINA.Sequencer.Conditions.MoonIlluminationCondition, NINA.Sequencer",
+              "UserMoonIllumination": 71.5,
+              "Comparator": 1,
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "427",
+              "$type": "NINA.Sequencer.Conditions.SafetyMonitorCondition, NINA.Sequencer",
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "428",
+              "$type": "NINA.Sequencer.Conditions.SunAltitudeCondition, NINA.Sequencer",
+              "Data": {
+                "$id": "429",
+                "$type": "NINA.Sequencer.SequenceItem.Utility.WaitLoopData, NINA.Sequencer",
+                "Coordinates": {
+                  "$id": "430",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                },
+                "Offset": 0.0,
+                "Comparator": 3
+              },
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "431",
+              "$type": "NINA.Sequencer.Conditions.TimeCondition, NINA.Sequencer",
+              "Hours": 5,
+              "Minutes": 5,
+              "MinutesOffset": 5,
+              "Seconds": 5,
+              "SelectedProvider": {
+                "$ref": "190"
+              },
+              "Parent": {
+                "$ref": "413"
+              }
+            },
+            {
+              "$id": "432",
+              "$type": "NINA.Sequencer.Conditions.TimeSpanCondition, NINA.Sequencer",
+              "Hours": 6,
+              "Minutes": 6,
+              "Seconds": 6,
+              "Parent": {
+                "$ref": "413"
+              }
+            }
+          ]
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "433",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Triggers": {
+          "$id": "434",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "435",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Triggers - master defaults",
+        "Conditions": {
+          "$id": "436",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "437",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Triggers": {
+          "$id": "438",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "439",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterExposures, NINA.Sequencer",
+              "AfterExposures": 5,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "440",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "441",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "442",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "443",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "440"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "444",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "445",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterFilterChange, NINA.Sequencer",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "446",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "447",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "448",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "449",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "446"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "450",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "451",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger, NINA.Sequencer",
+              "Amount": 5.0,
+              "SampleSize": 10,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "452",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "453",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "454",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "455",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "452"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "456",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "457",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTemperatureChangeTrigger, NINA.Sequencer",
+              "Amount": 5.0,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "458",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "459",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "460",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "461",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "458"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "462",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "463",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTimeTrigger, NINA.Sequencer",
+              "Amount": 30.0,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "464",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "465",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "466",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "467",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "464"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "468",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "469",
+              "$type": "NINA.Sequencer.Trigger.Connect.ReconnectOnDownloadFailure, NINA.Sequencer",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "470",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "471",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "472",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "473",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "474",
+              "$type": "NINA.Sequencer.Trigger.Connect.ReconnectTrigger, NINA.Sequencer",
+              "SelectedDevice": "Camera",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "475",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "476",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "477",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "478",
+                      "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment, NINA.Sequencer",
+                      "SelectedDevice": "Camera",
+                      "Parent": {
+                        "$ref": "475"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "479",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "480",
+              "$type": "NINA.Sequencer.Trigger.Dome.SynchronizeDomeTrigger, NINA.Sequencer",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "481",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "482",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "483",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "484",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "485",
+              "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+              "AfterExposures": 1,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "486",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "487",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "488",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "489",
+                      "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "486"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "490",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "491",
+              "$type": "NINA.Sequencer.Trigger.Guider.RestoreGuiding, NINA.Sequencer",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "492",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "493",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "494",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "495",
+                      "$type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding, NINA.Sequencer",
+                      "ForceCalibration": false,
+                      "Parent": {
+                        "$ref": "492"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "496",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "497",
+              "$type": "NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger, NINA.Sequencer",
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "498",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "499",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "500",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "501",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "502",
+              "$type": "NINA.Sequencer.Trigger.Platesolving.CenterAfterDriftTrigger, NINA.Sequencer",
+              "Coordinates": {
+                "$id": "503",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 0,
+                "RAMinutes": 0,
+                "RASeconds": 0.0,
+                "NegativeDec": false,
+                "DecDegrees": 0,
+                "DecMinutes": 0,
+                "DecSeconds": 0.0
+              },
+              "DistanceArcMinutes": 10.0,
+              "AfterExposures": 1,
+              "Parent": {
+                "$ref": "435"
+              },
+              "TriggerRunner": {
+                "$id": "504",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "505",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "506",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "507",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            }
+          ]
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "508",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Triggers - populated scalar values",
+        "Conditions": {
+          "$id": "509",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "510",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Triggers": {
+          "$id": "511",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "512",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterExposures, NINA.Sequencer",
+              "AfterExposures": 7,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "513",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "514",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "515",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "516",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "513"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "517",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "518",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterFilterChange, NINA.Sequencer",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "519",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "520",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "521",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "522",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "519"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "523",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "524",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger, NINA.Sequencer",
+              "Amount": 78.5,
+              "SampleSize": 10,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "525",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "526",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "527",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "528",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "525"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "529",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "530",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTemperatureChangeTrigger, NINA.Sequencer",
+              "Amount": 79.5,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "531",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "532",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "533",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "534",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "531"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "535",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "536",
+              "$type": "NINA.Sequencer.Trigger.Autofocus.AutofocusAfterTimeTrigger, NINA.Sequencer",
+              "Amount": 80.5,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "537",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "538",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "539",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "540",
+                      "$type": "NINA.Sequencer.SequenceItem.Autofocus.RunAutofocus, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "537"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "541",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "542",
+              "$type": "NINA.Sequencer.Trigger.Connect.ReconnectOnDownloadFailure, NINA.Sequencer",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "543",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "544",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "545",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "546",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "547",
+              "$type": "NINA.Sequencer.Trigger.Connect.ReconnectTrigger, NINA.Sequencer",
+              "SelectedDevice": "Legacy SelectedDevice 082",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "548",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "549",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "550",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "551",
+                      "$type": "NINA.Sequencer.SequenceItem.Connect.ConnectEquipment, NINA.Sequencer",
+                      "SelectedDevice": "Legacy SelectedDevice 082",
+                      "Parent": {
+                        "$ref": "548"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "552",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "553",
+              "$type": "NINA.Sequencer.Trigger.Dome.SynchronizeDomeTrigger, NINA.Sequencer",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "554",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "555",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "556",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "557",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "558",
+              "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+              "AfterExposures": 1,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "559",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "560",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "561",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "562",
+                      "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                      "Parent": {
+                        "$ref": "559"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "563",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "564",
+              "$type": "NINA.Sequencer.Trigger.Guider.RestoreGuiding, NINA.Sequencer",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "565",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "566",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "567",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": [
+                    {
+                      "$id": "568",
+                      "$type": "NINA.Sequencer.SequenceItem.Guider.StartGuiding, NINA.Sequencer",
+                      "ForceCalibration": false,
+                      "Parent": {
+                        "$ref": "565"
+                      },
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  ]
+                },
+                "Triggers": {
+                  "$id": "569",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "570",
+              "$type": "NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger, NINA.Sequencer",
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "571",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "572",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "573",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "574",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            },
+            {
+              "$id": "575",
+              "$type": "NINA.Sequencer.Trigger.Platesolving.CenterAfterDriftTrigger, NINA.Sequencer",
+              "Coordinates": {
+                "$id": "576",
+                "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                "RAHours": 12,
+                "RAMinutes": 20,
+                "RASeconds": 42.0,
+                "NegativeDec": true,
+                "DecDegrees": -45,
+                "DecMinutes": 40,
+                "DecSeconds": 40.8
+              },
+              "DistanceArcMinutes": 87.5,
+              "AfterExposures": 4,
+              "Parent": {
+                "$ref": "508"
+              },
+              "TriggerRunner": {
+                "$id": "577",
+                "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                "Strategy": {
+                  "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                },
+                "Name": null,
+                "Conditions": {
+                  "$id": "578",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "IsExpanded": true,
+                "Items": {
+                  "$id": "579",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Triggers": {
+                  "$id": "580",
+                  "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                  "$values": []
+                },
+                "Parent": null,
+                "ErrorBehavior": 0,
+                "Attempts": 1
+              }
+            }
+          ]
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "581",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Containers - master defaults",
+        "Conditions": {
+          "$id": "582",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "583",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "584",
+              "$type": "NINA.Sequencer.Container.DeepSkyObjectContainer, NINA.Sequencer",
+              "Target": {
+                "$id": "585",
+                "$type": "NINA.Astrometry.InputTarget, NINA.Astrometry",
+                "Expanded": true,
+                "TargetName": null,
+                "PositionAngle": 0.0,
+                "InputCoordinates": {
+                  "$id": "586",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                }
+              },
+              "ExposureInfoListExpanded": false,
+              "ExposureInfoList": {
+                "$id": "587",
+                "$type": "NINA.Core.Utility.AsyncObservableCollection`1[[NINA.Sequencer.Utility.ExposureInfo, NINA.Sequencer]], NINA.Core",
+                "$values": []
+              },
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container DeepSkyObjectContainer 088",
+              "Conditions": {
+                "$id": "588",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "589",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "590",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "591",
+              "$type": "NINA.Sequencer.Container.EndAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container EndAreaContainer 089",
+              "Conditions": {
+                "$id": "592",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "593",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "594",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "595",
+              "$type": "NINA.Sequencer.Container.ParallelContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.ParallelStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container ParallelContainer 090",
+              "Conditions": {
+                "$id": "596",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "597",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "598",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "599",
+              "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container SequentialContainer 091",
+              "Conditions": {
+                "$id": "600",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "601",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "602",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "603",
+              "$type": "NINA.Sequencer.Container.StartAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container StartAreaContainer 092",
+              "Conditions": {
+                "$id": "604",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "605",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "606",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "607",
+              "$type": "NINA.Sequencer.Container.TargetAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container TargetAreaContainer 093",
+              "Conditions": {
+                "$id": "608",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "609",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "610",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              },
+              "ErrorBehavior": 0,
+              "Attempts": 1
+            },
+            {
+              "$id": "611",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "MinBrightness": 20,
+              "MaxBrightness": 100,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container AutoBrightnessFlat 094",
+              "Conditions": {
+                "$id": "612",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "613",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "614",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "615",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "616",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "617",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "618",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "619",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "620",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "618"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "621",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "622",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 1.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "623",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "618"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "624",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "625",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "626",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "611"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "627",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "628",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "MinExposure": 0.0,
+              "MaxExposure": 10.0,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container AutoExposureFlat 095",
+              "Conditions": {
+                "$id": "629",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "630",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "631",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "632",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "633",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "634",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 50,
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "635",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "636",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "637",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "635"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "638",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "639",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "640",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "635"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "641",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "642",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "643",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "628"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "644",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "645",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "MinExposure": 0.0,
+              "MaxExposure": 10.0,
+              "HistogramTargetPercentage": 0.5,
+              "HistogramTolerancePercentage": 0.1,
+              "ShouldDither": false,
+              "DitherPixels": 5.0,
+              "DitherSettleTime": 10.0,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container SkyFlat 096",
+              "Conditions": {
+                "$id": "646",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "647",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "648",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "645"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "649",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "645"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "650",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "645"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "651",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "645"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "652",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "653",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "654",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "652"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "655",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "656",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "657",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "652"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "658",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "645"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "659",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "660",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container TrainedDarkFlatExposure 097",
+              "Conditions": {
+                "$id": "661",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "662",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "663",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "664",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "665",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "666",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "667",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "668",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "669",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "667"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "670",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "671",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "672",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "DARK",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "667"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "673",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "674",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "660"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "675",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "676",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "KeepPanelClosed": false,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container TrainedFlatExposure 098",
+              "Conditions": {
+                "$id": "677",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "678",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "679",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "680",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "681",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "682",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "683",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "684",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "685",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "683"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "686",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "687",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "688",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "683"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "689",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "690",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "691",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "676"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "692",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "693",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container SmartExposure 099",
+              "Conditions": {
+                "$id": "694",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "695",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 2,
+                    "Parent": {
+                      "$ref": "693"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "696",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "697",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "693"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "698",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "699",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "693"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "700",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "701",
+                    "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+                    "AfterExposures": 1,
+                    "Parent": {
+                      "$ref": "693"
+                    },
+                    "TriggerRunner": {
+                      "$id": "702",
+                      "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                      "Strategy": {
+                        "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                      },
+                      "Name": null,
+                      "Conditions": {
+                        "$id": "703",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "IsExpanded": true,
+                      "Items": {
+                        "$id": "704",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                        "$values": [
+                          {
+                            "$id": "705",
+                            "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                            "Parent": {
+                              "$ref": "702"
+                            },
+                            "ErrorBehavior": 0,
+                            "Attempts": 1
+                          }
+                        ]
+                      },
+                      "Triggers": {
+                        "$id": "706",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "Parent": null,
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  }
+                ]
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            },
+            {
+              "$id": "707",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures, NINA.Sequencer",
+              "ErrorBehavior": 0,
+              "Attempts": 1,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Default Container TakeManyExposures 100",
+              "Conditions": {
+                "$id": "708",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "709",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 1,
+                    "Parent": {
+                      "$ref": "707"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": false,
+              "Items": {
+                "$id": "710",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "711",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "712",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "707"
+                    },
+                    "ErrorBehavior": 0,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "713",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "581"
+              }
+            }
+          ]
+        },
+        "Triggers": {
+          "$id": "714",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      },
+      {
+        "$id": "715",
+        "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+        "Strategy": {
+          "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+        },
+        "Name": "Containers - populated scalar values",
+        "Conditions": {
+          "$id": "716",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "IsExpanded": true,
+        "Items": {
+          "$id": "717",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+          "$values": [
+            {
+              "$id": "718",
+              "$type": "NINA.Sequencer.Container.DeepSkyObjectContainer, NINA.Sequencer",
+              "Target": {
+                "$id": "719",
+                "$type": "NINA.Astrometry.InputTarget, NINA.Astrometry",
+                "Expanded": true,
+                "TargetName": null,
+                "PositionAngle": 0.0,
+                "InputCoordinates": {
+                  "$id": "720",
+                  "$type": "NINA.Astrometry.InputCoordinates, NINA.Astrometry",
+                  "RAHours": 0,
+                  "RAMinutes": 0,
+                  "RASeconds": 0.0,
+                  "NegativeDec": false,
+                  "DecDegrees": 0,
+                  "DecMinutes": 0,
+                  "DecSeconds": 0.0
+                }
+              },
+              "ExposureInfoListExpanded": true,
+              "ExposureInfoList": {
+                "$id": "721",
+                "$type": "NINA.Core.Utility.AsyncObservableCollection`1[[NINA.Sequencer.Utility.ExposureInfo, NINA.Sequencer]], NINA.Core",
+                "$values": []
+              },
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 088",
+              "Conditions": {
+                "$id": "722",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "723",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "724",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 5
+            },
+            {
+              "$id": "725",
+              "$type": "NINA.Sequencer.Container.EndAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 089",
+              "Conditions": {
+                "$id": "726",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "727",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "728",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 6
+            },
+            {
+              "$id": "729",
+              "$type": "NINA.Sequencer.Container.ParallelContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.ParallelStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 090",
+              "Conditions": {
+                "$id": "730",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "731",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "732",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 7
+            },
+            {
+              "$id": "733",
+              "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 091",
+              "Conditions": {
+                "$id": "734",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "735",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "736",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 1
+            },
+            {
+              "$id": "737",
+              "$type": "NINA.Sequencer.Container.StartAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 092",
+              "Conditions": {
+                "$id": "738",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "739",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "740",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 2
+            },
+            {
+              "$id": "741",
+              "$type": "NINA.Sequencer.Container.TargetAreaContainer, NINA.Sequencer",
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 093",
+              "Conditions": {
+                "$id": "742",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "743",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Triggers": {
+                "$id": "744",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              },
+              "ErrorBehavior": 1,
+              "Attempts": 3
+            },
+            {
+              "$id": "745",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoBrightnessFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 4,
+              "KeepPanelClosed": true,
+              "MinBrightness": 4,
+              "MaxBrightness": 4,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 094",
+              "Conditions": {
+                "$id": "746",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "747",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "748",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "749",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "750",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "751",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "752",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "753",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "754",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "752"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "755",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "756",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 1.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "757",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "752"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "758",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "759",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  },
+                  {
+                    "$id": "760",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "745"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 4
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "761",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "762",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.AutoExposureFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 5,
+              "KeepPanelClosed": true,
+              "MinExposure": 12.75,
+              "MaxExposure": 12.75,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 095",
+              "Conditions": {
+                "$id": "763",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "764",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "765",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "766",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "767",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "768",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 50,
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "769",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "770",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "771",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "769"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "772",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "773",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "774",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "769"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "775",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "776",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  },
+                  {
+                    "$id": "777",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "762"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 5
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "778",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "779",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SkyFlat, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 6,
+              "MinExposure": 12.75,
+              "MaxExposure": 12.75,
+              "HistogramTargetPercentage": 1.0,
+              "HistogramTolerancePercentage": 0.75,
+              "ShouldDither": true,
+              "DitherPixels": 96.5,
+              "DitherSettleTime": 96.5,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 096",
+              "Conditions": {
+                "$id": "780",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "781",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "782",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "779"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 6
+                  },
+                  {
+                    "$id": "783",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "779"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 6
+                  },
+                  {
+                    "$id": "784",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "779"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 6
+                  },
+                  {
+                    "$id": "785",
+                    "$type": "NINA.Sequencer.SequenceItem.Utility.Annotation, NINA.Sequencer",
+                    "Text": null,
+                    "Parent": {
+                      "$ref": "779"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 6
+                  },
+                  {
+                    "$id": "786",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "787",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "788",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "786"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "789",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "790",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "791",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "786"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "792",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "779"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 6
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "793",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "794",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedDarkFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 7,
+              "KeepPanelClosed": true,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 097",
+              "Conditions": {
+                "$id": "795",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "796",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "797",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  },
+                  {
+                    "$id": "798",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  },
+                  {
+                    "$id": "799",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  },
+                  {
+                    "$id": "800",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  },
+                  {
+                    "$id": "801",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "802",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "803",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "801"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "804",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "805",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "806",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "DARK",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "801"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "807",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  },
+                  {
+                    "$id": "808",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "794"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 7
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "809",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "810",
+              "$type": "NINA.Sequencer.SequenceItem.FlatDevice.TrainedFlatExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 1,
+              "KeepPanelClosed": true,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 098",
+              "Conditions": {
+                "$id": "811",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "812",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "813",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.CloseCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "814",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": true,
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "815",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "816",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.SetBrightness, NINA.Sequencer",
+                    "Brightness": 0,
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "817",
+                    "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                    "Strategy": {
+                      "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                    },
+                    "Name": null,
+                    "Conditions": {
+                      "$id": "818",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "819",
+                          "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                          "CompletedIterations": 0,
+                          "Iterations": 1,
+                          "Parent": {
+                            "$ref": "817"
+                          }
+                        }
+                      ]
+                    },
+                    "IsExpanded": true,
+                    "Items": {
+                      "$id": "820",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                      "$values": [
+                        {
+                          "$id": "821",
+                          "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                          "ExposureTime": 0.0,
+                          "Gain": -1,
+                          "Offset": -1,
+                          "Binning": {
+                            "$id": "822",
+                            "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                            "X": 1,
+                            "Y": 1
+                          },
+                          "ImageType": "FLAT",
+                          "ExposureCount": 0,
+                          "Parent": {
+                            "$ref": "817"
+                          },
+                          "ErrorBehavior": 0,
+                          "Attempts": 1
+                        }
+                      ]
+                    },
+                    "Triggers": {
+                      "$id": "823",
+                      "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                      "$values": []
+                    },
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "824",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.ToggleLight, NINA.Sequencer",
+                    "OnOff": false,
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  },
+                  {
+                    "$id": "825",
+                    "$type": "NINA.Sequencer.SequenceItem.FlatDevice.OpenCover, NINA.Sequencer",
+                    "Parent": {
+                      "$ref": "810"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 1
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "826",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "827",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.SmartExposure, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 2,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 099",
+              "Conditions": {
+                "$id": "828",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "829",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 2,
+                    "Parent": {
+                      "$ref": "827"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "830",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "831",
+                    "$type": "NINA.Sequencer.SequenceItem.FilterWheel.SwitchFilter, NINA.Sequencer",
+                    "Filter": null,
+                    "Parent": {
+                      "$ref": "827"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  },
+                  {
+                    "$id": "832",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "833",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "827"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 2
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "834",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "835",
+                    "$type": "NINA.Sequencer.Trigger.Guider.DitherAfterExposures, NINA.Sequencer",
+                    "AfterExposures": 1,
+                    "Parent": {
+                      "$ref": "827"
+                    },
+                    "TriggerRunner": {
+                      "$id": "836",
+                      "$type": "NINA.Sequencer.Container.SequentialContainer, NINA.Sequencer",
+                      "Strategy": {
+                        "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+                      },
+                      "Name": null,
+                      "Conditions": {
+                        "$id": "837",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "IsExpanded": true,
+                      "Items": {
+                        "$id": "838",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                        "$values": [
+                          {
+                            "$id": "839",
+                            "$type": "NINA.Sequencer.SequenceItem.Guider.Dither, NINA.Sequencer",
+                            "Parent": {
+                              "$ref": "836"
+                            },
+                            "ErrorBehavior": 0,
+                            "Attempts": 1
+                          }
+                        ]
+                      },
+                      "Triggers": {
+                        "$id": "840",
+                        "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                        "$values": []
+                      },
+                      "Parent": null,
+                      "ErrorBehavior": 0,
+                      "Attempts": 1
+                    }
+                  }
+                ]
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            },
+            {
+              "$id": "841",
+              "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeManyExposures, NINA.Sequencer",
+              "ErrorBehavior": 1,
+              "Attempts": 3,
+              "Strategy": {
+                "$type": "NINA.Sequencer.Container.ExecutionStrategy.SequentialStrategy, NINA.Sequencer"
+              },
+              "Name": "Legacy Name 100",
+              "Conditions": {
+                "$id": "842",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Conditions.ISequenceCondition, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "843",
+                    "$type": "NINA.Sequencer.Conditions.LoopCondition, NINA.Sequencer",
+                    "CompletedIterations": 0,
+                    "Iterations": 1,
+                    "Parent": {
+                      "$ref": "841"
+                    }
+                  }
+                ]
+              },
+              "IsExpanded": true,
+              "Items": {
+                "$id": "844",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.SequenceItem.ISequenceItem, NINA.Sequencer]], System.ObjectModel",
+                "$values": [
+                  {
+                    "$id": "845",
+                    "$type": "NINA.Sequencer.SequenceItem.Imaging.TakeExposure, NINA.Sequencer",
+                    "ExposureTime": 0.0,
+                    "Gain": -1,
+                    "Offset": -1,
+                    "Binning": {
+                      "$id": "846",
+                      "$type": "NINA.Core.Model.Equipment.BinningMode, NINA.Core",
+                      "X": 1,
+                      "Y": 1
+                    },
+                    "ImageType": "LIGHT",
+                    "ExposureCount": 0,
+                    "Parent": {
+                      "$ref": "841"
+                    },
+                    "ErrorBehavior": 1,
+                    "Attempts": 3
+                  }
+                ]
+              },
+              "Triggers": {
+                "$id": "847",
+                "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+                "$values": []
+              },
+              "Parent": {
+                "$ref": "715"
+              }
+            }
+          ]
+        },
+        "Triggers": {
+          "$id": "848",
+          "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+          "$values": []
+        },
+        "Parent": {
+          "$ref": "1"
+        },
+        "ErrorBehavior": 0,
+        "Attempts": 1
+      }
+    ]
+  },
+  "Triggers": {
+    "$id": "849",
+    "$type": "System.Collections.ObjectModel.ObservableCollection`1[[NINA.Sequencer.Trigger.ISequenceTrigger, NINA.Sequencer]], System.ObjectModel",
+    "$values": []
+  },
+  "Parent": null,
+  "ErrorBehavior": 0,
+  "Attempts": 1
+}


### PR DESCRIPTION
## Purpose

  Fixes legacy sequencer migration for symbol/expression-backed values, with focused coverage for old sequence JSON importing into the current expression model without value drift.

Key fixes:

- Culture-invariant expression backfills for legacy numeric values.
- Legacy nested sequencer values mapped into current expressions.
- CenterAfterDriftTrigger drift threshold accepts legacy values above 60.
- SmartExposure / TakeManyExposures backfill container IterationsExpression from legacy nested LoopCondition.Iterations.

## How Was It Tested?

Automated:

- Added golden legacy master 3.2 sequence migration corpus.
- Added expression-specific assertions for imported legacy values, migrated save/round-trip behavior, and nested legacy mappings.
- Added targeted regression coverage for culture-sensitive migration and imaging container iteration backfill.

## AI / Tooling Disclosure
OpenAI Codex / GPT-5 was used to analyze the migration surface and generate tests.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
    - [x] No breaking changes to interfaces
    - [x] No changes to method/class signatures (especially optional parameters)
- [ ] RELEASE_NOTES.md updated (if applicable)
- [ ] Documentation (https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None.

## Screenshots

Not applicable. No UI changes.

## Additional Notes

The corpus is generated from master 3.2 and is intended as a regression guard for old sequence import compatibility. Build/test output still contains existing
unrelated warnings.