### PR TITLE
Added a new Trigger On Unsafe safety monitor trigger.

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7898,4 +7898,22 @@ If exposure count is not important to you, enable this option to avoid having to
   <data name="LblEccentricity" xml:space="preserve">
     <value>Eccentricity</value>
   </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_Name" xml:space="preserve">
+    <value>Trigger On Unsafe</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_Description" xml:space="preserve">
+    <value>Runs configured instructions when the safety monitor reports unsafe conditions or disconnects after being connected, waits until conditions are safe again, then runs follow-up instructions.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description" xml:space="preserve">
+    <value>Before Waiting For Safety</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description" xml:space="preserve">
+    <value>After Waiting For Safety</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_HelpDescription" xml:space="preserve">
+    <value>Instructions that run before waiting until conditions are safe again.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription" xml:space="preserve">
+    <value>Instructions that run after conditions are safe again.</value>
+  </data>
 </root>

--- a/NINA.Sequencer/Container/SequenceRootContainer.cs
+++ b/NINA.Sequencer/Container/SequenceRootContainer.cs
@@ -106,6 +106,22 @@ namespace NINA.Sequencer.Container {
             }
         }
 
+        public void InterruptAndResetCurrentRunningItems() {
+            List<ISequenceItem> items;
+            lock (runningItemsLock) {
+                items = runningItems.ToList();
+            }
+
+            foreach (var item in items) {
+                if (item is NINA.Sequencer.SequenceItem.SequenceItem sequenceItem) {
+                    sequenceItem.InterruptAndReset();
+                } else {
+                    item.Skip();
+                    item.ResetProgress();
+                }
+            }
+        }
+
         public IReadOnlyCollection<ISequenceItem> GetCurrentRunningItems() {
             lock (runningItemsLock) {
                 return runningItems.ToList().AsReadOnly();

--- a/NINA.Sequencer/Interfaces/ISequenceRootContainer.cs
+++ b/NINA.Sequencer/Interfaces/ISequenceRootContainer.cs
@@ -29,6 +29,8 @@ namespace NINA.Sequencer.Container {
 
         void SkipCurrentRunningItems();
 
+        void InterruptAndResetCurrentRunningItems();
+
         IReadOnlyCollection<ISequenceItem> GetCurrentRunningItems();
 
         string SequenceTitle { get; set; }

--- a/NINA.Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafe.cs
+++ b/NINA.Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafe.cs
@@ -81,7 +81,8 @@ namespace NINA.Sequencer.SequenceItem.SafetyMonitor {
             }
 
             Issues = i;
-            return i.Count == 0;
+            // The instruction is always valid. A disconnected safety monitor should still execute the instruction and wait until it is connected again.
+            return true;
         }
 
         public override string ToString() {

--- a/NINA.Sequencer/SequenceItem/SequenceItem.cs
+++ b/NINA.Sequencer/SequenceItem/SequenceItem.cs
@@ -182,6 +182,7 @@ namespace NINA.Sequencer.SequenceItem {
         }
 
         private CancellationTokenSource localCts;
+        private volatile bool resetOnCancel;
 
         private void RunErrorBehavior(ISequenceRootContainer root) {
             var attemptWord = Attempts != 1 ? "attempts" : "attempt";
@@ -296,15 +297,19 @@ namespace NINA.Sequencer.SequenceItem {
                         Logger.Warning($"Skipped {this}");
                         Status = SequenceEntityStatus.SKIPPED;
                     } catch (OperationCanceledException) {
-                        if (token.IsCancellationRequested) {
+                        if (token.IsCancellationRequested || resetOnCancel) {
                             Status = SequenceEntityStatus.CREATED;
                             Logger.Debug($"Cancelled {this}");
-                            throw;
+                            if (token.IsCancellationRequested) {
+                                resetOnCancel = false;
+                                throw;
+                            }
                         } else {
                             Status = SequenceEntityStatus.SKIPPED;
                             Logger.Debug($"Skipped {this}");
                         }
                     } finally {
+                        resetOnCancel = false;
                         progress?.Report(new ApplicationStatus());
                         if (root != null && !(this is ISequenceContainer)) {
                             root?.RemoveRunningItem(this);
@@ -334,6 +339,22 @@ namespace NINA.Sequencer.SequenceItem {
                     localCts?.Cancel();
                 } catch { }
             }
+        }
+
+        public virtual void InterruptAndReset() {
+            if (this.Status == SequenceEntityStatus.DISABLED) {
+                return;
+            }
+
+            if (this.Status != SequenceEntityStatus.RUNNING) {
+                ResetProgress();
+                return;
+            }
+
+            resetOnCancel = true;
+            try {
+                localCts?.Cancel();
+            } catch { }
         }
 
         public virtual void Initialize() {

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml
@@ -11,9 +11,12 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:af="clr-namespace:NINA.Sequencer.Trigger.Autofocus"
+    xmlns:behaviors="clr-namespace:NINA.Sequencer.Behaviors"
     xmlns:connect="clr-namespace:NINA.Sequencer.Trigger.Connect"
     xmlns:d="clr-namespace:NINA.Sequencer.Trigger.Dome"
+    xmlns:enum="clr-namespace:NINA.Core.Enum;assembly=NINA.Core"
     xmlns:g="clr-namespace:NINA.Sequencer.Trigger.Guider"
+    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:local="clr-namespace:NINA.Sequencer.Trigger"
     xmlns:logic="clr-namespace:NINA.Sequencer.Logic"
     xmlns:mf="clr-namespace:NINA.Sequencer.Trigger.MeridianFlip"
@@ -22,7 +25,9 @@
     xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
     xmlns:p="clr-namespace:NINA.Sequencer.Trigger.Platesolving"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
-    xmlns:view="clr-namespace:NINA.View.Sequencer">
+    xmlns:safety="clr-namespace:NINA.Sequencer.Trigger.SafetyMonitor"
+    xmlns:view="clr-namespace:NINA.View.Sequencer"
+    xmlns:wpfutil="clr-namespace:NINA.WPF.Base.Utility;assembly=NINA.WPF.Base">
 
     <DataTemplate x:Key="NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger_Mini">
         <mini:MiniTrigger>
@@ -449,6 +454,354 @@
                 <TextBlock VerticalAlignment="Center" Text="{Binding SelectedDevice}" />
             </mini:MiniSequenceItem.SequenceItemContent>
         </mini:MiniSequenceItem>
+    </DataTemplate>
+
+    <Style x:Key="TriggerOnUnsafeSequenceContainerHeaderExpanderStyle" TargetType="ToggleButton">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <StackPanel>
+                        <Border
+                            x:Name="topBorder"
+                            BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                            BorderThickness="1,1,0,0">
+                            <Grid
+                                x:Name="Head"
+                                MinHeight="30"
+                                Background="{StaticResource SecondaryBackgroundBrush}"
+                                UseLayoutRounding="True">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Path
+                                    x:Name="iconarrow"
+                                    Grid.Column="0"
+                                    Width="10"
+                                    Height="10"
+                                    Margin="10,0,10,0"
+                                    Data="{StaticResource ArrowRightSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <Path
+                                    x:Name="icon"
+                                    Grid.Column="1"
+                                    Margin="5,0,3,0"
+                                    Data="{StaticResource BoxClosedSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <Path
+                                    Grid.Column="2"
+                                    Width="20"
+                                    Height="20"
+                                    Margin="5,0,3,0"
+                                    Data="{Binding Icon}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <ContentPresenter
+                                    Grid.Column="3"
+                                    Margin="4,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    RecognizesAccessKey="True"
+                                    UseLayoutRounding="True">
+                                    <i:Interaction.Behaviors>
+                                        <!--  This gives the ability to drag and drop a sequence container by its header  -->
+                                        <behaviors:DragDropBehavior />
+                                    </i:Interaction.Behaviors>
+                                </ContentPresenter>
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="true">
+                            <Setter TargetName="icon" Property="Data" Value="{StaticResource BoxSVG}" />
+                            <Setter TargetName="iconarrow" Property="Data" Value="{StaticResource ArrowDownSVG}" />
+                            <Setter TargetName="iconarrow" Property="Margin" Value="5,0,10,0" />
+                        </Trigger>
+
+                        <Trigger Property="IsChecked" Value="false">
+                            <Setter TargetName="topBorder" Property="BorderThickness" Value="1,1,1,1" />
+                        </Trigger>
+
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Head" Property="Background" Value="{StaticResource ButtonBackgroundSelectedBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="TriggerOnUnsafeSequenceContainerExpander" TargetType="{x:Type ninactrl:DetachingExpander}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ninactrl:DetachingExpander}">
+                    <Border
+                        Margin="0,5,0,5"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Focusable="False"
+                        UseLayoutRounding="True">
+                        <DockPanel>
+                            <ToggleButton
+                                x:Name="HeaderSite"
+                                MinWidth="0"
+                                MinHeight="0"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                DockPanel.Dock="Top"
+                                FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontStretch="{TemplateBinding FontStretch}"
+                                FontStyle="{TemplateBinding FontStyle}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                Style="{StaticResource TriggerOnUnsafeSequenceContainerHeaderExpanderStyle}" />
+                            <Border x:Name="ContainerBorder" BorderBrush="{StaticResource SecondaryBackgroundBrush}">
+                                <ContentPresenter
+                                    x:Name="ExpandSite"
+                                    Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Focusable="false" />
+                            </Border>
+                        </DockPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="true">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="10,0,0,15" />
+                        </Trigger>
+                        <Trigger Property="IsExpanded" Value="False">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="0" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <DataTemplate DataType="{x:Type safety:TriggerOnUnsafe}">
+        <Border>
+            <Border.Resources>
+                <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
+            </Border.Resources>
+            <i:Interaction.Behaviors>
+                <!--  Drop area above and below the Sequence Container  -->
+                <behaviors:DragOverBehavior
+                    AllowDragCenter="False"
+                    DragAboveSize="25"
+                    DragBelowSize="15" />
+            </i:Interaction.Behaviors>
+            <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+                <ninactrl:DetachingExpander.Header>
+                    <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock
+                                MinHeight="25"
+                                Margin="10,10,10,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="{Binding Name}" />
+                            <Border
+                                Width="20"
+                                Height="20"
+                                Margin="5,0,5,0"
+                                Background="{StaticResource NotificationErrorBrush}"
+                                BorderBrush="Transparent"
+                                CornerRadius="10">
+                                <Border.Visibility>
+                                    <PriorityBinding>
+                                        <Binding
+                                            Converter="{StaticResource ZeroToVisibilityConverter}"
+                                            FallbackValue="Collapsed"
+                                            Path="Issues.Count" />
+                                    </PriorityBinding>
+                                </Border.Visibility>
+                                <Path
+                                    HorizontalAlignment="Right"
+                                    Data="{StaticResource ExclamationCircledSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform" />
+                                <Border.ToolTip>
+                                    <ItemsControl ItemsSource="{Binding Issues}" />
+                                </Border.ToolTip>
+                            </Border>
+                        </StackPanel>
+                        <Border Grid.Column="1" Background="{StaticResource SecondaryBackgroundBrush}">
+                            <ContentPresenter
+                                Margin="2,0,10,0"
+                                HorizontalAlignment="Right"
+                                Content="{Binding}"
+                                DockPanel.Dock="Right"
+                                Style="{StaticResource ProgressPresenter}" />
+                        </Border>
+                        <Border
+                            x:Name="ButtonCommands"
+                            Grid.Column="2"
+                            HorizontalAlignment="Stretch"
+                            Background="{StaticResource SecondaryBackgroundBrush}">
+                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                                <Button
+                                    x:Name="EnableDisableButton"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DisableEnableCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource PowerSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+
+                                <Button
+                                    x:Name="CloseButton"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DetachCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource TrashCanSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </ninactrl:DetachingExpander.Header>
+
+                <StackPanel Orientation="Vertical">
+                    <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+                        <ninactrl:DetachingExpander.Header>
+                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description}" />
+                        </ninactrl:DetachingExpander.Header>
+                        <StackPanel Orientation="Vertical">
+                            <Border
+                                MinHeight="50"
+                                Margin="0,10,0,0"
+                                BorderBrush="{StaticResource BorderBrush}"
+                                BorderThickness="1">
+                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding BeforeWaitForSafe}">
+                                    <ItemsControl MinHeight="50" ItemsSource="{Binding Items}" />
+                                    <TextBlock
+                                        Height="18"
+                                        MaxHeight="18"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontStyle="Italic"
+                                        Opacity="0.4"
+                                        Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_HelpDescription}"
+                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DragOverBehavior DragAboveSize="0" DragBelowSize="0" />
+                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                                    </i:Interaction.Behaviors>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </ninactrl:DetachingExpander>
+                    <ContentControl DataContext="{Binding WaitUntilSafe}" IsEnabled="False" />
+                    <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+                        <ninactrl:DetachingExpander.Header>
+                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description}" />
+                        </ninactrl:DetachingExpander.Header>
+                        <StackPanel Orientation="Vertical">
+                            <Border
+                                MinHeight="50"
+                                Margin="0,10,0,0"
+                                BorderBrush="{StaticResource BorderBrush}"
+                                BorderThickness="1">
+                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding AfterWaitForSafe}">
+                                    <ItemsControl MinHeight="50" ItemsSource="{Binding Items}" />
+                                    <TextBlock
+                                        Height="18"
+                                        MaxHeight="18"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontStyle="Italic"
+                                        Opacity="0.4"
+                                        Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription}"
+                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DragOverBehavior DragAboveSize="0" DragBelowSize="0" />
+                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                                    </i:Interaction.Behaviors>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </ninactrl:DetachingExpander>
+                </StackPanel>
+
+            </ninactrl:DetachingExpander>
+        </Border>
+    </DataTemplate>
+
+    <DataTemplate x:Key="NINA.Sequencer.Trigger.SafetyMonitor.TriggerOnUnsafe_Mini">
+        <StackPanel Orientation="Vertical">
+            <mini:MiniTrigger />
+            <StackPanel Orientation="Vertical">
+                <StackPanel.Style>
+                    <Style TargetType="{x:Type StackPanel}">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Status}" Value="{x:Static enum:SequenceEntityStatus.RUNNING}">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <mini:MiniContainer DataContext="{Binding BeforeWaitForSafe}" />
+                <mini:MiniSequenceItem DataContext="{Binding WaitUntilSafe}" />
+                <mini:MiniContainer DataContext="{Binding AfterWaitForSafe}" />
+            </StackPanel>
+        </StackPanel>
     </DataTemplate>
 
     <DataTemplate DataType="{x:Type local:SequenceTrigger}">

