### PR TITLE
Add custom trigger with reusable trigger instruction areas

### DIFF
--- a/.codex/skills/nina-repository/references/testing-map.md
+++ b/.codex/skills/nina-repository/references/testing-map.md
@@ -98,7 +98,7 @@ Use these when the changed file is under the matching sequencer subtree:
 - `NINA.Test.Sequencer.Serialization`
 - `NINA.Test.Sequencer.SequenceItem.<Area>` where `<Area>` is `Autofocus`, `Camera`, `Dome`, `FilterWheel`, `FlatDevice`, `Focuser`, `Guider`, `Imaging`, `Platesolving`, `Rotator`, `SafetyMonitor`, `Switch`, `Telescope`, or `Utility`
 - Target-coordinate inheritance across `CoordinatesInstruction` sequence items: `NINA.Test.Sequencer.SequenceItem.CoordinatesInstructionInheritanceTest`
-- `NINA.Test.Sequencer.Trigger.<Area>` where `<Area>` is `Autofocus`, `Dome`, `Guider`, `MeridianFlip`, or `Platesolving`
+- `NINA.Test.Sequencer.Trigger.<Area>` where `<Area>` is `Autofocus`, `Dome`, `Guider`, `MeridianFlip`, `Platesolving`, or `Utility`
 - `NINA.Test.Sequencer.Utility.DateTimeProvider`
 - `NINA.Test.Sequencer.View`, `NINA.Test.Sequencer.View.Converter`, or `NINA.Test.Sequencer.View.MiniSequencer`
 

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7898,6 +7898,31 @@ If exposure count is not important to you, enable this option to avoid having to
   <data name="LblEccentricity" xml:space="preserve">
     <value>Eccentricity</value>
   </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_Name" xml:space="preserve">
+    <value>Custom Trigger</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_Description" xml:space="preserve">
+    <value>Use an existing trigger as the trigger source, then choose your own instructions to run when that trigger would normally fire.
+This is useful when a built-in trigger has the timing you need, but you want custom actions.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_TriggerSource_Name" xml:space="preserve">
+    <value>Trigger Source</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_Instructions_Name" xml:space="preserve">
+    <value>Custom Trigger Instructions</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_TriggerSource_HelpDescription" xml:space="preserve">
+    <value>Drop a trigger here to choose when the custom trigger runs.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_Instructions_HelpDescription" xml:space="preserve">
+    <value>Drop instructions here to run when the selected trigger source fires.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_NoTriggerSource_Issue" xml:space="preserve">
+    <value>Add a trigger source.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_CustomTrigger_NoInstructions_Issue" xml:space="preserve">
+    <value>Add at least one instruction.</value>
+  </data>
   <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_Name" xml:space="preserve">
     <value>Trigger On Unsafe</value>
   </data>

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml
@@ -13,6 +13,9 @@
     xmlns:af="clr-namespace:NINA.Sequencer.Trigger.Autofocus"
     xmlns:behaviors="clr-namespace:NINA.Sequencer.Behaviors"
     xmlns:connect="clr-namespace:NINA.Sequencer.Trigger.Connect"
+    xmlns:cont="clr-namespace:NINA.Sequencer.Container"
+    xmlns:converter="clr-namespace:NINA.View.Sequencer.Converter"
+    xmlns:coreUtil="clr-namespace:NINA.Core.Utility;assembly=NINA.Core"
     xmlns:d="clr-namespace:NINA.Sequencer.Trigger.Dome"
     xmlns:enum="clr-namespace:NINA.Core.Enum;assembly=NINA.Core"
     xmlns:g="clr-namespace:NINA.Sequencer.Trigger.Guider"
@@ -26,8 +29,215 @@
     xmlns:p="clr-namespace:NINA.Sequencer.Trigger.Platesolving"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:safety="clr-namespace:NINA.Sequencer.Trigger.SafetyMonitor"
+    xmlns:seqItem="clr-namespace:NINA.Sequencer.SequenceItem"
+    xmlns:utility="clr-namespace:NINA.Sequencer.Trigger.Utility"
     xmlns:view="clr-namespace:NINA.View.Sequencer"
+    xmlns:wpfbehaviors="clr-namespace:NINA.WPF.Base.Behaviors;assembly=NINA.WPF.Base"
     xmlns:wpfutil="clr-namespace:NINA.WPF.Base.Utility;assembly=NINA.WPF.Base">
