### PR TITLE
Fix uncaught exception in QHY filter wheel driver

### DIFF
--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QHYFilterWheels.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QHYFilterWheels.cs
@@ -13,6 +13,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using System;
 using System.Collections.Generic;
 
 namespace QHYCCD {
@@ -37,21 +38,29 @@ namespace QHYCCD {
                     Sdk.GetId(i, out cameraId);
                     Sdk.Open(cameraId);
 
-                    if (Sdk.IsCfwPlugged()) {
-                        positions = (uint)Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_CFWSLOTSNUM);
+                    try {
+                        if (Sdk.IsCfwPlugged()) {
+                            positions = (uint)Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_CFWSLOTSNUM);
 
-                        /*
-                         * Ensure that the filter wheel we found is reporting that it has filter slots.
-                         */
-                        if (positions > 0) {
-                            Logger.Debug($"QHYCFW: Camera {i} ({cameraId}) has a {positions}-position CFW");
-                            FWheels.Add(cameraId.ToString());
-                        } else {
-                            Logger.Error($"QHYCFW: Camera {i} ({cameraId}) has a filter wheel but says it has {positions} slots! Skipping.");
+                            /*
+                             * Ensure that the filter wheel we found is reporting that it has filter slots.
+                             */
+                            if (positions > 0) {
+                                Logger.Debug($"QHYCFW: Camera {i} ({cameraId}) has a {positions}-position CFW");
+                                FWheels.Add(cameraId.ToString());
+                            } else {
+                                Logger.Error($"QHYCFW: Camera {i} ({cameraId}) has a filter wheel but says it has {positions} slots! Skipping.");
+                            }
+                        }
+                    } catch (Exception ex) {
+                        Logger.Error($"QHYCFW: Error querying camera {i} ({cameraId}) for filter wheel: {ex.Message}");
+                    } finally {
+                        try {
+                            Sdk.Close();
+                        } catch (Exception ex) {
+                            Logger.Error($"QHYCFW: Error closing camera {i} ({cameraId}): {ex.Message}");
                         }
                     }
-
-                    Sdk.Close();
                 }
             }
 


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

Uncaught exception is encountered during startup equipment scan with newest QHY firmware and SDK on a camera with filter wheel port but no filter wheel attached:

```
Application: NINA.exe
CoreCLR Version: 10.0.726.21808
.NET Version: 10.0.7
Description: The process was terminated due to an unhandled exception.
Stack:
   at QHYCCD.QhySdk.CloseQHYCCD(IntPtr)
   at QHYCCD.QhySdk.CloseQHYCCD(IntPtr)
   at QHYCCD.QhySdk.Close()
   at QHYCCD.QHYFilterWheels.GetFilterWheels()
   at NINA.WPF.Base.ViewModel.Equipment.FilterWheel.FilterWheelChooserVM+<GetEquipment>d__2.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
   at NINA.WPF.Base.ViewModel.Equipment.FilterWheel.FilterWheelChooserVM.GetEquipment()
   at NINA.WPF.Base.ViewModel.Equipment.FilterWheel.FilterWheelVM+<<Rescan>b__7_0>d.MoveNext()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[[System.__Canon, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]](System.__Canon ByRef)
   at NINA.WPF.Base.ViewModel.Equipment.FilterWheel.FilterWheelVM.<Rescan>b__7_0()
   at System.Threading.Tasks.Task`1[[System.__Canon, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].InnerInvoke()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(System.Threading.Thread, System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef, System.Threading.Thread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()

```
## 🧪 How Was It Tested?

Test with QHY600 with no filter wheel attached. Catching the exception prevents hard crash.

## 🤖 AI / Tooling Disclosure

None

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