--- a/NINA.Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafe.cs
+++ b/NINA.Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafe.cs
@@ -1,0 +1,264 @@
+﻿using Newtonsoft.Json;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.SafetyMonitor;
+using NINA.Sequencer.Utility;
+using NINA.Sequencer.Validations;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Sequencer.Trigger.SafetyMonitor {
+    [ExportMetadata("Name", "Lbl_SequenceTrigger_TriggerOnUnsafe_Name")]
+    [ExportMetadata("Description", "Lbl_SequenceTrigger_TriggerOnUnsafe_Description")]
+    [ExportMetadata("Icon", "ShieldSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_SafetyMonitor")]
+    [Export(typeof(ISequenceTrigger))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public class TriggerOnUnsafe : SequenceTrigger, IValidatable {
+        private IList<string> issues = new List<string>();
+        private readonly ISafetyMonitorMediator safetyMonitorMediator;
+        private readonly IApplicationResourceDictionary resourceDictionary;
+        private readonly object triggerLock = new object();
+        private bool shouldTrigger;
+        private bool triggerIsRunning;
+        private bool hasSeenConnected;
+
+        [ImportingConstructor]
+        public TriggerOnUnsafe(ISafetyMonitorMediator safetyMonitorMediator, IApplicationResourceDictionary resourceDictionary) {
+            this.safetyMonitorMediator = safetyMonitorMediator;
+            this.resourceDictionary = resourceDictionary;
+            BeforeWaitForSafe = new SequentialContainer() { Name = Loc.Instance["Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description"], IsExpanded = true }.AddMetaData(resourceDictionary) as SequentialContainer;
+            AfterWaitForSafe = new SequentialContainer() { Name = Loc.Instance["Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description"], IsExpanded = true }.AddMetaData(resourceDictionary) as SequentialContainer;
+            WaitUntilSafe = new WaitUntilSafe(safetyMonitorMediator).AddMetaData(resourceDictionary) as WaitUntilSafe;
+        }
+
+        private TriggerOnUnsafe(TriggerOnUnsafe cloneMe) : this(cloneMe.safetyMonitorMediator, cloneMe.resourceDictionary) {
+            CopyMetaData(cloneMe);
+            BeforeWaitForSafe = (SequentialContainer)cloneMe.BeforeWaitForSafe.Clone();
+            AfterWaitForSafe = (SequentialContainer)cloneMe.AfterWaitForSafe.Clone();
+            WaitUntilSafe = (WaitUntilSafe)cloneMe.WaitUntilSafe.Clone();
+        }
+
+
+        public bool Validate() {
+            List<string> i = new List<string>();
+
+            BeforeWaitForSafe.Validate();
+            AfterWaitForSafe.Validate();
+            i.AddRange(BeforeWaitForSafe.Issues);
+            i.AddRange(AfterWaitForSafe.Issues);
+
+            Issues = i;
+            return true;
+        }
+
+        public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
+            return ShouldRunUnsafeTrigger();
+        }
+
+        public override bool ShouldTriggerAfter(ISequenceItem previousItem, ISequenceItem nextItem) {
+            return ShouldRunUnsafeTrigger();
+        }
+
+        private bool ShouldRunUnsafeTrigger() {
+            var info = safetyMonitorMediator.GetInfo();
+            lock (triggerLock) {
+                if (info.Connected) {
+                    hasSeenConnected = true;
+                    if (info.IsSafe) {
+                        shouldTrigger = false;
+                        return false;
+                    }
+                } else if (!hasSeenConnected) {
+                    shouldTrigger = false;
+                    return false;
+                }
+
+                shouldTrigger = true;
+                return shouldTrigger && !triggerIsRunning;
+            }
+        }
+
+        [JsonProperty]
+        public SequentialContainer BeforeWaitForSafe {
+            get;
+            set;
+        }
+
+        [JsonProperty]
+        public SequentialContainer AfterWaitForSafe {
+            get;
+            set;
+        }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public WaitUntilSafe WaitUntilSafe { get; private set; }
+
+        public override async Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            lock (triggerLock) {
+                shouldTrigger = false;
+                triggerIsRunning = true;
+            }
+
+            try {
+                BeforeWaitForSafe.ResetProgress();
+                WaitUntilSafe.ResetProgress();
+                AfterWaitForSafe.ResetProgress();
+                await ConfigureTriggerRunner();
+
+                Logger.Info("Unsafe conditions detected, running Trigger On Unsafe");
+                await TriggerRunner.Run(progress, token);
+            } finally {
+
+                lock (triggerLock) {
+                    BeforeWaitForSafe.AttachNewParent(null);
+                    AfterWaitForSafe.AttachNewParent(null);
+                    BeforeWaitForSafe.ResetProgress();
+                    WaitUntilSafe.ResetProgress();
+                    AfterWaitForSafe.ResetProgress();
+
+                    triggerIsRunning = false;
+                    shouldTrigger = IsUnsafe();
+                }
+            }
+        }
+
+        private async Task ConfigureTriggerRunner() {
+            var dispatcher = System.Windows.Application.Current?.Dispatcher;
+            if (dispatcher != null && !dispatcher.CheckAccess()) {
+                await dispatcher.InvokeAsync(ConfigureTriggerRunnerCore, System.Windows.Threading.DispatcherPriority.Normal);
+            } else {
+                ConfigureTriggerRunnerCore();
+            }
+        }
+
+        private void ConfigureTriggerRunnerCore() {
+            foreach (var item in TriggerRunner.GetItemsSnapshot()) {
+                TriggerRunner.Remove(item);
+            }
+
+            TriggerRunner.Add(BeforeWaitForSafe);
+            TriggerRunner.Add(WaitUntilSafe);
+            TriggerRunner.Add(AfterWaitForSafe);
+        }
+
+        public override void AfterParentChanged() {
+            if (Parent == null) {
+                SequenceBlockTeardown();
+            } else if (Parent.Status == SequenceEntityStatus.RUNNING) {
+                SequenceBlockInitialize();
+            }
+        }
+
+        public override void SequenceBlockInitialize() {
+            SequenceBlockTeardown();
+
+            lock (triggerLock) {
+                shouldTrigger = false;
+                triggerIsRunning = false;
+                hasSeenConnected = safetyMonitorMediator.GetInfo().Connected;
+            }
+
+            safetyMonitorMediator.Connected += SafetyMonitorMediator_Connected;
+            safetyMonitorMediator.IsSafeChanged += SafetyMonitorMediator_IsSafeChanged;
+            safetyMonitorMediator.Disconnected += SafetyMonitorMediator_Disconnected;
+
+            QueueIfUnsafe();
+        }
+
+        public override void SequenceBlockTeardown() {
+            safetyMonitorMediator.Connected -= SafetyMonitorMediator_Connected;
+            safetyMonitorMediator.IsSafeChanged -= SafetyMonitorMediator_IsSafeChanged;
+            safetyMonitorMediator.Disconnected -= SafetyMonitorMediator_Disconnected;
+
+            lock (triggerLock) {
+                shouldTrigger = false;
+                triggerIsRunning = false;
+                hasSeenConnected = false;
+            }
+        }
+
+        private Task SafetyMonitorMediator_Connected(object sender, EventArgs e) {
+            lock (triggerLock) {
+                hasSeenConnected = true;
+            }
+
+            QueueIfUnsafe();
+            return Task.CompletedTask;
+        }
+
+        private void SafetyMonitorMediator_IsSafeChanged(object sender, IsSafeEventArgs e) {
+            if (!e.IsSafe) {
+                QueueIfUnsafe();
+            }
+        }
+
+        private Task SafetyMonitorMediator_Disconnected(object sender, EventArgs e) {
+            QueueIfUnsafe();
+            return Task.CompletedTask;
+        }
+
+        private void QueueIfUnsafe() {
+            if (!IsUnsafe() || !IsActive()) {
+                return;
+            }
+
+            bool shouldSkipRunningItems;
+            lock (triggerLock) {
+                bool wasAlreadyQueued = shouldTrigger;
+                shouldTrigger = true;
+                shouldSkipRunningItems = !wasAlreadyQueued && !triggerIsRunning;
+            }
+
+            if (shouldSkipRunningItems) {
+                ItemUtility.GetRootContainer(Parent)?.InterruptAndResetCurrentRunningItems();
+            }
+        }
+
+        private bool IsUnsafe() {
+            var info = safetyMonitorMediator.GetInfo();
+            lock (triggerLock) {
+                if (info.Connected) {
+                    hasSeenConnected = true;
+                    return !info.IsSafe;
+                }
+
+                return hasSeenConnected;
+            }
+        }
+
+        private bool IsActive() {
+            return Parent != null
+                && ItemUtility.IsInRootContainer(Parent)
+                && Parent.Status == SequenceEntityStatus.RUNNING
+                && Status != SequenceEntityStatus.DISABLED;
+        }
+
+        public override object Clone() {
+            return new TriggerOnUnsafe(this);
+        }
+
+        public IList<string> Issues {
+            get => issues;
+            set {
+                issues = ImmutableList.CreateRange(value);
+                RaisePropertyChanged();
+            }
+        }
+
+        public override string ToString() {
+            return $"Trigger: {nameof(TriggerOnUnsafe)}";
+        }
+    }
+}