+
+    <converter:TreeViewDepthToColorConverter x:Key="TriggerInstructionTreeViewDepthToColorConverter" />
+    <Style x:Key="TriggerInstructionItemStyle" TargetType="{x:Type TreeViewItem}">
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="20" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Border
+                            x:Name="Bd"
+                            Grid.Column="1"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="true">
+                            <ContentPresenter
+                                x:Name="PART_Header"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                ContentSource="Header"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                        <ItemsPresenter
+                            x:Name="ItemsHost"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            Margin="-21,0,0,0"
+                            HorizontalAlignment="Stretch">
+                            <i:Interaction.Behaviors>
+                                <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                            </i:Interaction.Behaviors>
+                        </ItemsPresenter>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsSelected" Value="true">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="true" />
+                                <Condition Property="IsSelectionActive" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="TriggerInstructionContainerStyle" TargetType="{x:Type TreeViewItem}">
+        <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                    <Grid Margin="0,5,0,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="20" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Border
+                            x:Name="Bd"
+                            Grid.Column="1"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderThickness="4,0,0,0"
+                            SnapsToDevicePixels="true">
+                            <Border.BorderBrush>
+                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                    <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
+                                </MultiBinding>
+                            </Border.BorderBrush>
+                            <ContentPresenter
+                                x:Name="PART_Header"
+                                Margin="-1,-5,0,-5"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                ContentSource="Header"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                        <Border
+                            x:Name="ContainerColorSideBorder"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            BorderThickness="4,0,0,0">
+                            <Border.BorderBrush>
+                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                    <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
+                                </MultiBinding>
+                            </Border.BorderBrush>
+                            <Border
+                                x:Name="ContainerSideBorder"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Grid.ColumnSpan="2"
+                                BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                                BorderThickness="10,0,0,0">
+                                <ItemsPresenter
+                                    x:Name="ItemsHost"
+                                    Margin="0,0,0,15"
+                                    HorizontalAlignment="Stretch">
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                                    </i:Interaction.Behaviors>
+                                </ItemsPresenter>
+                            </Border>
+                        </Border>
+                        <Border
+                            x:Name="ContainerBottomBorder"
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            Margin="0,0,0,5"
+                            BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                            BorderThickness="4,0,0,15">
+                            <i:Interaction.Behaviors>
+                                <behaviors:DragOverBehavior
+                                    AllowDragAbove="False"
+                                    AllowDragBelow="{Binding IsExpanded}"
+                                    AllowDragCenter="False"
+                                    DragBelowSize="15"
+                                    Enabled="{Binding IsExpanded}" />
+                            </i:Interaction.Behaviors>
+                        </Border>
+                        <Rectangle
+                            x:Name="ContainerBottomCapLine"
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            Width="40"
+                            Height="2"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            IsHitTestVisible="False">
+                            <Rectangle.Fill>
+                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                    <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
+                                </MultiBinding>
+                            </Rectangle.Fill>
+                        </Rectangle>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsExpanded}" Value="false">
+                            <Setter TargetName="ContainerSideBorder" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ContainerColorSideBorder" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ContainerBottomBorder" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ContainerBottomCapLine" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.ApplicationSettings.ColoredContainerBorders}" Value="False">
+                            <Setter TargetName="Bd" Property="BorderThickness" Value="0,0,0,0" />
+                            <Setter TargetName="ContainerColorSideBorder" Property="BorderThickness" Value="0,0,0,0" />
+                            <Setter TargetName="ContainerSideBorder" Property="BorderThickness" Value="10,0,0,0" />
+                            <Setter TargetName="ContainerBottomBorder" Property="BorderThickness" Value="0,0,0,15" />
+                            <Setter TargetName="ContainerBottomCapLine" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                        <Trigger Property="IsSelected" Value="true">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="true" />
+                                <Condition Property="IsSelectionActive" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <view:SequenceTreeViewItemStyleSelector
+        x:Key="TriggerInstructionTreeViewItemStyleSelector"
+        ContainerStyle="{StaticResource TriggerInstructionContainerStyle}"
+        DefaultStyle="{StaticResource TriggerInstructionItemStyle}"
+        ItemStyle="{StaticResource TriggerInstructionItemStyle}" />
 
     <DataTemplate x:Key="NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger_Mini">
         <mini:MiniTrigger>