--- a/NINA.Sequencer/Utility/SequenceEntityExtensions.cs
+++ b/NINA.Sequencer/Utility/SequenceEntityExtensions.cs
@@ -1,0 +1,60 @@
+﻿using NINA.Core.Locale;
+using NINA.Core.Utility;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.Trigger;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+
+namespace NINA.Sequencer.Utility {
+    /// <summary>
+    /// Creating new instances of Sequence Entities doesn't add the Name, Category and Icon to them, as these are handled differently in the core application
+    /// These Extension methods work similar to the plugin loader and inject the export attributes into the respective fields
+    /// This should be put into a future Version of core NINA.Sequencer
+    /// </summary>
+    public static class SequenceEntityExtension {
+        public static ISequenceContainer AddMetaData(this ISequenceContainer entity, IApplicationResourceDictionary resourceDictionary) {
+            var attributes = entity.GetType().GetCustomAttributes(false).OfType<ExportMetadataAttribute>();
+            entity.Description = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Description")?.Value?.ToString() ?? "");
+            entity.Category = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Category")?.Value?.ToString() ?? "");
+            entity.Icon = (System.Windows.Media.GeometryGroup)resourceDictionary[(attributes.FirstOrDefault(x => x.Name == "Icon")?.Value?.ToString() ?? "")];
+            return entity;
+        }
+        public static ISequenceItem AddMetaData(this ISequenceItem entity, IApplicationResourceDictionary resourceDictionary) {
+            var attributes = entity.GetType().GetCustomAttributes(false).OfType<ExportMetadataAttribute>();
+            entity.Name = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Name")?.Value?.ToString() ?? "");
+            entity.Description = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Description")?.Value?.ToString() ?? "");
+            entity.Category = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Category")?.Value?.ToString() ?? "");
+            entity.Icon = (System.Windows.Media.GeometryGroup)resourceDictionary[(attributes.FirstOrDefault(x => x.Name == "Icon")?.Value?.ToString() ?? "")];
+            return entity;
+        }
+        public static ISequenceCondition AddMetaData(this ISequenceCondition entity, IApplicationResourceDictionary resourceDictionary) {
+            var attributes = entity.GetType().GetCustomAttributes(false).OfType<ExportMetadataAttribute>();
+            entity.Name = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Name")?.Value?.ToString() ?? "");
+            entity.Description = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Description")?.Value?.ToString() ?? "");
+            entity.Category = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Category")?.Value?.ToString() ?? "");
+            entity.Icon = (System.Windows.Media.GeometryGroup)resourceDictionary[(attributes.FirstOrDefault(x => x.Name == "Icon")?.Value?.ToString() ?? "")];
+            return entity;
+        }
+        public static ISequenceTrigger AddMetaData(this ISequenceTrigger entity, IApplicationResourceDictionary resourceDictionary) {
+            var attributes = entity.GetType().GetCustomAttributes(false).OfType<ExportMetadataAttribute>();
+            entity.Name = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Name")?.Value?.ToString() ?? "");
+            entity.Description = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Description")?.Value?.ToString() ?? "");
+            entity.Category = GrabLabel(attributes.FirstOrDefault(x => x.Name == "Category")?.Value?.ToString() ?? "");
+            entity.Icon = (System.Windows.Media.GeometryGroup)resourceDictionary[(attributes.FirstOrDefault(x => x.Name == "Icon")?.Value?.ToString() ?? "")];
+            return entity;
+        }
+        private static string GrabLabel(string label) {
+            if (label == null) return "";
+            if (label.StartsWith("Lbl_")) {
+                return Loc.Instance[label];
+            } else {
+                return label;
+            }
+        }
+    }
+}

--- a/NINA.Test/Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafeTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafeTest.cs
@@ -70,10 +70,10 @@ namespace NINA.Test.Sequencer.SequenceItem.SafetyMonitor {
             var sut = new WaitUntilSafe(safetyMonitorMock.Object);
             var valid = sut.Validate();
 
+            // Should still run when disconnected but report issues
             valid.Should().BeTrue();
 
-            // Should still run when disconnected
-            sut.Issues.Should().HaveCount(0);
+            sut.Issues.Should().HaveCount(1);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafeTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/SafetyMonitor/WaitUntilSafeTest.cs
@@ -64,15 +64,16 @@ namespace NINA.Test.Sequencer.SequenceItem.SafetyMonitor {
         }
 
         [Test]
-        public void Validate_NotConnected_OneIssue() {
+        public void Validate_NotConnected_NoIssue() {
             safetyMonitorMock.Setup(x => x.GetInfo()).Returns(new SafetyMonitorInfo() { Connected = false });
 
             var sut = new WaitUntilSafe(safetyMonitorMock.Object);
             var valid = sut.Validate();
 
-            valid.Should().BeFalse();
+            valid.Should().BeTrue();
 
-            sut.Issues.Should().HaveCount(1);
+            // Should still run when disconnected
+            sut.Issues.Should().HaveCount(0);
         }
 
         [Test]

--- a/NINA.Test/Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafeTest.cs
+++ b/NINA.Test/Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafeTest.cs
@@ -1,0 +1,256 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.Enum;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MySafetyMonitor;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.Trigger.SafetyMonitor;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
+
+    [TestFixture]
+    public class TriggerOnUnsafeTest {
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
+        private Mock<IApplicationResourceDictionary> resourceDictionaryMock;
+        private SafetyMonitorInfo safetyMonitorInfo;
+        private TriggerOnUnsafe sut;
+
+        [SetUp]
+        public void Setup() {
+            safetyMonitorInfo = new SafetyMonitorInfo() {
+                Connected = true,
+                IsSafe = true
+            };
+
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
+            safetyMonitorMediatorMock.Setup(x => x.GetInfo()).Returns(() => safetyMonitorInfo);
+
+            resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+
+            sut = new TriggerOnUnsafe(safetyMonitorMediatorMock.Object, resourceDictionaryMock.Object) {
+                Name = "Trigger On Unsafe",
+                Description = "Description",
+                Category = "Safety",
+                Icon = new GeometryGroup()
+            };
+        }
+
+        /// <summary>
+        /// Verifies cloning preserves trigger metadata and creates independent nested trigger instructions.
+        /// </summary>
+        [Test]
+        public void Clone_CopiesMetadataAndNestedSteps() {
+            TriggerOnUnsafe clone = (TriggerOnUnsafe)sut.Clone();
+
+            clone.Should().NotBeSameAs(sut);
+            clone.Name.Should().Be(sut.Name);
+            clone.Description.Should().Be(sut.Description);
+            clone.Category.Should().Be(sut.Category);
+            clone.Icon.Should().BeSameAs(sut.Icon);
+            clone.BeforeWaitForSafe.Should().NotBeSameAs(sut.BeforeWaitForSafe);
+            clone.AfterWaitForSafe.Should().NotBeSameAs(sut.AfterWaitForSafe);
+            clone.WaitUntilSafe.Should().NotBeSameAs(sut.WaitUntilSafe);
+        }
+
+        /// <summary>
+        /// Verifies a disconnected safety monitor does not trigger before this sequence context has observed a connection.
+        /// </summary>
+        [Test]
+        public void ShouldTrigger_DisconnectedBeforeSafetyMonitorWasConnected_ReturnsFalse() {
+            safetyMonitorInfo.Connected = false;
+            safetyMonitorInfo.IsSafe = false;
+
+            sut.ShouldTrigger(null, null).Should().BeFalse();
+            sut.ShouldTriggerAfter(null, null).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Verifies an actively connected unsafe safety monitor queues the trigger.
+        /// </summary>
+        [Test]
+        public void ShouldTrigger_ConnectedUnsafe_ReturnsTrue() {
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = false;
+
+            sut.ShouldTrigger(null, null).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Verifies disconnecting after a known connection is treated as unsafe and queues the trigger.
+        /// </summary>
+        [Test]
+        public void ShouldTrigger_DisconnectedAfterSafetyMonitorWasConnected_ReturnsTrue() {
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = true;
+
+            sut.ShouldTrigger(null, null).Should().BeFalse();
+
+            safetyMonitorInfo.Connected = false;
+
+            sut.ShouldTrigger(null, null).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Verifies the disconnected event does not interrupt running work before the monitor has connected once.
+        /// </summary>
+        [Test]
+        public void DisconnectedEvent_BeforeFirstConnection_DoesNotInterruptRunningItems() {
+            safetyMonitorInfo.Connected = false;
+            safetyMonitorInfo.IsSafe = false;
+            Mock<ISequenceItem> runningItemMock = AttachToRunningRoot();
+
+            safetyMonitorMediatorMock.Raise(x => x.Disconnected += null, safetyMonitorMediatorMock.Object, EventArgs.Empty);
+
+            runningItemMock.Verify(x => x.Skip(), Times.Never);
+            runningItemMock.Verify(x => x.ResetProgress(), Times.Never);
+        }
+
+        /// <summary>
+        /// Verifies the disconnected event interrupts and resets running work after a prior monitor connection.
+        /// </summary>
+        [Test]
+        public void DisconnectedEvent_AfterFirstConnection_InterruptsRunningItems() {
+            safetyMonitorInfo.Connected = false;
+            safetyMonitorInfo.IsSafe = false;
+            Mock<ISequenceItem> runningItemMock = AttachToRunningRoot();
+
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = true;
+            safetyMonitorMediatorMock.Raise(x => x.Connected += null, safetyMonitorMediatorMock.Object, EventArgs.Empty);
+
+            safetyMonitorInfo.Connected = false;
+            safetyMonitorMediatorMock.Raise(x => x.Disconnected += null, safetyMonitorMediatorMock.Object, EventArgs.Empty);
+
+            runningItemMock.Verify(x => x.Skip(), Times.Once);
+            runningItemMock.Verify(x => x.ResetProgress(), Times.Once);
+        }
+
+        /// <summary>
+        /// Verifies an unsafe state-change event interrupts and resets running work.
+        /// </summary>
+        [Test]
+        public void IsSafeChanged_ToUnsafe_InterruptsRunningItems() {
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = true;
+            Mock<ISequenceItem> runningItemMock = AttachToRunningRoot();
+
+            safetyMonitorInfo.IsSafe = false;
+            safetyMonitorMediatorMock.Raise(x => x.IsSafeChanged += null, safetyMonitorMediatorMock.Object, new IsSafeEventArgs(false));
+
+            runningItemMock.Verify(x => x.Skip(), Times.Once);
+            runningItemMock.Verify(x => x.ResetProgress(), Times.Once);
+        }
+
+        /// <summary>
+        /// Verifies executing the trigger builds the expected nested instruction list and resets progress afterwards.
+        /// </summary>
+        [Test]
+        public async Task Execute_WhenAlreadySafe_RunsAndResetsNestedSteps() {
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = true;
+
+            await sut.Execute(new SequentialContainer(), Mock.Of<IProgress<ApplicationStatus>>(), CancellationToken.None);
+
+            sut.BeforeWaitForSafe.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.WaitUntilSafe.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.AfterWaitForSafe.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.TriggerRunner.GetItemsSnapshot().Should().HaveCount(3);
+        }
+
+        /// <summary>
+        /// Verifies validation remains non-blocking when the monitor is disconnected.
+        /// </summary>
+        [Test]
+        public void Validate_SafetyMonitorDisconnected_DoesNotReportSafetyMonitorIssue() {
+            safetyMonitorInfo.Connected = false;
+            safetyMonitorInfo.IsSafe = false;
+
+            sut.Validate().Should().BeTrue();
+            sut.Issues.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies nested instruction container issues are exposed while validation still returns true.
+        /// </summary>
+        [Test]
+        public void Validate_InstructionContainerIssues_ReturnsTrueAndReportsIssues() {
+            sut.BeforeWaitForSafe = new IssueReportingSequentialContainer("before issue");
+            sut.AfterWaitForSafe = new IssueReportingSequentialContainer("after issue");
+
+            sut.Validate().Should().BeTrue();
+            sut.Issues.Should().Equal("before issue", "after issue");
+        }
+
+        /// <summary>
+        /// Verifies the trigger string representation identifies the trigger type.
+        /// </summary>
+        [Test]
+        public void ToString_ReturnsTriggerName() {
+            sut.ToString().Should().Be("Trigger: TriggerOnUnsafe");
+        }
+
+        /// <summary>
+        /// Attaches the trigger to a running root container with one mocked running item.
+        /// </summary>
+        private Mock<ISequenceItem> AttachToRunningRoot() {
+            Mock<ISequenceItem> runningItemMock = new Mock<ISequenceItem>();
+            runningItemMock.SetupGet(x => x.Status).Returns(SequenceEntityStatus.RUNNING);
+
+            SequenceRootContainer root = new SequenceRootContainer() {
+                Status = SequenceEntityStatus.RUNNING
+            };
+            root.AddRunningItem(runningItemMock.Object);
+
+            sut.AttachNewParent(root);
+
+            return runningItemMock;
+        }
+
+        /// <summary>
+        /// Test-only container that simulates nested instruction validation feedback.
+        /// </summary>
+        private sealed class IssueReportingSequentialContainer : SequentialContainer {
+            private readonly string issue;
+
+            /// <summary>
+            /// Initializes a container that reports the specified issue during validation.
+            /// </summary>
+            public IssueReportingSequentialContainer(string issue) {
+                this.issue = issue;
+            }
+
+            /// <summary>
+            /// Reports the configured issue and returns false to prove trigger validation remains non-blocking.
+            /// </summary>
+            public override bool Validate() {
+                Issues.Clear();
+                Issues.Add(issue);
+                return false;
+            }
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,7 @@ This allows you to safely return to a stable release if needed.
 - Unparking the mount no longer automatically starts sidereal tracking. Tracking will begin automatically during a slew to a target, as usual.
   - This change only affects mount drivers that previously started tracking immediately upon unparking; drivers that did not exhibit this behavior are unaffected.
   - Preventing automatic tracking on unpark avoids unexpected mount movement and reduces the risk of pier collisions or other unintended motion, while ensuring consistent and predictable behavior across drivers.
+- `Wait Until Safe` instruction no longer requires a safety monitor to be connected. A disconnected safety monitor is treated as unsafe, as it could be disconnected due to communication failures.
 
 ## Features
 
@@ -87,6 +88,10 @@ This allows you to safely return to a stable release if needed.
   - Expression support for plugin-provided sequence items is **opt-in** and requires plugin updates.
   - Plugins must explicitly adopt the new expression system to expose expression-enabled fields.
   - Plugins that are not updated continue to function normally, but their sequence items will not offer expression support.
+
+- **Sequencer**
+    - Added a new **Trigger On Unsafe** safety monitor trigger. It can run configured instructions when the safety monitor reports unsafe or disconnects after it has been connected, then wait until the safety monitor reports safe again before running follow-up instructions.
+    - When triggered, the currently running instruction is interrupted and reset so safety handling can take over immediately.
 
 ### **Device Management**
 - **ASCOM Alpaca Direct Drivers**


### PR DESCRIPTION
##  Purpose

Adds a new **Trigger On Unsafe** safety monitor trigger for the advanced sequencer. It can interrupt/reset running work when unsafe conditions are detected, run safety instructions, wait until safe again, and then run follow-up instructions.

Additionally it adds `InterruptAndResetCurrentRunningItems()` to the sequence root container contract so safety triggers can interrupt and reset active instructions before running safety handling.

##  How Was It Tested?

- Added unit coverage for `TriggerOnUnsafe`.
- Ran targeted `TriggerOnUnsafeTest` fixture successfully.
- Manually validated sequencer UI behavior for the new trigger template.

##  AI / Tooling Disclosure

None.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
  - [ ] No breaking changes to interfaces
  - [ ] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

##  Related Issues

None.

##  Screenshots

N/A

##  Additional Notes