@@ -596,18 +806,292 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <DataTemplate DataType="{x:Type utility:CustomTrigger}">
+        <Border>
+            <Border.Resources>
+                <ResourceDictionary>
+                    <ResourceDictionary.MergedDictionaries>
+                        <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
+                    </ResourceDictionary.MergedDictionaries>
+                    <coreUtil:BindingProxy x:Key="ViewModel" Data="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:SequenceView}}, Path=DataContext}" />
+                    <DataTemplate x:Key="TriggerSourceMenuItemTemplate">
+                        <StackPanel MinHeight="30" Orientation="Horizontal">
+                            <Path
+                                Width="20"
+                                Height="20"
+                                Margin="5"
+                                Data="{Binding Entity.Icon}"
+                                Fill="{StaticResource PrimaryBrush}"
+                                Stretch="Uniform"
+                                UseLayoutRounding="True" />
+                            <TextBlock VerticalAlignment="Center" Text="{Binding Entity.Name}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ResourceDictionary>
+            </Border.Resources>
+            <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+                <ninactrl:DetachingExpander.Header>
+                    <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal">
+                            <TextBlock
+                                MinHeight="25"
+                                Margin="10,10,10,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="{Binding Name}" />
+                            <Border
+                                Width="20"
+                                Height="20"
+                                Margin="5,0,5,0"
+                                Background="{StaticResource NotificationErrorBrush}"
+                                BorderBrush="Transparent"
+                                CornerRadius="10">
+                                <Border.Visibility>
+                                    <PriorityBinding>
+                                        <Binding
+                                            Converter="{StaticResource ZeroToVisibilityConverter}"
+                                            FallbackValue="Collapsed"
+                                            Path="Issues.Count" />
+                                    </PriorityBinding>
+                                </Border.Visibility>
+                                <Path
+                                    HorizontalAlignment="Right"
+                                    Data="{StaticResource ExclamationCircledSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform" />
+                                <Border.ToolTip>
+                                    <ItemsControl ItemsSource="{Binding Issues}" />
+                                </Border.ToolTip>
+                            </Border>
+                        </StackPanel>
+                        <Border
+                            Grid.Column="1"
+                            MinHeight="30"
+                            Margin="10,3,10,3"
+                            Background="{StaticResource BackgroundBrush}"
+                            BorderBrush="{StaticResource BorderBrush}"
+                            BorderThickness="1">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <ContentControl
+                                    Grid.Column="0"
+                                    MinHeight="30"
+                                    Content="{Binding TriggerSource}"
+                                    Visibility="{Binding TriggerSource, Converter={StaticResource NullToVisibilityCollapsedConverter}}" />
+                                <TextBlock
+                                    Grid.Column="0"
+                                    Height="18"
+                                    MaxHeight="18"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    FontStyle="Italic"
+                                    Opacity="0.4"
+                                    Text="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_TriggerSource_HelpDescription}"
+                                    Visibility="{Binding TriggerSource, Converter={StaticResource InverseNullToVisibilityCollapsedConverter}}" />
+                                <Button
+                                    x:Name="AddTriggerSourceButton"
+                                    Grid.Column="1"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="5,0,5,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
+                                    <Path
+                                        Margin="5"
+                                        Data="{StaticResource AddSVG}"
+                                        Fill="{StaticResource PrimaryBrush}"
+                                        Stretch="Uniform"
+                                        UseLayoutRounding="True" />
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_AddTrigger_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                    <Button.Style>
+                                        <Style BasedOn="{StaticResource BackgroundButton}" TargetType="{x:Type Button}">
+                                            <EventSetter Event="Click" Handler="AddTriggerSourceButton_Click" />
+                                            <Setter Property="ContextMenu">
+                                                <Setter.Value>
+                                                    <ContextMenu ItemTemplate="{StaticResource TriggerSourceMenuItemTemplate}" ItemsSource="{Binding Source={StaticResource ViewModel}, Path=Data.SequencerFactory.TriggersView}">
+                                                        <ContextMenu.Template>
+                                                            <ControlTemplate>
+                                                                <Border Background="{StaticResource BackgroundBrush}">
+                                                                    <ScrollViewer
+                                                                        CanContentScroll="True"
+                                                                        HorizontalScrollBarVisibility="Disabled"
+                                                                        Style="{StaticResource MenuScrollViewer}"
+                                                                        VerticalScrollBarVisibility="Auto">
+                                                                        <ItemsPresenter />
+                                                                    </ScrollViewer>
+                                                                </Border>
+                                                            </ControlTemplate>
+                                                        </ContextMenu.Template>
+                                                        <ContextMenu.ItemContainerStyle>
+                                                            <Style TargetType="MenuItem">
+                                                                <EventSetter Event="Click" Handler="MenuItemTriggerSource_Click" />
+                                                            </Style>
+                                                        </ContextMenu.ItemContainerStyle>
+                                                    </ContextMenu>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                                <i:Interaction.Behaviors>
+                                    <behaviors:DragOverBehavior
+                                        AllowDragAbove="False"
+                                        AllowDragBelow="False"
+                                        AllowDragCenter="True"
+                                        DragOverCenterText="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_TriggerSource_HelpDescription}" />
+                                    <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Trigger.ISequenceTrigger" OnDropCommand="DropIntoTriggerSourceCommand" />
+                                </i:Interaction.Behaviors>
+                            </Grid>
+                        </Border>
+                        <Border Grid.Column="2" Background="{StaticResource SecondaryBackgroundBrush}">
+                            <ContentPresenter
+                                Margin="2,0,10,0"
+                                HorizontalAlignment="Right"
+                                Content="{Binding}"
+                                DockPanel.Dock="Right"
+                                Style="{StaticResource ProgressPresenter}" />
+                        </Border>
+                        <Border
+                            x:Name="ButtonCommands"
+                            Grid.Column="3"
+                            HorizontalAlignment="Stretch"
+                            Background="{StaticResource SecondaryBackgroundBrush}">
+                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                                <Button
+                                    x:Name="EnableDisableButton"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DisableEnableCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource PowerSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+
+                                <Button
+                                    x:Name="CloseButton"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DetachCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource TrashCanSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </ninactrl:DetachingExpander.Header>
+
+                <Grid
+                    MinHeight="50"
+                    Background="{StaticResource BackgroundBrush}"
+                    DataContext="{Binding TriggerRunner}">
+                    <TreeView
+                        MinHeight="50"
+                        Background="{StaticResource BackgroundBrush}"
+                        BorderThickness="0"
+                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
+                        ItemsSource="{Binding Items}">
+                        <i:Interaction.Behaviors>
+                            <wpfbehaviors:BubbleScrollEvent />
+                        </i:Interaction.Behaviors>
+                        <TreeView.Resources>
+                            <ResourceDictionary>
+                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                    <view:SequenceBlockView />
+                                </DataTemplate>
+                            </ResourceDictionary>
+                        </TreeView.Resources>
+                    </TreeView>
+                    <TextBlock
+                        Height="18"
+                        MaxHeight="18"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        FontStyle="Italic"
+                        Opacity="0.4"
+                        Text="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_HelpDescription}"
+                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                    <i:Interaction.Behaviors>
+                        <behaviors:DragOverBehavior
+                            DragAboveSize="0"
+                            DragBelowSize="0"
+                            DragOverCenterText="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_HelpDescription}" />
+                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                    </i:Interaction.Behaviors>
+                </Grid>
+            </ninactrl:DetachingExpander>
+        </Border>
+    </DataTemplate>
+
+    <DataTemplate x:Key="NINA.Sequencer.Trigger.Utility.CustomTrigger_Mini">
+        <StackPanel Orientation="Vertical">
+            <mini:MiniTrigger />
+            <StackPanel Orientation="Vertical">
+                <StackPanel.Style>
+                    <Style TargetType="{x:Type StackPanel}">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Status}" Value="{x:Static enum:SequenceEntityStatus.RUNNING}">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <mini:MiniContainer DataContext="{Binding TriggerRunner}" />
+            </StackPanel>
+        </StackPanel>
+    </DataTemplate>
+
     <DataTemplate DataType="{x:Type safety:TriggerOnUnsafe}">
         <Border>
             <Border.Resources>
                 <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
             </Border.Resources>
-            <i:Interaction.Behaviors>
-                <!--  Drop area above and below the Sequence Container  -->
-                <behaviors:DragOverBehavior
-                    AllowDragCenter="False"
-                    DragAboveSize="25"
-                    DragBelowSize="15" />
-            </i:Interaction.Behaviors>
             <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
@@ -729,7 +1213,23 @@
                                 BorderBrush="{StaticResource BorderBrush}"
                                 BorderThickness="1">
                                 <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding BeforeWaitForSafe}">
-                                    <ItemsControl MinHeight="50" ItemsSource="{Binding Items}" />
+                                    <TreeView
+                                        MinHeight="50"
+                                        Background="{StaticResource BackgroundBrush}"
+                                        BorderThickness="0"
+                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
+                                        ItemsSource="{Binding Items}">
+                                        <i:Interaction.Behaviors>
+                                            <wpfbehaviors:BubbleScrollEvent />
+                                        </i:Interaction.Behaviors>
+                                        <TreeView.Resources>
+                                            <ResourceDictionary>
+                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                                    <view:SequenceBlockView />
+                                                </DataTemplate>
+                                            </ResourceDictionary>
+                                        </TreeView.Resources>
+                                    </TreeView>
                                     <TextBlock
                                         Height="18"
                                         MaxHeight="18"
@@ -759,7 +1259,23 @@
                                 BorderBrush="{StaticResource BorderBrush}"
                                 BorderThickness="1">
                                 <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding AfterWaitForSafe}">
-                                    <ItemsControl MinHeight="50" ItemsSource="{Binding Items}" />
+                                    <TreeView
+                                        MinHeight="50"
+                                        Background="{StaticResource BackgroundBrush}"
+                                        BorderThickness="0"
+                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
+                                        ItemsSource="{Binding Items}">
+                                        <i:Interaction.Behaviors>
+                                            <wpfbehaviors:BubbleScrollEvent />
+                                        </i:Interaction.Behaviors>
+                                        <TreeView.Resources>
+                                            <ResourceDictionary>
+                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                                    <view:SequenceBlockView />
+                                                </DataTemplate>
+                                            </ResourceDictionary>
+                                        </TreeView.Resources>
+                                    </TreeView>
                                     <TextBlock
                                         Height="18"
                                         MaxHeight="18"

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml.cs
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml.cs
@@ -12,6 +12,10 @@
 
 #endregion "copyright"
 
+using NINA.Core.Enum;
+using NINA.Sequencer;
+using NINA.Sequencer.DragDrop;
+using NINA.Sequencer.Trigger.Utility;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -19,6 +23,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace NINA.Sequencer.Trigger {
 
@@ -27,6 +32,46 @@ namespace NINA.Sequencer.Trigger {
 
         public Datatemplates() {
             InitializeComponent();
+        }
+
+        private void AddTriggerSourceButton_Click(object sender, RoutedEventArgs e) {
+            if (sender is not Button button || button.ContextMenu == null) {
+                return;
+            }
+
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.DataContext = button.DataContext;
+            button.ContextMenu.IsOpen = true;
+            e.Handled = true;
+        }
+
+        private void MenuItemTriggerSource_Click(object sender, RoutedEventArgs e) {
+            if (sender is not MenuItem menuItem) {
+                return;
+            }
+
+            if (menuItem.DataContext is not SidebarEntity entity || entity.Entity is not ISequenceTrigger trigger) {
+                return;
+            }
+
+            if (ItemsControl.ItemsControlFromItemContainer(menuItem) is not ContextMenu contextMenu) {
+                return;
+            }
+
+            CustomTrigger customTrigger = contextMenu.DataContext as CustomTrigger;
+            if (customTrigger == null && contextMenu.PlacementTarget is FrameworkElement placementTarget) {
+                customTrigger = placementTarget.DataContext as CustomTrigger;
+            }
+
+            if (customTrigger == null) {
+                return;
+            }
+
+            DropIntoParameters parameters = new DropIntoParameters(trigger) {
+                Position = DropTargetEnum.Center
+            };
+
+            customTrigger.DropIntoTriggerSourceCommand.Execute(parameters);
         }
     }
 }

--- a/NINA.Sequencer/Trigger/Utility/CustomTrigger.cs
+++ b/NINA.Sequencer/Trigger/Utility/CustomTrigger.cs
@@ -1,0 +1,333 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using GalaSoft.MvvmLight.Command;
+using Newtonsoft.Json;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Sequencer;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.DragDrop;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.Utility;
+using NINA.Sequencer.Validations;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace NINA.Sequencer.Trigger.Utility {
+
+    [ExportMetadata("Name", "Lbl_SequenceTrigger_CustomTrigger_Name")]
+    [ExportMetadata("Description", "Lbl_SequenceTrigger_CustomTrigger_Description")]
+    [ExportMetadata("Icon", "PuzzlePieceSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_Utility")]
+    [Export(typeof(ISequenceTrigger))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public class CustomTrigger : SequenceTrigger, IValidatable {
+        private readonly IApplicationResourceDictionary resourceDictionary;
+        private readonly TriggerSourceParent triggerSourceParent;
+        private IList<string> issues = new List<string>();
+        private ISequenceTrigger triggerSource;
+
+        [ImportingConstructor]
+        public CustomTrigger(IApplicationResourceDictionary resourceDictionary) {
+            this.resourceDictionary = resourceDictionary;
+            triggerSourceParent = new TriggerSourceParent(this);
+            TriggerRunner = CreateAreaContainer("Lbl_SequenceTrigger_CustomTrigger_Instructions_Name");
+        }
+
+        private CustomTrigger(CustomTrigger cloneMe) : this(cloneMe.resourceDictionary) {
+            CopyMetaData(cloneMe);
+            TriggerRunner = (SequentialContainer)cloneMe.TriggerRunner.Clone();
+            TriggerSource = (ISequenceTrigger)cloneMe.TriggerSource?.Clone();
+            AttachTriggerSourceToParent();
+        }
+
+        public override bool AllowMultiplePerSet => true;
+
+        [JsonProperty]
+        public ISequenceTrigger TriggerSource {
+            get => triggerSource;
+            set {
+                if (IsInvalidTriggerSource(value)) {
+                    return;
+                }
+
+                if (ReferenceEquals(triggerSource, value)) {
+                    return;
+                }
+
+                if (triggerSource != null && ReferenceEquals(triggerSource.Parent, triggerSourceParent)) {
+                    triggerSource.AttachNewParent(null);
+                }
+
+                triggerSource = value;
+                AttachTriggerSourceToParent();
+                RaisePropertyChanged();
+            }
+        }
+
+        public ICommand DropIntoTriggerSourceCommand => new RelayCommand<DropIntoParameters>(DropInTriggerSource);
+
+        public IList<string> Issues {
+            get => issues;
+            set {
+                issues = [.. value];
+                RaisePropertyChanged();
+            }
+        }
+
+        [OnDeserialized]
+        public void OnDeserialized(StreamingContext context) {
+            EnsureAreaContainers();
+            AttachTriggerSourceToParent();
+        }
+
+        public override object Clone() {
+            return new CustomTrigger(this);
+        }
+
+        public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
+            return TriggerSource != null
+                && TriggerSource.Status != SequenceEntityStatus.DISABLED
+                && TriggerSource.ShouldTrigger(previousItem, nextItem);
+        }
+
+        public override bool ShouldTriggerAfter(ISequenceItem previousItem, ISequenceItem nextItem) {
+            return TriggerSource != null
+                && TriggerSource.Status != SequenceEntityStatus.DISABLED
+                && TriggerSource.ShouldTriggerAfter(previousItem, nextItem);
+        }
+
+        public override async Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            ISequenceContainer originalParent = TriggerRunner.Parent;
+            ISequenceRootContainer root = ItemUtility.GetRootContainer(context ?? Parent);
+            ISequenceContainer runtimeParent = root == null ? originalParent : new TriggerRunnerRuntimeRoot(root);
+
+            if (!ReferenceEquals(TriggerRunner.Parent, runtimeParent)) {
+                TriggerRunner.AttachNewParent(runtimeParent);
+            }
+
+            try {
+                TriggerRunner.ResetAll();
+                await TriggerRunner.Run(progress, token);
+            } finally {
+                if (!ReferenceEquals(TriggerRunner.Parent, originalParent)) {
+                    TriggerRunner.AttachNewParent(originalParent);
+                }
+            }
+        }
+
+        public override void AfterParentChanged() {
+            AttachTriggerSourceToParent();
+            Validate();
+        }
+
+        public override void Initialize() {
+            TriggerSource?.Initialize();
+        }
+
+        public override void SequenceBlockInitialize() {
+            triggerSourceParent.Status = Parent?.Status ?? SequenceEntityStatus.CREATED;
+            TriggerSource?.SequenceBlockInitialize();
+        }
+
+        public override void SequenceBlockStarted() {
+            triggerSourceParent.Status = Parent?.Status ?? SequenceEntityStatus.RUNNING;
+            TriggerSource?.SequenceBlockStarted();
+        }
+
+        public override void SequenceBlockFinished() {
+            TriggerSource?.SequenceBlockFinished();
+        }
+
+        public override void SequenceBlockTeardown() {
+            TriggerSource?.SequenceBlockTeardown();
+            triggerSourceParent.Status = SequenceEntityStatus.CREATED;
+        }
+
+        public override void Teardown() {
+            TriggerSource?.Teardown();
+        }
+
+        public bool Validate() {
+            List<string> i = new List<string>();
+            bool valid = true;
+
+            if (TriggerSource == null) {
+                i.Add(Loc.Instance["Lbl_SequenceTrigger_CustomTrigger_NoTriggerSource_Issue"]);
+                valid = false;
+            } else if (TriggerSource is IValidatable validatableTrigger) {
+                valid = validatableTrigger.Validate() && valid;
+                i.AddRange(validatableTrigger.Issues);
+            }
+
+            if (!TriggerRunner.GetItemsSnapshot().Any()) {
+                i.Add(Loc.Instance["Lbl_SequenceTrigger_CustomTrigger_NoInstructions_Issue"]);
+                valid = false;
+            }
+
+            TriggerRunner.Validate();
+            i.AddRange(TriggerRunner.Issues);
+
+            Issues = i;
+            return valid;
+        }
+
+        public override string ToString() {
+            return $"Trigger: {nameof(CustomTrigger)}";
+        }
+
+        private void DropInTriggerSource(DropIntoParameters parameters) {
+            if (parameters?.Source is not ISequenceTrigger source) {
+                return;
+            }
+
+            if (IsInvalidTriggerSource(source)) {
+                return;
+            }
+
+            ISequenceTrigger trigger = source.Parent != null && !parameters.Duplicate
+                ? source
+                : (ISequenceTrigger)source.Clone();
+
+            if (trigger.Parent != null && !ReferenceEquals(trigger.Parent, triggerSourceParent)) {
+                trigger.Parent.Remove(trigger);
+            }
+
+            TriggerSource = trigger;
+            Validate();
+        }
+
+        private bool IsInvalidTriggerSource(ISequenceTrigger trigger) {
+            return ReferenceEquals(trigger, this) || trigger is CustomTrigger;
+        }
+
+        private void EnsureAreaContainers() {
+            TriggerRunner ??= CreateAreaContainer("Lbl_SequenceTrigger_CustomTrigger_Instructions_Name");
+
+            if (string.IsNullOrWhiteSpace(TriggerRunner.Name)) {
+                TriggerRunner.Name = Loc.Instance["Lbl_SequenceTrigger_CustomTrigger_Instructions_Name"];
+            }
+        }
+
+        private SequentialContainer CreateAreaContainer(string labelKey) {
+            SequentialContainer container = new SequentialContainer() {
+                Name = Loc.Instance[labelKey],
+                IsExpanded = true
+            };
+
+            return container.AddMetaData(resourceDictionary) as SequentialContainer;
+        }
+
+        private void AttachTriggerSourceToParent() {
+            triggerSourceParent.AttachNewParent(Parent);
+            triggerSourceParent.Status = Parent?.Status ?? SequenceEntityStatus.CREATED;
+            TriggerSource?.AttachNewParent(triggerSourceParent);
+        }
+
+        private void ClearTriggerSource(ISequenceTrigger trigger) {
+            if (!ReferenceEquals(TriggerSource, trigger)) {
+                return;
+            }
+
+            trigger.AttachNewParent(null);
+            triggerSource = null;
+            RaisePropertyChanged(nameof(TriggerSource));
+            Validate();
+        }
+
+        private sealed class TriggerSourceParent : SequentialContainer {
+            private readonly CustomTrigger owner;
+
+            public TriggerSourceParent(CustomTrigger owner) {
+                this.owner = owner;
+            }
+
+            public override bool Remove(ISequenceTrigger trigger) {
+                if (ReferenceEquals(owner.TriggerSource, trigger)) {
+                    owner.ClearTriggerSource(trigger);
+                    return true;
+                }
+
+                return base.Remove(trigger);
+            }
+        }
+
+        private sealed class TriggerRunnerRuntimeRoot : SequentialContainer, ISequenceRootContainer {
+            private readonly ISequenceRootContainer root;
+
+            public TriggerRunnerRuntimeRoot(ISequenceRootContainer root) {
+                this.root = root;
+                Items = root.Items;
+            }
+
+            public string SequenceTitle {
+                get => root.SequenceTitle;
+                set => root.SequenceTitle = value;
+            }
+
+            public Dictionary<string, bool> HasChanges => root.HasChanges;
+
+            public event Func<object, SequenceEntityFailureEventArgs, Task> FailureEvent {
+                add => root.FailureEvent += value;
+                remove => root.FailureEvent -= value;
+            }
+
+            public void AddRunningItem(ISequenceItem item) {
+                root.AddRunningItem(item);
+            }
+
+            public void RemoveRunningItem(ISequenceItem item) {
+                root.RemoveRunningItem(item);
+            }
+
+            public void SkipCurrentRunningItems() {
+                root.SkipCurrentRunningItems();
+            }
+
+            public void InterruptAndResetCurrentRunningItems() {
+                root.InterruptAndResetCurrentRunningItems();
+            }
+
+            public IReadOnlyCollection<ISequenceItem> GetCurrentRunningItems() {
+                return root.GetCurrentRunningItems();
+            }
+
+            public Task RaiseFailureEvent(ISequenceEntity sender, Exception ex) {
+                return root.RaiseFailureEvent(sender, ex);
+            }
+
+            public bool DoesHaveChanges(string hasChangeSet) {
+                return root.DoesHaveChanges(hasChangeSet);
+            }
+
+            public void SetChanged(string changedSet = defaultChangeSet) {
+                root.SetChanged(changedSet);
+            }
+
+            public override Task Interrupt() {
+                return root.Interrupt();
+            }
+        }
+    }
+}

--- a/NINA.Test/Sequencer/Trigger/Utility/CustomTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Utility/CustomTriggerTest.cs
@@ -1,0 +1,365 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.Enum;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.DragDrop;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.Trigger;
+using NINA.Sequencer.Trigger.Utility;
+using NINA.Sequencer.Validations;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using SequenceItemBase = NINA.Sequencer.SequenceItem.SequenceItem;
+
+namespace NINA.Test.Sequencer.Trigger.Utility {
+
+    [TestFixture]
+    public class CustomTriggerTest {
+        private Mock<IApplicationResourceDictionary> resourceDictionaryMock;
+        private CustomTrigger sut;
+
+        [SetUp]
+        public void Setup() {
+            resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+
+            sut = new CustomTrigger(resourceDictionaryMock.Object) {
+                Name = "Custom Trigger",
+                Description = "Description",
+                Category = "Utility",
+                Icon = new GeometryGroup()
+            };
+        }
+
+        /// <summary>
+        /// Verifies cloning preserves trigger metadata and keeps nested trigger/action areas independent.
+        /// </summary>
+        [Test]
+        public void Clone_CopiesMetadataAndNestedAreas() {
+            TestTrigger source = new TestTrigger();
+            TestInstruction instruction = new TestInstruction();
+            sut.TriggerSource = source;
+            sut.TriggerRunner.Add(instruction);
+
+            CustomTrigger clone = (CustomTrigger)sut.Clone();
+
+            clone.Should().NotBeSameAs(sut);
+            clone.Name.Should().Be(sut.Name);
+            clone.Description.Should().Be(sut.Description);
+            clone.Category.Should().Be(sut.Category);
+            clone.Icon.Should().BeSameAs(sut.Icon);
+            clone.TriggerSource.Should().NotBeSameAs(source);
+            clone.TriggerRunner.Should().NotBeSameAs(sut.TriggerRunner);
+            clone.TriggerRunner.GetItemsSnapshot().Should().ContainSingle()
+                .Which.Should().NotBeSameAs(instruction);
+        }
+
+        /// <summary>
+        /// Verifies dropping a trigger into the source area replaces the previous source trigger.
+        /// </summary>
+        [Test]
+        public void DropIntoTriggerSource_ReplacesExistingSourceTrigger() {
+            TestTrigger first = new TestTrigger();
+            TestTrigger second = new TestTrigger();
+
+            sut.DropIntoTriggerSourceCommand.Execute(new DropIntoParameters(first));
+            sut.DropIntoTriggerSourceCommand.Execute(new DropIntoParameters(second));
+
+            sut.TriggerSource.Should().BeOfType<TestTrigger>();
+            sut.TriggerSource.Should().NotBeSameAs(first);
+            sut.TriggerSource.Should().NotBeSameAs(second);
+            sut.TriggerSource.Parent.Should().NotBeNull();
+            first.Parent.Should().BeNull();
+            second.Parent.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies the direct trigger source property rejects self-references.
+        /// </summary>
+        [Test]
+        public void TriggerSource_DoesNotAcceptSelf() {
+            sut.TriggerSource = sut;
+
+            sut.TriggerSource.Should().BeNull();
+            sut.Parent.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies dropping the custom trigger onto its own source area is ignored.
+        /// </summary>
+        [Test]
+        public void DropIntoTriggerSource_IgnoresSelf() {
+            sut.DropIntoTriggerSourceCommand.Execute(new DropIntoParameters(sut));
+
+            sut.TriggerSource.Should().BeNull();
+            sut.Parent.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Verifies the custom trigger uses the nested trigger only as the trigger predicate.
+        /// </summary>
+        [Test]
+        public void ShouldTrigger_DelegatesToNestedSourceTrigger() {
+            TestTrigger source = new TestTrigger() {
+                ShouldTriggerResult = true,
+                ShouldTriggerAfterResult = true
+            };
+            sut.TriggerSource = source;
+
+            sut.ShouldTrigger(null, null).Should().BeTrue();
+            sut.ShouldTriggerAfter(null, null).Should().BeTrue();
+
+            source.ShouldTriggerCount.Should().Be(1);
+            source.ShouldTriggerAfterCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Verifies a disabled nested trigger does not fire the custom trigger.
+        /// </summary>
+        [Test]
+        public void ShouldTrigger_DisabledNestedTrigger_ReturnsFalse() {
+            TestTrigger source = new TestTrigger() {
+                Status = SequenceEntityStatus.DISABLED,
+                ShouldTriggerResult = true,
+                ShouldTriggerAfterResult = true
+            };
+            sut.TriggerSource = source;
+
+            sut.ShouldTrigger(null, null).Should().BeFalse();
+            sut.ShouldTriggerAfter(null, null).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Verifies execution runs the custom instructions and does not run the nested trigger action.
+        /// </summary>
+        [Test]
+        public async Task Execute_RunsCustomInstructionsOnly() {
+            TestTrigger source = new TestTrigger();
+            TestInstruction instruction = new TestInstruction();
+            sut.TriggerSource = source;
+            sut.TriggerRunner.Add(instruction);
+
+            await sut.Execute(new SequentialContainer(), Mock.Of<IProgress<ApplicationStatus>>(), CancellationToken.None);
+
+            instruction.ExecuteCount.Should().Be(1);
+            source.ExecuteCount.Should().Be(0);
+        }
+
+        /// <summary>
+        /// Verifies execution resets stale trigger-runner progress before running custom instructions.
+        /// </summary>
+        [Test]
+        public async Task Execute_ResetsTriggerRunnerBeforeRun() {
+            TestInstruction instruction = new TestInstruction() {
+                Status = SequenceEntityStatus.FINISHED
+            };
+            sut.TriggerRunner.Add(instruction);
+
+            await sut.Execute(new SequentialContainer(), Mock.Of<IProgress<ApplicationStatus>>(), CancellationToken.None);
+
+            instruction.ExecuteCount.Should().Be(1);
+            instruction.Status.Should().Be(SequenceEntityStatus.FINISHED);
+        }
+
+        /// <summary>
+        /// Verifies custom trigger instructions are registered with the real sequence root so the global skip command can skip them.
+        /// </summary>
+        [Test]
+        public async Task Execute_RegistersRunningInstructionWithRootForSkip() {
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer context = new SequentialContainer();
+            BlockingInstruction instruction = new BlockingInstruction();
+            root.Add(context);
+            sut.AttachNewParent(context);
+            sut.TriggerRunner.Add(instruction);
+
+            Task executeTask = sut.Execute(context, Mock.Of<IProgress<ApplicationStatus>>(), CancellationToken.None);
+
+            await instruction.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            root.GetCurrentRunningItems().Should().ContainSingle().Which.Should().BeSameAs(instruction);
+
+            root.SkipCurrentRunningItems();
+            await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            instruction.Status.Should().Be(SequenceEntityStatus.SKIPPED);
+            root.GetCurrentRunningItems().Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies validation reports missing configuration and passes once a trigger source and instruction exist.
+        /// </summary>
+        [Test]
+        public void Validate_RequiresTriggerSourceAndInstruction() {
+            sut.Validate().Should().BeFalse();
+            sut.Issues.Should().HaveCount(2);
+
+            sut.TriggerSource = new TestTrigger();
+            sut.TriggerRunner.Add(new TestInstruction());
+
+            sut.Validate().Should().BeTrue();
+            sut.Issues.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Verifies trigger runner issues are shown without blocking the custom trigger itself.
+        /// </summary>
+        [Test]
+        public void Validate_ReportsTriggerRunnerIssuesWithoutBlockingTrigger() {
+            sut.TriggerSource = new TestTrigger();
+            sut.TriggerRunner.Add(new TestInstruction());
+            sut.TriggerRunner.Issues.Add("runner issue");
+
+            sut.Validate().Should().BeTrue();
+
+            sut.Issues.Should().ContainSingle().Which.Should().Be("runner issue");
+        }
+
+        /// <summary>
+        /// Verifies lifecycle calls are forwarded to the nested source trigger.
+        /// </summary>
+        [Test]
+        public void Lifecycle_ForwardsToSourceTrigger() {
+            TestTrigger source = new TestTrigger();
+            sut.TriggerSource = source;
+
+            sut.Initialize();
+            sut.SequenceBlockInitialize();
+            sut.SequenceBlockStarted();
+            sut.SequenceBlockFinished();
+            sut.SequenceBlockTeardown();
+            sut.Teardown();
+
+            source.InitializeCount.Should().Be(1);
+            source.SequenceBlockInitializeCount.Should().Be(1);
+            source.SequenceBlockStartedCount.Should().Be(1);
+            source.SequenceBlockFinishedCount.Should().Be(1);
+            source.SequenceBlockTeardownCount.Should().Be(1);
+            source.TeardownCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Verifies the nested trigger's existing detach command clears the direct trigger source.
+        /// </summary>
+        [Test]
+        public void DetachSourceTrigger_ClearsTriggerSource() {
+            TestTrigger source = new TestTrigger();
+            sut.TriggerSource = source;
+
+            source.Detach();
+
+            sut.TriggerSource.Should().BeNull();
+            source.Parent.Should().BeNull();
+        }
+
+        private sealed class TestTrigger : SequenceTrigger, IValidatable {
+            public bool ShouldTriggerResult { get; set; }
+            public bool ShouldTriggerAfterResult { get; set; }
+            public int ShouldTriggerCount { get; private set; }
+            public int ShouldTriggerAfterCount { get; private set; }
+            public int ExecuteCount { get; private set; }
+            public int InitializeCount { get; private set; }
+            public int SequenceBlockInitializeCount { get; private set; }
+            public int SequenceBlockStartedCount { get; private set; }
+            public int SequenceBlockFinishedCount { get; private set; }
+            public int SequenceBlockTeardownCount { get; private set; }
+            public int TeardownCount { get; private set; }
+            public IList<string> Issues { get; set; } = new List<string>();
+
+            public override object Clone() {
+                return new TestTrigger() {
+                    ShouldTriggerResult = ShouldTriggerResult,
+                    ShouldTriggerAfterResult = ShouldTriggerAfterResult
+                };
+            }
+
+            public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
+                ShouldTriggerCount++;
+                return ShouldTriggerResult;
+            }
+
+            public override bool ShouldTriggerAfter(ISequenceItem previousItem, ISequenceItem nextItem) {
+                ShouldTriggerAfterCount++;
+                return ShouldTriggerAfterResult;
+            }
+
+            public override Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
+                ExecuteCount++;
+                return Task.CompletedTask;
+            }
+
+            public override void Initialize() {
+                InitializeCount++;
+            }
+
+            public override void SequenceBlockInitialize() {
+                SequenceBlockInitializeCount++;
+            }
+
+            public override void SequenceBlockStarted() {
+                SequenceBlockStartedCount++;
+            }
+
+            public override void SequenceBlockFinished() {
+                SequenceBlockFinishedCount++;
+            }
+
+            public override void SequenceBlockTeardown() {
+                SequenceBlockTeardownCount++;
+            }
+
+            public override void Teardown() {
+                TeardownCount++;
+            }
+
+            public bool Validate() {
+                return Issues.Count == 0;
+            }
+        }
+
+        private sealed class TestInstruction : SequenceItemBase {
+            public int ExecuteCount { get; private set; }
+
+            public override object Clone() {
+                return new TestInstruction();
+            }
+
+            public override Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+                ExecuteCount++;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class BlockingInstruction : SequenceItemBase {
+            public TaskCompletionSource<bool> Started { get; } = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public override object Clone() {
+                return new BlockingInstruction();
+            }
+
+            public override async Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+                Started.TrySetResult(true);
+                await Task.Delay(TimeSpan.FromMinutes(1), token);
+            }
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -92,6 +92,7 @@ This allows you to safely return to a stable release if needed.
 - **Sequencer**
     - Added a new **Trigger On Unsafe** safety monitor trigger. It can run configured instructions when the safety monitor reports unsafe or disconnects after it has been connected, then wait until the safety monitor reports safe again before running follow-up instructions.
     - When triggered, the currently running instruction is interrupted and reset so safety handling can take over immediately.
+    - Added a new **Custom Trigger** that uses an existing trigger as its trigger source and runs user-configured instructions when that source would normally fire.
 
 ### **Device Management**
 - **ASCOM Alpaca Direct Drivers**


### PR DESCRIPTION
## Purpose

  Adds a new Custom Trigger that uses an existing trigger as its source and runs user-configured instructions when that source would normally fire.

This also updates the trigger-owned instruction areas so containers dropped into Custom Trigger and Trigger On Unsafe render like normal sequencer containers, including the expected container borders.

## How Was It Tested?

Manual testing was performed in the sequencer UI, including:

- Adding a Custom Trigger.
- Assigning an existing trigger as the trigger source.
- Adding custom instructions to the trigger.
- Dropping sequence items and containers into the custom instruction area.
- Verifying containers render with the expected sequencer container borders.
- Verifying the same container rendering behavior in Trigger On Unsafe instruction areas.
- Running the custom trigger instructions and using Skip from the sequencer UI.
- Verifying validation behavior for trigger source and instruction issues.

## AI / Tooling Disclosure
Codex GPT-5.4 was used for unit testing and review assistance.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None.

## Screenshots

Not included.

## Additional Notes