### PR TITLE
Programmable meridian flip trigger

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -4516,6 +4516,36 @@ Note: This mode requires that HFR differences between filters in your setup are 
   <data name="Lbl_SequenceTrigger_MeridianFlipTrigger_Name" xml:space="preserve">
     <value>Meridian Flip</value>
   </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_Name" xml:space="preserve">
+    <value>Programmable Meridian Flip</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_Description" xml:space="preserve">
+    <value>A meridian flip trigger with customizable actions before and after the flip.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description" xml:space="preserve">
+    <value>Before Flip Actions</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description" xml:space="preserve">
+    <value>After Flip Actions</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_HelpDescription" xml:space="preserve">
+    <value>Instructions that run before waiting for the meridian flip.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_HelpDescription" xml:space="preserve">
+    <value>Instructions that run after the meridian flip.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Warning" xml:space="preserve">
+    <value>Keep these steps short. Long before-flip actions can delay the meridian flip.</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description" xml:space="preserve">
+    <value>Wait For Flip Window</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description" xml:space="preserve">
+    <value>Resume Tracking and Flip</value>
+  </data>
+  <data name="Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description" xml:space="preserve">
+    <value>Settle</value>
+  </data>
   <data name="Lbl_SequenceItem_Validation_CameraCannotSetTemperature" xml:space="preserve">
     <value>Camera does not have a cooler and is unable to set a temperature</value>
   </data>

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml
@@ -30,13 +30,18 @@
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:safety="clr-namespace:NINA.Sequencer.Trigger.SafetyMonitor"
     xmlns:seqItem="clr-namespace:NINA.Sequencer.SequenceItem"
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:utility="clr-namespace:NINA.Sequencer.Trigger.Utility"
     xmlns:view="clr-namespace:NINA.View.Sequencer"
     xmlns:wpfbehaviors="clr-namespace:NINA.WPF.Base.Behaviors;assembly=NINA.WPF.Base"
     xmlns:wpfutil="clr-namespace:NINA.WPF.Base.Utility;assembly=NINA.WPF.Base">
 
-    <converter:TreeViewDepthToColorConverter x:Key="TriggerInstructionTreeViewDepthToColorConverter" />
-    <Style x:Key="TriggerInstructionItemStyle" TargetType="{x:Type TreeViewItem}">
+    <ResourceDictionary.MergedDictionaries>
+        <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <converter:TreeViewDepthToColorConverter x:Key="SequencerTriggerInstructionDepthToColorConverter" />
+    <Style x:Key="SequencerTriggerInstructionTreeItemStyle" TargetType="{x:Type TreeViewItem}">
         <Setter Property="ItemsControl.AlternationCount" Value="1024" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue" />
         <Setter Property="Focusable" Value="False" />
@@ -101,7 +106,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="TriggerInstructionContainerStyle" TargetType="{x:Type TreeViewItem}">
+    <Style x:Key="SequencerTriggerInstructionContainerTreeItemStyle" TargetType="{x:Type TreeViewItem}">
         <Setter Property="ItemsControl.AlternationCount" Value="1024" />
         <Setter Property="KeyboardNavigation.TabNavigation" Value="Continue" />
         <Setter Property="Focusable" Value="False" />
@@ -128,7 +133,7 @@
                             BorderThickness="4,0,0,0"
                             SnapsToDevicePixels="true">
                             <Border.BorderBrush>
-                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                <MultiBinding Converter="{StaticResource SequencerTriggerInstructionDepthToColorConverter}">
                                     <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
                                     <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
                                     <Binding Path="(ItemsControl.AlternationIndex)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -148,7 +153,7 @@
                             Grid.ColumnSpan="2"
                             BorderThickness="4,0,0,0">
                             <Border.BorderBrush>
-                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                <MultiBinding Converter="{StaticResource SequencerTriggerInstructionDepthToColorConverter}">
                                     <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
                                     <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
                                     <Binding Path="(ItemsControl.AlternationIndex)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -198,7 +203,7 @@
                             VerticalAlignment="Top"
                             IsHitTestVisible="False">
                             <Rectangle.Fill>
-                                <MultiBinding Converter="{StaticResource TriggerInstructionTreeViewDepthToColorConverter}">
+                                <MultiBinding Converter="{StaticResource SequencerTriggerInstructionDepthToColorConverter}">
                                     <Binding Source="{StaticResource SecondaryBackgroundBrush}" />
                                     <Binding RelativeSource="{RelativeSource AncestorType=TreeViewItem}" />
                                     <Binding Path="(ItemsControl.AlternationIndex)" RelativeSource="{RelativeSource TemplatedParent}" />
@@ -239,12 +244,54 @@
         </Setter>
     </Style>
     <view:SequenceTreeViewItemStyleSelector
-        x:Key="TriggerInstructionTreeViewItemStyleSelector"
-        ContainerStyle="{StaticResource TriggerInstructionContainerStyle}"
-        DefaultStyle="{StaticResource TriggerInstructionItemStyle}"
-        ItemStyle="{StaticResource TriggerInstructionItemStyle}" />
+        x:Key="SequencerTriggerInstructionTreeItemStyleSelector"
+        ContainerStyle="{StaticResource SequencerTriggerInstructionContainerTreeItemStyle}"
+        DefaultStyle="{StaticResource SequencerTriggerInstructionTreeItemStyle}"
+        ItemStyle="{StaticResource SequencerTriggerInstructionTreeItemStyle}" />
+    <Border
+        x:Key="SequencerTriggerInstructionMenuGroupHeader"
+        MinHeight="30"
+        x:Shared="false"
+        Background="Transparent">
+        <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
+    </Border>
+    <Border
+        x:Key="SequencerTriggerInstructionMenuEntityHeader"
+        MinHeight="30"
+        x:Shared="false"
+        Background="Transparent">
+        <TextBlock VerticalAlignment="Center" Text="{Binding Entity.Name}" />
+    </Border>
+    <Path
+        x:Key="SequencerTriggerInstructionMenuEntityIcon"
+        Width="20"
+        Height="20"
+        Margin="5"
+        x:Shared="false"
+        Data="{Binding Entity.Icon}"
+        Fill="{StaticResource PrimaryBrush}"
+        Stretch="Uniform"
+        UseLayoutRounding="True" />
+    <Style x:Key="SequencerTriggerInstructionMenuItemStyle" TargetType="MenuItem">
+        <Setter Property="Header" Value="{StaticResource SequencerTriggerInstructionMenuEntityHeader}" />
+        <Setter Property="Icon" Value="{StaticResource SequencerTriggerInstructionMenuEntityIcon}" />
+        <EventSetter Event="Click" Handler="MenuItemTriggerInstruction_Click" />
+    </Style>
+    <Style x:Key="SequencerTriggerInstructionMenuGroupItemStyle" TargetType="{x:Type GroupItem}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type GroupItem}">
+                    <MenuItem
+                        view:GroupMenuBehavior.Dummy="True"
+                        Header="{StaticResource SequencerTriggerInstructionMenuGroupHeader}"
+                        ItemContainerStyle="{StaticResource SequencerTriggerInstructionMenuItemStyle}"
+                        ItemsSource="{Binding Items}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-    <Style x:Key="TriggerOnUnsafeSequenceContainerHeaderExpanderStyle" TargetType="ToggleButton">
+    <Style x:Key="SequencerTriggerEditorHeaderToggleButtonStyle" TargetType="ToggleButton">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -325,7 +372,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="TriggerOnUnsafeSequenceContainerExpander" TargetType="{x:Type ninactrl:DetachingExpander}">
+    <Style x:Key="SequencerTriggerEditorExpanderStyle" TargetType="{x:Type ninactrl:DetachingExpander}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ninactrl:DetachingExpander}">
@@ -356,7 +403,7 @@
                                 FontWeight="{TemplateBinding FontWeight}"
                                 Foreground="{TemplateBinding Foreground}"
                                 IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                Style="{StaticResource TriggerOnUnsafeSequenceContainerHeaderExpanderStyle}" />
+                                Style="{StaticResource SequencerTriggerEditorHeaderToggleButtonStyle}" />
                             <Border x:Name="ContainerBorder" BorderBrush="{StaticResource SecondaryBackgroundBrush}">
                                 <ContentPresenter
                                     x:Name="ExpandSite"
@@ -384,7 +431,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="TriggerWorkflowStageBorderStyle" TargetType="Border">
+    <Style x:Key="SequencerTriggerWorkflowStageBorderStyle" TargetType="Border">
         <Setter Property="Background" Value="{StaticResource TertiaryBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
@@ -399,7 +446,14 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="TriggerWorkflowStageTitleStyle" TargetType="TextBlock">
+    <Style
+        x:Key="SequencerTriggerWorkflowFixedStageBorderStyle"
+        BasedOn="{StaticResource SequencerTriggerWorkflowStageBorderStyle}"
+        TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style x:Key="SequencerTriggerWorkflowStageTitleStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Foreground" Value="{StaticResource ButtonForegroundBrush}" />
         <Style.Triggers>
@@ -407,6 +461,382 @@
                 <Setter Property="FontWeight" Value="Bold" />
             </DataTrigger>
         </Style.Triggers>
+    </Style>
+    <DataTemplate x:Key="SequencerTriggerInstructionStageHeaderTemplate">
+        <Grid>
+            <Grid.Resources>
+                <coreUtil:BindingProxy x:Key="SequencerTriggerInstructionMenuViewModel" Data="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:SequenceView}}, Path=DataContext}" />
+            </Grid.Resources>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Path
+                Grid.Column="0"
+                Width="20"
+                Height="20"
+                Margin="0,0,8,0"
+                Data="{StaticResource BoxSVG}"
+                Fill="{StaticResource ButtonForegroundBrush}"
+                Stretch="Uniform"
+                UseLayoutRounding="True" />
+            <TextBlock
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                Style="{StaticResource SequencerTriggerWorkflowStageTitleStyle}"
+                Text="{Binding}" />
+            <Button
+                Grid.Column="2"
+                Width="25"
+                Height="25"
+                Margin="8,0,0,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type HeaderedContentControl}}, Path=Tag}">
+                <Path
+                    Margin="5"
+                    Data="{StaticResource AddSVG}"
+                    Fill="{StaticResource PrimaryBrush}"
+                    Stretch="Uniform"
+                    UseLayoutRounding="True" />
+                <Button.ToolTip>
+                    <ToolTip>
+                        <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_AddInstruction_Tooltip}" />
+                    </ToolTip>
+                </Button.ToolTip>
+                <Button.Style>
+                    <Style BasedOn="{StaticResource SecondaryBackgroundButton}" TargetType="{x:Type Button}">
+                        <EventSetter Event="Click" Handler="AddTriggerInstructionButton_Click" />
+                        <Setter Property="ContextMenu">
+                            <Setter.Value>
+                                <ContextMenu ItemsSource="{Binding Source={StaticResource SequencerTriggerInstructionMenuViewModel}, Path=Data.SequencerFactory.InstructionsView}">
+                                    <ContextMenu.Template>
+                                        <ControlTemplate>
+                                            <Border Background="{StaticResource BackgroundBrush}">
+                                                <ScrollViewer
+                                                    CanContentScroll="True"
+                                                    HorizontalScrollBarVisibility="Disabled"
+                                                    Style="{StaticResource MenuScrollViewer}"
+                                                    VerticalScrollBarVisibility="Auto">
+                                                    <ItemsPresenter />
+                                                </ScrollViewer>
+                                            </Border>
+                                        </ControlTemplate>
+                                    </ContextMenu.Template>
+                                    <ContextMenu.GroupStyle>
+                                        <GroupStyle ContainerStyle="{StaticResource SequencerTriggerInstructionMenuGroupItemStyle}" />
+                                    </ContextMenu.GroupStyle>
+                                </ContextMenu>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Button.Style>
+            </Button>
+        </Grid>
+    </DataTemplate>
+    <DataTemplate x:Key="SequencerTriggerEditorHeaderNameIssuesTemplate">
+        <StackPanel Orientation="Horizontal">
+            <TextBlock
+                MinHeight="25"
+                Margin="10,10,10,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Foreground="{StaticResource ButtonForegroundBrush}"
+                Text="{Binding Name}" />
+            <Border
+                Width="20"
+                Height="20"
+                Margin="5,0,5,0"
+                Background="{StaticResource NotificationErrorBrush}"
+                BorderBrush="Transparent"
+                CornerRadius="10">
+                <Border.Visibility>
+                    <PriorityBinding>
+                        <Binding
+                            Converter="{StaticResource ZeroToVisibilityConverter}"
+                            FallbackValue="Collapsed"
+                            Path="Issues.Count" />
+                    </PriorityBinding>
+                </Border.Visibility>
+                <Path
+                    HorizontalAlignment="Right"
+                    Data="{StaticResource ExclamationCircledSVG}"
+                    Fill="{StaticResource ButtonForegroundBrush}"
+                    Stretch="Uniform" />
+                <Border.ToolTip>
+                    <ItemsControl ItemsSource="{Binding Issues}" />
+                </Border.ToolTip>
+            </Border>
+        </StackPanel>
+    </DataTemplate>
+    <DataTemplate x:Key="SequencerTriggerEditorHeaderCommandButtonsTemplate">
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+            <Button
+                Width="25"
+                Height="25"
+                Margin="25,0,0,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Command="{Binding DisableEnableCommand}"
+                Style="{StaticResource SecondaryBackgroundButton}"
+                Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                <Grid>
+                    <Path
+                        Margin="5"
+                        Data="{StaticResource PowerSVG}"
+                        Fill="{StaticResource ButtonForegroundBrush}"
+                        Stretch="Uniform"
+                        UseLayoutRounding="True" />
+                </Grid>
+                <Button.ToolTip>
+                    <ToolTip>
+                        <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
+                    </ToolTip>
+                </Button.ToolTip>
+            </Button>
+
+            <Button
+                Width="25"
+                Height="25"
+                Margin="25,0,0,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Command="{Binding DetachCommand}"
+                Style="{StaticResource SecondaryBackgroundButton}"
+                Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                <Grid>
+                    <Path
+                        Margin="5"
+                        Data="{StaticResource TrashCanSVG}"
+                        Fill="{StaticResource ButtonForegroundBrush}"
+                        Stretch="Uniform"
+                        UseLayoutRounding="True" />
+                </Grid>
+                <Button.ToolTip>
+                    <ToolTip>
+                        <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
+                    </ToolTip>
+                </Button.ToolTip>
+            </Button>
+        </StackPanel>
+    </DataTemplate>
+    <Style x:Key="SequencerTriggerWorkflowStageHostStyle" TargetType="HeaderedContentControl">
+        <Setter Property="Margin" Value="0,0,0,8" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="HeaderedContentControl">
+                    <Border
+                        Margin="{TemplateBinding Margin}"
+                        Padding="10"
+                        Style="{StaticResource SequencerTriggerWorkflowStageBorderStyle}"
+                        Tag="{TemplateBinding Tag}">
+                        <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.Resources>
+                                    <DataTemplate DataType="{x:Type system:String}">
+                                        <TextBlock Style="{StaticResource SequencerTriggerWorkflowStageTitleStyle}" Text="{Binding}" />
+                                    </DataTemplate>
+                                </Grid.Resources>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    ContentSource="Header"
+                                    RecognizesAccessKey="True"
+                                    TextElement.Foreground="{StaticResource ButtonForegroundBrush}" />
+                                <ContentPresenter
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                            </Grid>
+                            <ContentPresenter
+                                x:Name="StageContentPresenter"
+                                Margin="0,10,0,0"
+                                ContentSource="Content" />
+                        </StackPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Content" Value="{x:Null}">
+                            <Setter TargetName="StageContentPresenter" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="SequencerTriggerInstructionSectionHostStyle" TargetType="HeaderedContentControl">
+        <Setter Property="Margin" Value="5,0,0,0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="HeaderedContentControl">
+                    <Border Margin="{TemplateBinding Margin}" Tag="{TemplateBinding Tag}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Border Grid.Row="0" Background="{StaticResource SecondaryBackgroundBrush}">
+                                <Grid MinHeight="30">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ContentPresenter
+                                        Margin="10,5,10,5"
+                                        VerticalAlignment="Center"
+                                        ContentSource="Header"
+                                        RecognizesAccessKey="True" />
+                                    <ContentPresenter
+                                        Grid.Column="1"
+                                        Margin="10,0,10,0"
+                                        VerticalAlignment="Center"
+                                        Content="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"
+                                        Style="{StaticResource ProgressPresenter}" />
+                                </Grid>
+                            </Border>
+                            <Border
+                                Grid.Row="1"
+                                Background="{StaticResource BackgroundBrush}"
+                                BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                                BorderThickness="10,0,0,0">
+                                <ContentPresenter
+                                    x:Name="InstructionSectionContentPresenter"
+                                    Margin="0,0,0,0"
+                                    ContentSource="Content" />
+                            </Border>
+                            <Border
+                                x:Name="InstructionSectionBottomBorder"
+                                Grid.Row="2"
+                                Margin="0,0,0,5"
+                                BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                                BorderThickness="10,0,0,15" />
+                            <Rectangle
+                                x:Name="InstructionSectionBottomCapLine"
+                                Grid.Row="2"
+                                Width="40"
+                                Height="2"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Fill="{StaticResource SecondaryBackgroundBrush}"
+                                IsHitTestVisible="False" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Content" Value="{x:Null}">
+                            <Setter TargetName="InstructionSectionContentPresenter" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="InstructionSectionBottomBorder" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="InstructionSectionBottomCapLine" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="SequencerTriggerWorkflowFixedStageHostStyle" TargetType="HeaderedContentControl">
+        <Setter Property="Margin" Value="0,0,0,2.5" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="HeaderedContentControl">
+                    <Border
+                        Margin="{TemplateBinding Margin}"
+                        Padding="10,0,0,0"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageBorderStyle}"
+                        Tag="{TemplateBinding Tag}">
+                        <Grid>
+                            <Grid.Resources>
+                                <DataTemplate DataType="{x:Type system:String}">
+                                    <TextBlock Style="{StaticResource SequencerTriggerWorkflowStageTitleStyle}" Text="{Binding}" />
+                                </DataTemplate>
+                            </Grid.Resources>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Border
+                                Grid.Column="0"
+                                MinWidth="200"
+                                HorizontalAlignment="Left"
+                                Background="{StaticResource TertiaryBackgroundBrush}"
+                                Tag="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}">
+                                <ContentPresenter
+                                    Margin="10,6,10,6"
+                                    VerticalAlignment="Center"
+                                    ContentSource="Header"
+                                    RecognizesAccessKey="True"
+                                    TextElement.Foreground="{StaticResource ButtonForegroundBrush}" />
+                            </Border>
+                            <ContentPresenter
+                                Grid.Column="1"
+                                Margin="8,0,10,0"
+                                VerticalAlignment="Center"
+                                Content="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"
+                                Style="{StaticResource ProgressPresenter}" />
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="SequencerTriggerWorkflowInstructionDropAreaStyle" TargetType="HeaderedContentControl">
+        <Setter Property="MinHeight" Value="50" />
+        <Setter Property="Background" Value="{StaticResource BackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="BorderThickness" Value="0,2,0,0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="HeaderedContentControl">
+                    <Border
+                        MinHeight="{TemplateBinding MinHeight}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid DataContext="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}">
+                            <TreeView
+                                MinHeight="{TemplateBinding MinHeight}"
+                                Margin="0,15,0,0"
+                                Background="{TemplateBinding Background}"
+                                BorderThickness="0"
+                                ItemContainerStyleSelector="{StaticResource SequencerTriggerInstructionTreeItemStyleSelector}"
+                                ItemsSource="{Binding Items}">
+                                <i:Interaction.Behaviors>
+                                    <wpfbehaviors:BubbleScrollEvent />
+                                </i:Interaction.Behaviors>
+                                <TreeView.Resources>
+                                    <ResourceDictionary>
+                                        <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                            <view:SequenceBlockView />
+                                        </DataTemplate>
+                                    </ResourceDictionary>
+                                </TreeView.Resources>
+                            </TreeView>
+                            <TextBlock
+                                Height="18"
+                                MaxHeight="18"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                FontStyle="Italic"
+                                Opacity="0.4"
+                                Text="{TemplateBinding Header}"
+                                Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                            <i:Interaction.Behaviors>
+                                <behaviors:DragOverBehavior
+                                    AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
+                                    DragAboveSize="0"
+                                    DragBelowSize="0"
+                                    DragOverCenterText="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}" />
+                                <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                            </i:Interaction.Behaviors>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <DataTemplate x:Key="NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger_Mini">
@@ -493,10 +923,7 @@
 
     <DataTemplate DataType="{x:Type mf:ProgrammableMeridianFlipTrigger}">
         <Border>
-            <Border.Resources>
-                <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
-            </Border.Resources>
-            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SequencerTriggerEditorExpanderStyle}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
                         <Grid.ColumnDefinitions>
@@ -505,39 +932,10 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="0" Orientation="Horizontal">
-                            <TextBlock
-                                MinHeight="25"
-                                Margin="10,10,10,0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="{Binding Name}" />
-                            <Border
-                                Width="20"
-                                Height="20"
-                                Margin="5,0,5,0"
-                                Background="{StaticResource NotificationErrorBrush}"
-                                BorderBrush="Transparent"
-                                CornerRadius="10">
-                                <Border.Visibility>
-                                    <PriorityBinding>
-                                        <Binding
-                                            Converter="{StaticResource ZeroToVisibilityConverter}"
-                                            FallbackValue="Collapsed"
-                                            Path="Issues.Count" />
-                                    </PriorityBinding>
-                                </Border.Visibility>
-                                <Path
-                                    HorizontalAlignment="Right"
-                                    Data="{StaticResource ExclamationCircledSVG}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform" />
-                                <Border.ToolTip>
-                                    <ItemsControl ItemsSource="{Binding Issues}" />
-                                </Border.ToolTip>
-                            </Border>
-                        </StackPanel>
+                        <ContentControl
+                            Grid.Column="0"
+                            Content="{Binding}"
+                            ContentTemplate="{StaticResource SequencerTriggerEditorHeaderNameIssuesTemplate}" />
                         <StackPanel
                             Grid.Column="1"
                             Margin="10,3,10,3"
@@ -581,283 +979,64 @@
                             Grid.Column="3"
                             HorizontalAlignment="Stretch"
                             Background="{StaticResource SecondaryBackgroundBrush}">
-                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                                <Button
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DisableEnableCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource PowerSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-
-                                <Button
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DetachCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource TrashCanSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-                            </StackPanel>
+                            <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SequencerTriggerEditorHeaderCommandButtonsTemplate}" />
                         </Border>
                     </Grid>
                 </ninactrl:DetachingExpander.Header>
                 <StackPanel Margin="0,10,0,0" Orientation="Vertical">
-                    <Border
-                        Tag="{Binding StopTrackingStage}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter
-                                Margin="0,0,8,0"
-                                VerticalAlignment="Center"
-                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                Style="{StaticResource ProgressPresenter}" />
-                            <TextBlock
-                                Grid.Column="1"
-                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                Text="{ns:Loc LblStopTracking}" />
-                        </Grid>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc LblStopTracking}"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageHostStyle}"
+                        Tag="{Binding StopTrackingStage}" />
 
-                    <Border
-                        Tag="{Binding BeforeFlipActions}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description}"
+                        HeaderTemplate="{StaticResource SequencerTriggerInstructionStageHeaderTemplate}"
+                        Style="{StaticResource SequencerTriggerInstructionSectionHostStyle}"
+                        Tag="{Binding BeforeFlipActions}">
                         <StackPanel Orientation="Vertical">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    Margin="0,0,8,0"
-                                    VerticalAlignment="Center"
-                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                    Style="{StaticResource ProgressPresenter}" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                    Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description}" />
-                            </Grid>
                             <TextBlock
-                                Margin="0,6,0,0"
+                                Margin="5,0,0,6"
                                 FontSize="11"
                                 FontStyle="Italic"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Foreground="{StaticResource PrimaryBrush}"
                                 Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Warning}" />
-                            <Border
-                                MinHeight="50"
-                                Margin="0,10,0,0"
-                                BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="1">
-                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding BeforeFlipActions}">
-                                    <TreeView
-                                        MinHeight="50"
-                                        Background="{StaticResource BackgroundBrush}"
-                                        BorderThickness="0"
-                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
-                                        ItemsSource="{Binding Items}">
-                                        <i:Interaction.Behaviors>
-                                            <wpfbehaviors:BubbleScrollEvent />
-                                        </i:Interaction.Behaviors>
-                                        <TreeView.Resources>
-                                            <ResourceDictionary>
-                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
-                                                    <view:SequenceBlockView />
-                                                </DataTemplate>
-                                            </ResourceDictionary>
-                                        </TreeView.Resources>
-                                    </TreeView>
-                                    <TextBlock
-                                        Height="18"
-                                        MaxHeight="18"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        FontStyle="Italic"
-                                        Opacity="0.4"
-                                        Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_HelpDescription}"
-                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
-                                    <i:Interaction.Behaviors>
-                                        <behaviors:DragOverBehavior
-                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
-                                            DragAboveSize="0"
-                                            DragBelowSize="0" />
-                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
-                                    </i:Interaction.Behaviors>
-                                </Grid>
-                            </Border>
+                            <HeaderedContentControl
+                                Content="{Binding BeforeFlipActions}"
+                                Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_HelpDescription}"
+                                Style="{StaticResource SequencerTriggerWorkflowInstructionDropAreaStyle}"
+                                Tag="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_HelpDescription}" />
                         </StackPanel>
-                    </Border>
+                    </HeaderedContentControl>
 
-                    <Border
-                        Tag="{Binding WaitForFlipWindowStage}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter
-                                Margin="0,0,8,0"
-                                VerticalAlignment="Center"
-                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                Style="{StaticResource ProgressPresenter}" />
-                            <TextBlock
-                                Grid.Column="1"
-                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description}" />
-                        </Grid>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description}"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageHostStyle}"
+                        Tag="{Binding WaitForFlipWindowStage}" />
 
-                    <Border
-                        Tag="{Binding ResumeTrackingAndFlipStage}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter
-                                Margin="0,0,8,0"
-                                VerticalAlignment="Center"
-                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                Style="{StaticResource ProgressPresenter}" />
-                            <TextBlock
-                                Grid.Column="1"
-                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description}" />
-                        </Grid>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description}"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageHostStyle}"
+                        Tag="{Binding ResumeTrackingAndFlipStage}" />
 
-                    <Border
-                        Tag="{Binding SettleStage}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter
-                                Margin="0,0,8,0"
-                                VerticalAlignment="Center"
-                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                Style="{StaticResource ProgressPresenter}" />
-                            <TextBlock
-                                Grid.Column="1"
-                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description}" />
-                        </Grid>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description}"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageHostStyle}"
+                        Tag="{Binding SettleStage}" />
 
-                    <Border
-                        Tag="{Binding AfterFlipActions}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <StackPanel Orientation="Vertical">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    Margin="0,0,8,0"
-                                    VerticalAlignment="Center"
-                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                    Style="{StaticResource ProgressPresenter}" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                    Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description}" />
-                            </Grid>
-                            <Border
-                                MinHeight="50"
-                                Margin="0,10,0,0"
-                                BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="1">
-                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding AfterFlipActions}">
-                                    <TreeView
-                                        MinHeight="50"
-                                        Background="{StaticResource BackgroundBrush}"
-                                        BorderThickness="0"
-                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
-                                        ItemsSource="{Binding Items}">
-                                        <i:Interaction.Behaviors>
-                                            <wpfbehaviors:BubbleScrollEvent />
-                                        </i:Interaction.Behaviors>
-                                        <TreeView.Resources>
-                                            <ResourceDictionary>
-                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
-                                                    <view:SequenceBlockView />
-                                                </DataTemplate>
-                                            </ResourceDictionary>
-                                        </TreeView.Resources>
-                                    </TreeView>
-                                    <TextBlock
-                                        Height="18"
-                                        MaxHeight="18"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        FontStyle="Italic"
-                                        Opacity="0.4"
-                                        Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_HelpDescription}"
-                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
-                                    <i:Interaction.Behaviors>
-                                        <behaviors:DragOverBehavior
-                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
-                                            DragAboveSize="0"
-                                            DragBelowSize="0" />
-                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
-                                    </i:Interaction.Behaviors>
-                                </Grid>
-                            </Border>
-                        </StackPanel>
-                    </Border>
-
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description}"
+                        HeaderTemplate="{StaticResource SequencerTriggerInstructionStageHeaderTemplate}"
+                        Style="{StaticResource SequencerTriggerInstructionSectionHostStyle}"
+                        Tag="{Binding AfterFlipActions}">
+                        <HeaderedContentControl
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            Content="{Binding AfterFlipActions}"
+                            Header="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_HelpDescription}"
+                            Style="{StaticResource SequencerTriggerWorkflowInstructionDropAreaStyle}"
+                            Tag="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_HelpDescription}" />
+                    </HeaderedContentControl>
                 </StackPanel>
             </ninactrl:DetachingExpander>
         </Border>
@@ -1244,11 +1423,8 @@
         <Border>
             <Border.Resources>
                 <ResourceDictionary>
-                    <ResourceDictionary.MergedDictionaries>
-                        <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
-                    </ResourceDictionary.MergedDictionaries>
                     <coreUtil:BindingProxy x:Key="ViewModel" Data="{Binding RelativeSource={RelativeSource AncestorType={x:Type view:SequenceView}}, Path=DataContext}" />
-                    <DataTemplate x:Key="TriggerSourceMenuItemTemplate">
+                    <DataTemplate x:Key="CustomTriggerSourceMenuItemTemplate">
                         <StackPanel MinHeight="30" Orientation="Horizontal">
                             <Path
                                 Width="20"
@@ -1263,7 +1439,7 @@
                     </DataTemplate>
                 </ResourceDictionary>
             </Border.Resources>
-            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SequencerTriggerEditorExpanderStyle}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
                         <Grid.ColumnDefinitions>
@@ -1272,39 +1448,10 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="0" Orientation="Horizontal">
-                            <TextBlock
-                                MinHeight="25"
-                                Margin="10,10,10,0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="{Binding Name}" />
-                            <Border
-                                Width="20"
-                                Height="20"
-                                Margin="5,0,5,0"
-                                Background="{StaticResource NotificationErrorBrush}"
-                                BorderBrush="Transparent"
-                                CornerRadius="10">
-                                <Border.Visibility>
-                                    <PriorityBinding>
-                                        <Binding
-                                            Converter="{StaticResource ZeroToVisibilityConverter}"
-                                            FallbackValue="Collapsed"
-                                            Path="Issues.Count" />
-                                    </PriorityBinding>
-                                </Border.Visibility>
-                                <Path
-                                    HorizontalAlignment="Right"
-                                    Data="{StaticResource ExclamationCircledSVG}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform" />
-                                <Border.ToolTip>
-                                    <ItemsControl ItemsSource="{Binding Issues}" />
-                                </Border.ToolTip>
-                            </Border>
-                        </StackPanel>
+                        <ContentControl
+                            Grid.Column="0"
+                            Content="{Binding}"
+                            ContentTemplate="{StaticResource SequencerTriggerEditorHeaderNameIssuesTemplate}" />
                         <Border
                             Grid.Column="1"
                             MinHeight="30"
@@ -1356,7 +1503,7 @@
                                             <EventSetter Event="Click" Handler="AddTriggerSourceButton_Click" />
                                             <Setter Property="ContextMenu">
                                                 <Setter.Value>
-                                                    <ContextMenu ItemTemplate="{StaticResource TriggerSourceMenuItemTemplate}" ItemsSource="{Binding Source={StaticResource ViewModel}, Path=Data.SequencerFactory.TriggersView}">
+                                                    <ContextMenu ItemTemplate="{StaticResource CustomTriggerSourceMenuItemTemplate}" ItemsSource="{Binding Source={StaticResource ViewModel}, Path=Data.SequencerFactory.TriggersView}">
                                                         <ContextMenu.Template>
                                                             <ControlTemplate>
                                                                 <Border Background="{StaticResource BackgroundBrush}">
@@ -1404,100 +1551,25 @@
                             Grid.Column="3"
                             HorizontalAlignment="Stretch"
                             Background="{StaticResource SecondaryBackgroundBrush}">
-                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                                <Button
-                                    x:Name="EnableDisableButton"
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DisableEnableCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource PowerSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-
-                                <Button
-                                    x:Name="CloseButton"
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DetachCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource TrashCanSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-                            </StackPanel>
+                            <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SequencerTriggerEditorHeaderCommandButtonsTemplate}" />
                         </Border>
                     </Grid>
                 </ninactrl:DetachingExpander.Header>
 
-                <Grid
-                    MinHeight="50"
-                    Background="{StaticResource BackgroundBrush}"
-                    DataContext="{Binding TriggerRunner}">
-                    <TreeView
-                        MinHeight="50"
+                <HeaderedContentControl
+                    Header="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_Name}"
+                    HeaderTemplate="{StaticResource SequencerTriggerInstructionStageHeaderTemplate}"
+                    Style="{StaticResource SequencerTriggerInstructionSectionHostStyle}"
+                    Tag="{Binding TriggerRunner}">
+                    <HeaderedContentControl
                         Background="{StaticResource BackgroundBrush}"
+                        BorderBrush="Transparent"
                         BorderThickness="0"
-                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
-                        ItemsSource="{Binding Items}">
-                        <i:Interaction.Behaviors>
-                            <wpfbehaviors:BubbleScrollEvent />
-                        </i:Interaction.Behaviors>
-                        <TreeView.Resources>
-                            <ResourceDictionary>
-                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
-                                    <view:SequenceBlockView />
-                                </DataTemplate>
-                            </ResourceDictionary>
-                        </TreeView.Resources>
-                    </TreeView>
-                    <TextBlock
-                        Height="18"
-                        MaxHeight="18"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        FontStyle="Italic"
-                        Opacity="0.4"
-                        Text="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_HelpDescription}"
-                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
-                    <i:Interaction.Behaviors>
-                        <behaviors:DragOverBehavior
-                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
-                            DragAboveSize="0"
-                            DragBelowSize="0"
-                            DragOverCenterText="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_DragOverText}" />
-                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
-                    </i:Interaction.Behaviors>
-                </Grid>
+                        Content="{Binding TriggerRunner}"
+                        Header="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_HelpDescription}"
+                        Style="{StaticResource SequencerTriggerWorkflowInstructionDropAreaStyle}"
+                        Tag="{ns:Loc Lbl_SequenceTrigger_CustomTrigger_Instructions_DragOverText}" />
+                </HeaderedContentControl>
             </ninactrl:DetachingExpander>
         </Border>
     </DataTemplate>
@@ -1523,10 +1595,7 @@
 
     <DataTemplate DataType="{x:Type safety:TriggerOnUnsafe}">
         <Border>
-            <Border.Resources>
-                <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
-            </Border.Resources>
-            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource SequencerTriggerEditorExpanderStyle}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
                         <Grid.ColumnDefinitions>
@@ -1534,39 +1603,10 @@
                             <ColumnDefinition />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock
-                                MinHeight="25"
-                                Margin="10,10,10,0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                Foreground="{StaticResource ButtonForegroundBrush}"
-                                Text="{Binding Name}" />
-                            <Border
-                                Width="20"
-                                Height="20"
-                                Margin="5,0,5,0"
-                                Background="{StaticResource NotificationErrorBrush}"
-                                BorderBrush="Transparent"
-                                CornerRadius="10">
-                                <Border.Visibility>
-                                    <PriorityBinding>
-                                        <Binding
-                                            Converter="{StaticResource ZeroToVisibilityConverter}"
-                                            FallbackValue="Collapsed"
-                                            Path="Issues.Count" />
-                                    </PriorityBinding>
-                                </Border.Visibility>
-                                <Path
-                                    HorizontalAlignment="Right"
-                                    Data="{StaticResource ExclamationCircledSVG}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform" />
-                                <Border.ToolTip>
-                                    <ItemsControl ItemsSource="{Binding Issues}" />
-                                </Border.ToolTip>
-                            </Border>
-                        </StackPanel>
+                        <ContentControl
+                            Grid.Column="0"
+                            Content="{Binding}"
+                            ContentTemplate="{StaticResource SequencerTriggerEditorHeaderNameIssuesTemplate}" />
                         <Border Grid.Column="1" Background="{StaticResource SecondaryBackgroundBrush}">
                             <ContentPresenter
                                 Margin="2,0,10,0"
@@ -1580,219 +1620,44 @@
                             Grid.Column="2"
                             HorizontalAlignment="Stretch"
                             Background="{StaticResource SecondaryBackgroundBrush}">
-                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                                <Button
-                                    x:Name="EnableDisableButton"
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DisableEnableCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource PowerSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-
-                                <Button
-                                    x:Name="CloseButton"
-                                    Width="25"
-                                    Height="25"
-                                    Margin="25,0,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DetachCommand}"
-                                    Style="{StaticResource SecondaryBackgroundButton}"
-                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
-                                    <Grid>
-                                        <Path
-                                            Margin="5"
-                                            Data="{StaticResource TrashCanSVG}"
-                                            Fill="{StaticResource ButtonForegroundBrush}"
-                                            Stretch="Uniform"
-                                            UseLayoutRounding="True" />
-                                    </Grid>
-                                    <Button.ToolTip>
-                                        <ToolTip>
-                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
-                                        </ToolTip>
-                                    </Button.ToolTip>
-                                </Button>
-                            </StackPanel>
+                            <ContentControl Content="{Binding}" ContentTemplate="{StaticResource SequencerTriggerEditorHeaderCommandButtonsTemplate}" />
                         </Border>
                     </Grid>
                 </ninactrl:DetachingExpander.Header>
 
                 <StackPanel Margin="0,10,0,0" Orientation="Vertical">
-                    <Border
-                        Tag="{Binding BeforeWaitForSafe}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <StackPanel Orientation="Vertical">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    Margin="0,0,8,0"
-                                    VerticalAlignment="Center"
-                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                    Style="{StaticResource ProgressPresenter}" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                    Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description}" />
-                            </Grid>
-                            <Border
-                                MinHeight="50"
-                                Margin="0,10,0,0"
-                                BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="1">
-                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding BeforeWaitForSafe}">
-                                    <TreeView
-                                        MinHeight="50"
-                                        Background="{StaticResource BackgroundBrush}"
-                                        BorderThickness="0"
-                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
-                                        ItemsSource="{Binding Items}">
-                                        <i:Interaction.Behaviors>
-                                            <wpfbehaviors:BubbleScrollEvent />
-                                        </i:Interaction.Behaviors>
-                                        <TreeView.Resources>
-                                            <ResourceDictionary>
-                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
-                                                    <view:SequenceBlockView />
-                                                </DataTemplate>
-                                            </ResourceDictionary>
-                                        </TreeView.Resources>
-                                    </TreeView>
-                                    <TextBlock
-                                        Height="18"
-                                        MaxHeight="18"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        FontStyle="Italic"
-                                        Opacity="0.4"
-                                        Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_HelpDescription}"
-                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
-                                    <i:Interaction.Behaviors>
-                                        <behaviors:DragOverBehavior
-                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
-                                            DragAboveSize="0"
-                                            DragBelowSize="0" />
-                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
-                                    </i:Interaction.Behaviors>
-                                </Grid>
-                            </Border>
-                        </StackPanel>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description}"
+                        HeaderTemplate="{StaticResource SequencerTriggerInstructionStageHeaderTemplate}"
+                        Style="{StaticResource SequencerTriggerInstructionSectionHostStyle}"
+                        Tag="{Binding BeforeWaitForSafe}">
+                        <HeaderedContentControl
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            Content="{Binding BeforeWaitForSafe}"
+                            Header="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_HelpDescription}"
+                            Style="{StaticResource SequencerTriggerWorkflowInstructionDropAreaStyle}"
+                            Tag="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_HelpDescription}" />
+                    </HeaderedContentControl>
 
-                    <Border
-                        Tag="{Binding WaitUntilSafe}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Margin="0,0,0,8"
-                        Padding="10">
-                        <StackPanel Orientation="Vertical">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    Margin="0,0,8,0"
-                                    VerticalAlignment="Center"
-                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                    Style="{StaticResource ProgressPresenter}" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                    Text="{ns:Loc Lbl_SequenceItem_SafetyMonitor_WaitUntilSafe_Description}" />
-                            </Grid>
-                            <ContentControl
-                                Margin="0,10,0,0"
-                                DataContext="{Binding WaitUntilSafe}"
-                                IsEnabled="False" />
-                        </StackPanel>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceItem_SafetyMonitor_WaitUntilSafe_Description}"
+                        Style="{StaticResource SequencerTriggerWorkflowFixedStageHostStyle}"
+                        Tag="{Binding WaitUntilSafe}" />
 
-                    <Border
-                        Tag="{Binding AfterWaitForSafe}"
-                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
-                        Padding="10"
-                        >
-                        <StackPanel Orientation="Vertical">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    Margin="0,0,8,0"
-                                    VerticalAlignment="Center"
-                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
-                                    Style="{StaticResource ProgressPresenter}" />
-                                <TextBlock
-                                    Grid.Column="1"
-                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
-                                    Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description}" />
-                            </Grid>
-                            <Border
-                                MinHeight="50"
-                                Margin="0,10,0,0"
-                                BorderBrush="{StaticResource BorderBrush}"
-                                BorderThickness="1">
-                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding AfterWaitForSafe}">
-                                    <TreeView
-                                        MinHeight="50"
-                                        Background="{StaticResource BackgroundBrush}"
-                                        BorderThickness="0"
-                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
-                                        ItemsSource="{Binding Items}">
-                                        <i:Interaction.Behaviors>
-                                            <wpfbehaviors:BubbleScrollEvent />
-                                        </i:Interaction.Behaviors>
-                                        <TreeView.Resources>
-                                            <ResourceDictionary>
-                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
-                                                    <view:SequenceBlockView />
-                                                </DataTemplate>
-                                            </ResourceDictionary>
-                                        </TreeView.Resources>
-                                    </TreeView>
-                                    <TextBlock
-                                        Height="18"
-                                        MaxHeight="18"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        FontStyle="Italic"
-                                        Opacity="0.4"
-                                        Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription}"
-                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
-                                    <i:Interaction.Behaviors>
-                                        <behaviors:DragOverBehavior
-                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
-                                            DragAboveSize="0"
-                                            DragBelowSize="0" />
-                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
-                                    </i:Interaction.Behaviors>
-                                </Grid>
-                            </Border>
-                        </StackPanel>
-                    </Border>
+                    <HeaderedContentControl
+                        Header="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description}"
+                        HeaderTemplate="{StaticResource SequencerTriggerInstructionStageHeaderTemplate}"
+                        Style="{StaticResource SequencerTriggerInstructionSectionHostStyle}"
+                        Tag="{Binding AfterWaitForSafe}">
+                        <HeaderedContentControl
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            Content="{Binding AfterWaitForSafe}"
+                            Header="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription}"
+                            Style="{StaticResource SequencerTriggerWorkflowInstructionDropAreaStyle}"
+                            Tag="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription}" />
+                    </HeaderedContentControl>
                 </StackPanel>
 
             </ninactrl:DetachingExpander>

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml
@@ -244,6 +244,171 @@
         DefaultStyle="{StaticResource TriggerInstructionItemStyle}"
         ItemStyle="{StaticResource TriggerInstructionItemStyle}" />
 
+    <Style x:Key="TriggerOnUnsafeSequenceContainerHeaderExpanderStyle" TargetType="ToggleButton">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <StackPanel>
+                        <Border
+                            x:Name="topBorder"
+                            BorderBrush="{StaticResource SecondaryBackgroundBrush}"
+                            BorderThickness="1,1,0,0">
+                            <Grid
+                                x:Name="Head"
+                                MinHeight="30"
+                                Background="{StaticResource SecondaryBackgroundBrush}"
+                                UseLayoutRounding="True">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="30" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Path
+                                    x:Name="iconarrow"
+                                    Grid.Column="0"
+                                    Width="10"
+                                    Height="10"
+                                    Margin="10,0,10,0"
+                                    Data="{StaticResource ArrowRightSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <Path
+                                    x:Name="icon"
+                                    Grid.Column="1"
+                                    Margin="5,0,3,0"
+                                    Data="{StaticResource BoxClosedSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <Path
+                                    Grid.Column="2"
+                                    Width="20"
+                                    Height="20"
+                                    Margin="5,0,3,0"
+                                    Data="{Binding Icon}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform"
+                                    UseLayoutRounding="True" />
+                                <ContentPresenter
+                                    Grid.Column="3"
+                                    Margin="4,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    RecognizesAccessKey="True"
+                                    UseLayoutRounding="True">
+                                    <i:Interaction.Behaviors>
+                                        <!--  This gives the ability to drag and drop a sequence container by its header  -->
+                                        <behaviors:DragDropBehavior />
+                                    </i:Interaction.Behaviors>
+                                </ContentPresenter>
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="true">
+                            <Setter TargetName="icon" Property="Data" Value="{StaticResource BoxSVG}" />
+                            <Setter TargetName="iconarrow" Property="Data" Value="{StaticResource ArrowDownSVG}" />
+                            <Setter TargetName="iconarrow" Property="Margin" Value="5,0,10,0" />
+                        </Trigger>
+
+                        <Trigger Property="IsChecked" Value="false">
+                            <Setter TargetName="topBorder" Property="BorderThickness" Value="1,1,1,1" />
+                        </Trigger>
+
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Head" Property="Background" Value="{StaticResource ButtonBackgroundSelectedBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="TriggerOnUnsafeSequenceContainerExpander" TargetType="{x:Type ninactrl:DetachingExpander}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ninactrl:DetachingExpander}">
+                    <Border
+                        Margin="0,5,0,5"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Focusable="False"
+                        UseLayoutRounding="True">
+                        <DockPanel>
+                            <ToggleButton
+                                x:Name="HeaderSite"
+                                MinWidth="0"
+                                MinHeight="0"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                DockPanel.Dock="Top"
+                                FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontStretch="{TemplateBinding FontStretch}"
+                                FontStyle="{TemplateBinding FontStyle}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                Style="{StaticResource TriggerOnUnsafeSequenceContainerHeaderExpanderStyle}" />
+                            <Border x:Name="ContainerBorder" BorderBrush="{StaticResource SecondaryBackgroundBrush}">
+                                <ContentPresenter
+                                    x:Name="ExpandSite"
+                                    Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Focusable="false" />
+                            </Border>
+                        </DockPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="true">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="10,0,0,15" />
+                        </Trigger>
+                        <Trigger Property="IsExpanded" Value="False">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="0" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="TriggerWorkflowStageBorderStyle" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource TertiaryBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Tag.Status, RelativeSource={RelativeSource Self}}" Value="{x:Static enum:SequenceEntityStatus.RUNNING}">
+                <Setter Property="Background" Value="{StaticResource SecondaryBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource SecondaryBrush}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Tag.Status, RelativeSource={RelativeSource Self}}" Value="{x:Static enum:SequenceEntityStatus.FAILED}">
+                <Setter Property="Background" Value="{StaticResource NotificationErrorBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource NotificationErrorBrush}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="TriggerWorkflowStageTitleStyle" TargetType="TextBlock">
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource ButtonForegroundBrush}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Tag.Status, RelativeSource={RelativeSource AncestorType=Border}}" Value="{x:Static enum:SequenceEntityStatus.RUNNING}">
+                <Setter Property="FontWeight" Value="Bold" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <DataTemplate x:Key="NINA.Sequencer.Trigger.MeridianFlip.MeridianFlipTrigger_Mini">
         <mini:MiniTrigger>
             <mini:MiniTrigger.TriggerProgressContent>
@@ -292,6 +457,410 @@
                 </StackPanel>
             </view:SequenceBlockView.SequenceItemProgressContent>
         </view:SequenceBlockView>
+    </DataTemplate>
+
+    <DataTemplate x:Key="NINA.Sequencer.Trigger.MeridianFlip.ProgrammableMeridianFlipTrigger_Mini">
+        <mini:MiniTrigger>
+            <mini:MiniTrigger.TriggerProgressContent>
+                <StackPanel Orientation="Horizontal">
+                    <StackPanel
+                        HorizontalAlignment="Right"
+                        Orientation="Horizontal"
+                        Visibility="{Binding EarliestFlipTime, Converter={StaticResource DateTimeZeroToVisibilityCollapsedConverter}}">
+                        <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblFlipTime}" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding EarliestFlipTime, StringFormat='{}{0:HH:mm:ss}'}" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="-" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding LatestFlipTime, StringFormat='{}{0:HH:mm:ss}'}" />
+                    </StackPanel>
+                    <TextBlock
+                        Margin="10,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="{Binding ActiveStageTitle}"
+                        Visibility="{Binding ActiveStageTitle, Converter={StaticResource NullToVisibilityCollapsedConverter}}" />
+                </StackPanel>
+            </mini:MiniTrigger.TriggerProgressContent>
+        </mini:MiniTrigger>
+    </DataTemplate>
+
+    <DataTemplate DataType="{x:Type mf:ProgrammableMeridianFlipTrigger}">
+        <Border>
+            <Border.Resources>
+                <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
+            </Border.Resources>
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+                <ninactrl:DetachingExpander.Header>
+                    <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal">
+                            <TextBlock
+                                MinHeight="25"
+                                Margin="10,10,10,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="{Binding Name}" />
+                            <Border
+                                Width="20"
+                                Height="20"
+                                Margin="5,0,5,0"
+                                Background="{StaticResource NotificationErrorBrush}"
+                                BorderBrush="Transparent"
+                                CornerRadius="10">
+                                <Border.Visibility>
+                                    <PriorityBinding>
+                                        <Binding
+                                            Converter="{StaticResource ZeroToVisibilityConverter}"
+                                            FallbackValue="Collapsed"
+                                            Path="Issues.Count" />
+                                    </PriorityBinding>
+                                </Border.Visibility>
+                                <Path
+                                    HorizontalAlignment="Right"
+                                    Data="{StaticResource ExclamationCircledSVG}"
+                                    Fill="{StaticResource ButtonForegroundBrush}"
+                                    Stretch="Uniform" />
+                                <Border.ToolTip>
+                                    <ItemsControl ItemsSource="{Binding Issues}" />
+                                </Border.ToolTip>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel
+                            Grid.Column="1"
+                            Margin="10,3,10,3"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Orientation="Vertical">
+                            <StackPanel
+                                HorizontalAlignment="Right"
+                                Orientation="Horizontal"
+                                Visibility="{Binding EarliestFlipTime, Converter={StaticResource DateTimeZeroToVisibilityCollapsedConverter}}">
+                                <TextBlock Foreground="{StaticResource ButtonForegroundBrush}" Text="{ns:Loc LblFlipTime}" />
+                                <TextBlock
+                                    Margin="5,0,0,0"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="{Binding EarliestFlipTime, StringFormat='{}{0:HH:mm:ss}'}" />
+                                <TextBlock
+                                    Margin="5,0,0,0"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="-" />
+                                <TextBlock
+                                    Margin="5,0,0,0"
+                                    Foreground="{StaticResource ButtonForegroundBrush}"
+                                    Text="{Binding LatestFlipTime, StringFormat='{}{0:HH:mm:ss}'}" />
+                            </StackPanel>
+                            <TextBlock
+                                HorizontalAlignment="Right"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Opacity="0.8"
+                                Text="{Binding ActiveStageTitle}"
+                                Visibility="{Binding ActiveStageTitle, Converter={StaticResource NullToVisibilityCollapsedConverter}}" />
+                        </StackPanel>
+                        <Border Grid.Column="2" Background="{StaticResource SecondaryBackgroundBrush}">
+                            <ContentPresenter
+                                Margin="2,0,10,0"
+                                HorizontalAlignment="Right"
+                                Content="{Binding}"
+                                DockPanel.Dock="Right"
+                                Style="{StaticResource ProgressPresenter}" />
+                        </Border>
+                        <Border
+                            Grid.Column="3"
+                            HorizontalAlignment="Stretch"
+                            Background="{StaticResource SecondaryBackgroundBrush}">
+                            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                                <Button
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DisableEnableCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DisableEnableCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource PowerSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_DisableEnable_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+
+                                <Button
+                                    Width="25"
+                                    Height="25"
+                                    Margin="25,0,0,0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding DetachCommand}"
+                                    Style="{StaticResource SecondaryBackgroundButton}"
+                                    Visibility="{Binding DetachCommand, Converter={StaticResource NullToVisibilityCollapsedConverter}}">
+                                    <Grid>
+                                        <Path
+                                            Margin="5"
+                                            Data="{StaticResource TrashCanSVG}"
+                                            Fill="{StaticResource ButtonForegroundBrush}"
+                                            Stretch="Uniform"
+                                            UseLayoutRounding="True" />
+                                    </Grid>
+                                    <Button.ToolTip>
+                                        <ToolTip>
+                                            <TextBlock Foreground="{StaticResource PrimaryBrush}" Text="{ns:Loc Lbl_SequenceContainer_Delete_Tooltip}" />
+                                        </ToolTip>
+                                    </Button.ToolTip>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </ninactrl:DetachingExpander.Header>
+                <StackPanel Margin="0,10,0,0" Orientation="Vertical">
+                    <Border
+                        Tag="{Binding StopTrackingStage}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                Style="{StaticResource ProgressPresenter}" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                Text="{ns:Loc LblStopTracking}" />
+                        </Grid>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding BeforeFlipActions}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                    Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description}" />
+                            </Grid>
+                            <TextBlock
+                                Margin="0,6,0,0"
+                                FontSize="11"
+                                FontStyle="Italic"
+                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Warning}" />
+                            <Border
+                                MinHeight="50"
+                                Margin="0,10,0,0"
+                                BorderBrush="{StaticResource BorderBrush}"
+                                BorderThickness="1">
+                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding BeforeFlipActions}">
+                                    <TreeView
+                                        MinHeight="50"
+                                        Background="{StaticResource BackgroundBrush}"
+                                        BorderThickness="0"
+                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
+                                        ItemsSource="{Binding Items}">
+                                        <i:Interaction.Behaviors>
+                                            <wpfbehaviors:BubbleScrollEvent />
+                                        </i:Interaction.Behaviors>
+                                        <TreeView.Resources>
+                                            <ResourceDictionary>
+                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                                    <view:SequenceBlockView />
+                                                </DataTemplate>
+                                            </ResourceDictionary>
+                                        </TreeView.Resources>
+                                    </TreeView>
+                                    <TextBlock
+                                        Height="18"
+                                        MaxHeight="18"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontStyle="Italic"
+                                        Opacity="0.4"
+                                        Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_HelpDescription}"
+                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DragOverBehavior
+                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
+                                            DragAboveSize="0"
+                                            DragBelowSize="0" />
+                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                                    </i:Interaction.Behaviors>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding WaitForFlipWindowStage}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                Style="{StaticResource ProgressPresenter}" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description}" />
+                        </Grid>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding ResumeTrackingAndFlipStage}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                Style="{StaticResource ProgressPresenter}" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description}" />
+                        </Grid>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding SettleStage}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ContentPresenter
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                Style="{StaticResource ProgressPresenter}" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description}" />
+                        </Grid>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding AfterFlipActions}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
+                        <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                    Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description}" />
+                            </Grid>
+                            <Border
+                                MinHeight="50"
+                                Margin="0,10,0,0"
+                                BorderBrush="{StaticResource BorderBrush}"
+                                BorderThickness="1">
+                                <Grid Background="{StaticResource BackgroundBrush}" DataContext="{Binding AfterFlipActions}">
+                                    <TreeView
+                                        MinHeight="50"
+                                        Background="{StaticResource BackgroundBrush}"
+                                        BorderThickness="0"
+                                        ItemContainerStyleSelector="{StaticResource TriggerInstructionTreeViewItemStyleSelector}"
+                                        ItemsSource="{Binding Items}">
+                                        <i:Interaction.Behaviors>
+                                            <wpfbehaviors:BubbleScrollEvent />
+                                        </i:Interaction.Behaviors>
+                                        <TreeView.Resources>
+                                            <ResourceDictionary>
+                                                <DataTemplate DataType="{x:Type seqItem:SequenceItem}">
+                                                    <view:SequenceBlockView />
+                                                </DataTemplate>
+                                            </ResourceDictionary>
+                                        </TreeView.Resources>
+                                    </TreeView>
+                                    <TextBlock
+                                        Height="18"
+                                        MaxHeight="18"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontStyle="Italic"
+                                        Opacity="0.4"
+                                        Text="{ns:Loc Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_HelpDescription}"
+                                        Visibility="{Binding Items.Count, Converter={StaticResource InverseZeroToVisibilityConverter}}" />
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DragOverBehavior
+                                            AllowDragCenter="{Binding Items.Count, Converter={StaticResource ZeroToBooleanTrueConverter}}"
+                                            DragAboveSize="0"
+                                            DragBelowSize="0" />
+                                        <behaviors:DropIntoBehavior AllowedDragDropTypesString="NINA.Sequencer.Container.ISequenceContainer;NINA.Sequencer.SequenceItem.ISequenceItem;NINA.Sequencer.TemplatedSequenceContainer" OnDropCommand="DropIntoCommand" />
+                                    </i:Interaction.Behaviors>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+                    </Border>
+
+                </StackPanel>
+            </ninactrl:DetachingExpander>
+        </Border>
     </DataTemplate>
 
     <DataTemplate x:Key="NINA.Sequencer.Trigger.Autofocus.AutofocusAfterHFRIncreaseTrigger_Mini">
@@ -671,147 +1240,6 @@
         </mini:MiniSequenceItem>
     </DataTemplate>
 
-    <Style x:Key="TriggerOnUnsafeSequenceContainerHeaderExpanderStyle" TargetType="ToggleButton">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <StackPanel>
-                        <Border
-                            x:Name="topBorder"
-                            BorderBrush="{StaticResource SecondaryBackgroundBrush}"
-                            BorderThickness="1,1,0,0">
-                            <Grid
-                                x:Name="Head"
-                                MinHeight="30"
-                                Background="{StaticResource SecondaryBackgroundBrush}"
-                                UseLayoutRounding="True">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="30" />
-                                    <ColumnDefinition Width="30" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Path
-                                    x:Name="iconarrow"
-                                    Grid.Column="0"
-                                    Width="10"
-                                    Height="10"
-                                    Margin="10,0,10,0"
-                                    Data="{StaticResource ArrowRightSVG}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform"
-                                    UseLayoutRounding="True" />
-                                <Path
-                                    x:Name="icon"
-                                    Grid.Column="1"
-                                    Margin="5,0,3,0"
-                                    Data="{StaticResource BoxClosedSVG}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform"
-                                    UseLayoutRounding="True" />
-                                <Path
-                                    Grid.Column="2"
-                                    Width="20"
-                                    Height="20"
-                                    Margin="5,0,3,0"
-                                    Data="{Binding Icon}"
-                                    Fill="{StaticResource ButtonForegroundBrush}"
-                                    Stretch="Uniform"
-                                    UseLayoutRounding="True" />
-                                <ContentPresenter
-                                    Grid.Column="3"
-                                    Margin="4,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    RecognizesAccessKey="True"
-                                    UseLayoutRounding="True">
-                                    <i:Interaction.Behaviors>
-                                        <!--  This gives the ability to drag and drop a sequence container by its header  -->
-                                        <behaviors:DragDropBehavior />
-                                    </i:Interaction.Behaviors>
-                                </ContentPresenter>
-                            </Grid>
-                        </Border>
-                    </StackPanel>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="true">
-                            <Setter TargetName="icon" Property="Data" Value="{StaticResource BoxSVG}" />
-                            <Setter TargetName="iconarrow" Property="Data" Value="{StaticResource ArrowDownSVG}" />
-                            <Setter TargetName="iconarrow" Property="Margin" Value="5,0,10,0" />
-                        </Trigger>
-
-                        <Trigger Property="IsChecked" Value="false">
-                            <Setter TargetName="topBorder" Property="BorderThickness" Value="1,1,1,1" />
-                        </Trigger>
-
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Head" Property="Background" Value="{StaticResource ButtonBackgroundSelectedBrush}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-    <Style x:Key="TriggerOnUnsafeSequenceContainerExpander" TargetType="{x:Type ninactrl:DetachingExpander}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ninactrl:DetachingExpander}">
-                    <Border
-                        Margin="0,5,0,5"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Focusable="False"
-                        UseLayoutRounding="True">
-                        <DockPanel>
-                            <ToggleButton
-                                x:Name="HeaderSite"
-                                MinWidth="0"
-                                MinHeight="0"
-                                Padding="{TemplateBinding Padding}"
-                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Content="{TemplateBinding Header}"
-                                ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                DockPanel.Dock="Top"
-                                FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}"
-                                FontFamily="{TemplateBinding FontFamily}"
-                                FontSize="{TemplateBinding FontSize}"
-                                FontStretch="{TemplateBinding FontStretch}"
-                                FontStyle="{TemplateBinding FontStyle}"
-                                FontWeight="{TemplateBinding FontWeight}"
-                                Foreground="{TemplateBinding Foreground}"
-                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                Style="{StaticResource TriggerOnUnsafeSequenceContainerHeaderExpanderStyle}" />
-                            <Border x:Name="ContainerBorder" BorderBrush="{StaticResource SecondaryBackgroundBrush}">
-                                <ContentPresenter
-                                    x:Name="ExpandSite"
-                                    Margin="{TemplateBinding Padding}"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    Focusable="false" />
-                            </Border>
-                        </DockPanel>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsExpanded" Value="true">
-                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
-                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="10,0,0,15" />
-                        </Trigger>
-                        <Trigger Property="IsExpanded" Value="False">
-                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="ContainerBorder" Property="BorderThickness" Value="0" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
     <DataTemplate DataType="{x:Type utility:CustomTrigger}">
         <Border>
             <Border.Resources>
@@ -835,7 +1263,7 @@
                     </DataTemplate>
                 </ResourceDictionary>
             </Border.Resources>
-            <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
                         <Grid.ColumnDefinitions>
@@ -1098,7 +1526,7 @@
             <Border.Resources>
                 <wpfutil:SharedResourceDictionary Source="/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml" />
             </Border.Resources>
-            <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
+            <ninactrl:DetachingExpander IsExpanded="{Binding IsExpanded, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
                 <ninactrl:DetachingExpander.Header>
                     <Grid HorizontalAlignment="{Binding HorizontalAlignment, RelativeSource={RelativeSource AncestorType=ContentPresenter}, Mode=OneWayToSource}" Background="{StaticResource SecondaryBackgroundBrush}">
                         <Grid.ColumnDefinitions>
@@ -1207,12 +1635,28 @@
                     </Grid>
                 </ninactrl:DetachingExpander.Header>
 
-                <StackPanel Orientation="Vertical">
-                    <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
-                        <ninactrl:DetachingExpander.Header>
-                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description}" />
-                        </ninactrl:DetachingExpander.Header>
+                <StackPanel Margin="0,10,0,0" Orientation="Vertical">
+                    <Border
+                        Tag="{Binding BeforeWaitForSafe}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
                         <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                    Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_BeforeWaitingUntilSafe_Description}" />
+                            </Grid>
                             <Border
                                 MinHeight="50"
                                 Margin="0,10,0,0"
@@ -1255,13 +1699,57 @@
                                 </Grid>
                             </Border>
                         </StackPanel>
-                    </ninactrl:DetachingExpander>
-                    <ContentControl DataContext="{Binding WaitUntilSafe}" IsEnabled="False" />
-                    <ninactrl:DetachingExpander Style="{StaticResource TriggerOnUnsafeSequenceContainerExpander}">
-                        <ninactrl:DetachingExpander.Header>
-                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description}" />
-                        </ninactrl:DetachingExpander.Header>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding WaitUntilSafe}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Margin="0,0,0,8"
+                        Padding="10">
                         <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                    Text="{ns:Loc Lbl_SequenceItem_SafetyMonitor_WaitUntilSafe_Description}" />
+                            </Grid>
+                            <ContentControl
+                                Margin="0,10,0,0"
+                                DataContext="{Binding WaitUntilSafe}"
+                                IsEnabled="False" />
+                        </StackPanel>
+                    </Border>
+
+                    <Border
+                        Tag="{Binding AfterWaitForSafe}"
+                        Style="{StaticResource TriggerWorkflowStageBorderStyle}"
+                        Padding="10"
+                        >
+                        <StackPanel Orientation="Vertical">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter
+                                    Margin="0,0,8,0"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Tag, RelativeSource={RelativeSource AncestorType=Border}}"
+                                    Style="{StaticResource ProgressPresenter}" />
+                                <TextBlock
+                                    Grid.Column="1"
+                                    Style="{StaticResource TriggerWorkflowStageTitleStyle}"
+                                    Text="{ns:Loc Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_Description}" />
+                            </Grid>
                             <Border
                                 MinHeight="50"
                                 Margin="0,10,0,0"
@@ -1304,7 +1792,7 @@
                                 </Grid>
                             </Border>
                         </StackPanel>
-                    </ninactrl:DetachingExpander>
+                    </Border>
                 </StackPanel>
 
             </ninactrl:DetachingExpander>

--- a/NINA.Sequencer/Trigger/Datatemplates.xaml.cs
+++ b/NINA.Sequencer/Trigger/Datatemplates.xaml.cs
@@ -15,15 +15,12 @@
 using NINA.Core.Enum;
 using NINA.Sequencer;
 using NINA.Sequencer.DragDrop;
+using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.Trigger.Utility;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace NINA.Sequencer.Trigger {
 
@@ -35,14 +32,11 @@ namespace NINA.Sequencer.Trigger {
         }
 
         private void AddTriggerSourceButton_Click(object sender, RoutedEventArgs e) {
-            if (sender is not Button button || button.ContextMenu == null) {
-                return;
-            }
+            OpenButtonContextMenu(sender as Button, e);
+        }
 
-            button.ContextMenu.PlacementTarget = button;
-            button.ContextMenu.DataContext = button.DataContext;
-            button.ContextMenu.IsOpen = true;
-            e.Handled = true;
+        private void AddTriggerInstructionButton_Click(object sender, RoutedEventArgs e) {
+            OpenButtonContextMenu(sender as Button, e);
         }
 
         private void MenuItemTriggerSource_Click(object sender, RoutedEventArgs e) {
@@ -54,7 +48,8 @@ namespace NINA.Sequencer.Trigger {
                 return;
             }
 
-            if (ItemsControl.ItemsControlFromItemContainer(menuItem) is not ContextMenu contextMenu) {
+            ContextMenu contextMenu = GetOwningContextMenu(menuItem);
+            if (contextMenu == null) {
                 return;
             }
 
@@ -72,6 +67,74 @@ namespace NINA.Sequencer.Trigger {
             };
 
             customTrigger.DropIntoTriggerSourceCommand.Execute(parameters);
+        }
+
+        private void MenuItemTriggerInstruction_Click(object sender, RoutedEventArgs e) {
+            if (sender is not MenuItem menuItem) {
+                return;
+            }
+
+            if (menuItem.DataContext is not SidebarEntity entity || entity.Entity is not ISequenceItem sequenceItem) {
+                return;
+            }
+
+            ContextMenu contextMenu = GetOwningContextMenu(menuItem);
+            if (contextMenu == null) {
+                return;
+            }
+
+            IDropContainer dropContainer = contextMenu.DataContext as IDropContainer;
+            if (dropContainer == null && contextMenu.PlacementTarget is FrameworkElement placementTarget) {
+                dropContainer = placementTarget.DataContext as IDropContainer;
+            }
+
+            if (dropContainer == null) {
+                return;
+            }
+
+            DropIntoParameters parameters = new DropIntoParameters(sequenceItem as IDroppable) {
+                Position = DropTargetEnum.Center
+            };
+
+            dropContainer.DropIntoCommand.Execute(parameters);
+        }
+
+        private static void OpenButtonContextMenu(Button button, RoutedEventArgs e) {
+            if (button == null || button.ContextMenu == null) {
+                return;
+            }
+
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.DataContext = button.DataContext;
+            button.ContextMenu.IsOpen = true;
+            e.Handled = true;
+        }
+
+        private static ContextMenu GetOwningContextMenu(MenuItem menuItem) {
+            DependencyObject current = menuItem;
+
+            while (current != null) {
+                if (current is ContextMenu contextMenu) {
+                    return contextMenu;
+                }
+
+                current = GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static DependencyObject GetParent(DependencyObject dependencyObject) {
+            DependencyObject parent = LogicalTreeHelper.GetParent(dependencyObject);
+            if (parent != null) {
+                return parent;
+            }
+
+            if (dependencyObject is Visual) {
+                return VisualTreeHelper.GetParent(dependencyObject);
+            }
+
+            return null;
         }
     }
 }

--- a/NINA.Sequencer/Trigger/MeridianFlip/MeridianFlipTrigger.cs
+++ b/NINA.Sequencer/Trigger/MeridianFlip/MeridianFlipTrigger.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 
 /*
     Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
@@ -176,6 +176,10 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
             return TimeSpan.FromHours(TimeToMeridianFlip);
         }
 
+        protected virtual TimeSpan GetReservedExecutionDuration(ISequenceItem nextItem) {
+            return nextItem?.GetEstimatedDuration() ?? TimeSpan.Zero;
+        }
+
         public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
             var telescopeInfo = telescopeMediator.GetInfo();
             //var settings = profileService.ActiveProfile.MeridianFlipSettings;
@@ -215,7 +219,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 return false;
             }
 
-            var nextInstructionTime = nextItem?.GetEstimatedDuration().TotalSeconds ?? 0;
+            var nextInstructionTime = GetReservedExecutionDuration(nextItem).TotalSeconds;
 
             //The time to meridian flip reported by the telescope is the latest time for a flip to happen
             var minimumTimeRemaining = CalculateMinimumTimeRemaining();

--- a/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
+++ b/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
@@ -1,0 +1,587 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Newtonsoft.Json;
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.PlateSolving.Interfaces;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.SequenceItem.Platesolving;
+using NINA.Sequencer.Utility;
+using NINA.Sequencer.Validations;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Sequencer.Trigger.MeridianFlip {
+
+    [ExportMetadata("Name", "Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_Name")]
+    [ExportMetadata("Description", "Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_Description")]
+    [ExportMetadata("Icon", "MeridianFlipSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_Telescope")]
+    [Export(typeof(ISequenceTrigger))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ProgrammableMeridianFlipTrigger : MeridianFlipTrigger {
+        private const string StageStopTracking = "StopTracking";
+        private const string StageBeforeFlipActions = "BeforeFlipActions";
+        private const string StageWaitForFlipWindow = "WaitForFlipWindow";
+        private const string StageResumeTrackingAndFlip = "ResumeTrackingAndFlip";
+        private const string StageInitialSettleAndSyncDome = "InitialSettleAndSyncDome";
+        private const string StageAfterFlipActions = "AfterFlipActions";
+
+        private readonly IApplicationResourceDictionary resourceDictionary;
+        private readonly IGuiderMediator guiderMediator;
+        private readonly IImagingMediator imagingMediator;
+        private readonly IDomeMediator domeMediator;
+        private readonly IDomeFollower domeFollower;
+        private readonly IFilterWheelMediator filterWheelMediator;
+        private readonly IImageHistoryVM history;
+        private readonly IAutoFocusVMFactory autoFocusVMFactory;
+        private readonly IPlateSolverFactory plateSolverFactory;
+        private readonly IWindowServiceFactory windowServiceFactory;
+        private bool isExpanded = true;
+        private bool shouldSeedDefaults = true;
+        private string activeStageId;
+        private string activeStageTitle;
+
+        [ImportingConstructor]
+        public ProgrammableMeridianFlipTrigger(
+            IProfileService profileService,
+            ICameraMediator cameraMediator,
+            ITelescopeMediator telescopeMediator,
+            IFocuserMediator focuserMediator,
+            IApplicationStatusMediator applicationStatusMediator,
+            IMeridianFlipVMFactory meridianFlipVMFactory,
+            ISafetyMonitorMediator safetyMonitorMediator,
+            IGuiderMediator guiderMediator,
+            IImagingMediator imagingMediator,
+            IDomeMediator domeMediator,
+            IDomeFollower domeFollower,
+            IFilterWheelMediator filterWheelMediator,
+            IImageHistoryVM history,
+            IAutoFocusVMFactory autoFocusVMFactory,
+            IPlateSolverFactory plateSolverFactory,
+            IWindowServiceFactory windowServiceFactory,
+            IApplicationResourceDictionary resourceDictionary)
+            : base(profileService, cameraMediator, telescopeMediator, focuserMediator, applicationStatusMediator, meridianFlipVMFactory, safetyMonitorMediator) {
+            this.guiderMediator = guiderMediator;
+            this.imagingMediator = imagingMediator;
+            this.domeMediator = domeMediator;
+            this.domeFollower = domeFollower;
+            this.filterWheelMediator = filterWheelMediator;
+            this.history = history;
+            this.autoFocusVMFactory = autoFocusVMFactory;
+            this.plateSolverFactory = plateSolverFactory;
+            this.windowServiceFactory = windowServiceFactory;
+            this.resourceDictionary = resourceDictionary;
+
+            BeforeFlipActions = CreateActionContainer("Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description");
+            AfterFlipActions = CreateActionContainer("Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description");
+        }
+
+        private ProgrammableMeridianFlipTrigger(ProgrammableMeridianFlipTrigger cloneMe)
+            : this(
+                cloneMe.profileService,
+                cloneMe.cameraMediator,
+                cloneMe.telescopeMediator,
+                cloneMe.focuserMediator,
+                cloneMe.applicationStatusMediator,
+                cloneMe.meridianFlipVMFactory,
+                cloneMe.safetyMonitorMediator,
+                cloneMe.guiderMediator,
+                cloneMe.imagingMediator,
+                cloneMe.domeMediator,
+                cloneMe.domeFollower,
+                cloneMe.filterWheelMediator,
+                cloneMe.history,
+                cloneMe.autoFocusVMFactory,
+                cloneMe.plateSolverFactory,
+                cloneMe.windowServiceFactory,
+                cloneMe.resourceDictionary) {
+            CopyMetaData(cloneMe);
+            BeforeFlipActions = (SequentialContainer)cloneMe.BeforeFlipActions.Clone();
+            AfterFlipActions = (SequentialContainer)cloneMe.AfterFlipActions.Clone();
+            IsExpanded = cloneMe.IsExpanded;
+            shouldSeedDefaults = cloneMe.shouldSeedDefaults;
+        }
+
+        [JsonProperty]
+        public SequentialContainer BeforeFlipActions { get; set; }
+
+        [JsonProperty]
+        public SequentialContainer AfterFlipActions { get; set; }
+
+        [JsonProperty]
+        public bool IsExpanded {
+            get => isExpanded;
+            set {
+                isExpanded = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public string ActiveStageId {
+            get => activeStageId;
+            private set {
+                activeStageId = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public string ActiveStageTitle {
+            get => activeStageTitle;
+            private set {
+                activeStageTitle = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public TriggerStageState StopTrackingStage { get; } = new TriggerStageState();
+
+        [JsonIgnore]
+        public TriggerStageState WaitForFlipWindowStage { get; } = new TriggerStageState();
+
+        [JsonIgnore]
+        public TriggerStageState ResumeTrackingAndFlipStage { get; } = new TriggerStageState();
+
+        [JsonIgnore]
+        public TriggerStageState SettleStage { get; } = new TriggerStageState();
+
+        [OnDeserialized]
+        public void OnDeserialized(StreamingContext context) {
+            shouldSeedDefaults = false;
+            EnsureActionContainers();
+            AttachActionContainersToContext(Parent);
+            ResetWorkflowStageStatuses();
+            ClearActiveStage();
+        }
+
+        public override object Clone() {
+            return new ProgrammableMeridianFlipTrigger(this);
+        }
+
+        protected override TimeSpan GetReservedExecutionDuration(ISequenceItem nextItem) {
+            return base.GetReservedExecutionDuration(nextItem) + EstimateContainerDuration(BeforeFlipActions);
+        }
+
+        public override async Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            EnsureActionContainers();
+
+            Coordinates target = ResolveFlipTarget(context ?? Parent);
+            TimeSpan timeToFlip = CalculateScheduledFlipDelay();
+            DateTime flipDeadlineUtc = GetUtcNow().Add(timeToFlip);
+            bool trackingStopped = false;
+            bool completed = false;
+            DateTime flipDeadlineLocal = DateTime.Now.Add(timeToFlip);
+            ISequenceContainer originalBeforeFlipActionsParent = BeforeFlipActions.Parent;
+            ISequenceContainer originalAfterFlipActionsParent = AfterFlipActions.Parent;
+            ISequenceContainer runtimeParent = ItemUtility.CreateTriggerRunnerContext(context ?? Parent);
+            bool restoreCollapsedAfterExecution = !IsExpanded;
+
+            IsExpanded = true;
+
+            try {
+                ResetWorkflowStageStatuses();
+                lastFlipTime = DateTime.Now;
+                lastFlipCoordiantes = target;
+                EarliestFlipTime = flipDeadlineLocal;
+                LatestFlipTime = flipDeadlineLocal;
+
+                if (!ReferenceEquals(BeforeFlipActions.Parent, runtimeParent)) {
+                    BeforeFlipActions.AttachNewParent(runtimeParent);
+                }
+
+                if (!ReferenceEquals(AfterFlipActions.Parent, runtimeParent)) {
+                    AfterFlipActions.AttachNewParent(runtimeParent);
+                }
+
+                SetActiveStage(StageStopTracking, Loc.Instance["LblStopTracking"]);
+                progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblStopTracking"] });
+                telescopeMediator.SetTrackingEnabled(false);
+                trackingStopped = true;
+
+                await ExecuteActionSet(BeforeFlipActions, StageBeforeFlipActions, progress, token);
+
+                SetActiveStage(StageWaitForFlipWindow, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"]);
+                telescopeMediator.SetTrackingEnabled(false);
+                trackingStopped = true;
+                await WaitForFlipDeadline(flipDeadlineUtc, progress, token);
+
+                SetActiveStage(StageResumeTrackingAndFlip, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description"]);
+                progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblResumeTracking"] });
+                telescopeMediator.SetTrackingEnabled(true);
+                trackingStopped = false;
+
+                await ExecuteMeridianFlipCore(target, progress, token);
+
+                await ExecuteActionSet(AfterFlipActions, StageAfterFlipActions, progress, token);
+
+                if (profileService.ActiveProfile.MeridianFlipSettings.RotateImageAfterFlip) {
+                    await RotateImageAfterFlip(progress);
+                }
+
+                completed = true;
+            } finally {
+                if (!ReferenceEquals(BeforeFlipActions.Parent, originalBeforeFlipActionsParent)) {
+                    BeforeFlipActions.AttachNewParent(originalBeforeFlipActionsParent);
+                }
+
+                if (!ReferenceEquals(AfterFlipActions.Parent, originalAfterFlipActionsParent)) {
+                    AfterFlipActions.AttachNewParent(originalAfterFlipActionsParent);
+                }
+
+                BeforeFlipActions.ResetProgress();
+                AfterFlipActions.ResetProgress();
+                ResetWorkflowStageStatuses();
+                ClearActiveStage();
+
+                if (!completed) {
+                    if (trackingStopped) {
+                        telescopeMediator.SetTrackingEnabled(true);
+                    }
+                }
+
+                if (restoreCollapsedAfterExecution) {
+                    IsExpanded = false;
+                }
+
+                progress?.Report(new ApplicationStatus());
+            }
+        }
+
+        public override void AfterParentChanged() {
+            base.AfterParentChanged();
+            EnsureActionContainers();
+            SeedDefaultsIfNeeded();
+            AttachActionContainersToContext(Parent);
+            ResetWorkflowStageStatuses();
+            ClearActiveStage();
+            Validate();
+        }
+
+        public override bool Validate() {
+            EnsureActionContainers();
+
+            List<string> i = new List<string>();
+            bool valid = true;
+
+            if (!telescopeMediator.GetInfo().Connected) {
+                i.Add(Loc.Instance["LblTelescopeNotConnected"]);
+                valid = false;
+            }
+
+            BeforeFlipActions.Validate();
+            AfterFlipActions.Validate();
+            i.AddRange(BeforeFlipActions.Issues);
+            i.AddRange(AfterFlipActions.Issues);
+
+            Issues = i;
+            return valid;
+        }
+
+        public override string ToString() {
+            return $"Trigger: {nameof(ProgrammableMeridianFlipTrigger)}";
+        }
+
+        private void EnsureActionContainers() {
+            BeforeFlipActions ??= CreateActionContainer("Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description");
+            AfterFlipActions ??= CreateActionContainer("Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description");
+
+            if (string.IsNullOrWhiteSpace(BeforeFlipActions.Name)) {
+                BeforeFlipActions.Name = Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_BeforeFlipActions_Description"];
+            }
+
+            if (string.IsNullOrWhiteSpace(AfterFlipActions.Name)) {
+                AfterFlipActions.Name = Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_AfterFlipActions_Description"];
+            }
+        }
+
+        /// <summary>
+        /// Seeds a freshly dropped trigger from the active meridian-flip profile once, while keeping clones and loaded sequences unchanged.
+        /// </summary>
+        private void SeedDefaultsIfNeeded() {
+            if (!shouldSeedDefaults || Parent == null) {
+                return;
+            }
+
+            shouldSeedDefaults = false;
+
+            if (profileService.ActiveProfile.MeridianFlipSettings.AutoFocusAfterFlip) {
+                AfterFlipActions.Add(CreateDefaultAutofocusItem());
+            }
+
+            if (profileService.ActiveProfile.MeridianFlipSettings.Recenter) {
+                AfterFlipActions.Add(CreateDefaultCenterItem());
+            }
+        }
+
+        private SequentialContainer CreateActionContainer(string labelKey) {
+            SequentialContainer container = new SequentialContainer() {
+                Name = Loc.Instance[labelKey],
+                IsExpanded = true
+            };
+
+            return container.AddMetaData(resourceDictionary) as SequentialContainer;
+        }
+
+        private RunAutofocus CreateDefaultAutofocusItem() {
+            return new RunAutofocus(profileService, history, cameraMediator, filterWheelMediator, focuserMediator, autoFocusVMFactory).AddMetaData(resourceDictionary) as RunAutofocus;
+        }
+
+        private Center CreateDefaultCenterItem() {
+            return new Center(profileService, telescopeMediator, imagingMediator, filterWheelMediator, guiderMediator, domeMediator, domeFollower, plateSolverFactory, windowServiceFactory).AddMetaData(resourceDictionary) as Center;
+        }
+
+        private void AttachActionContainersToContext(ISequenceContainer parent) {
+            ISequenceContainer instructionSetParent = ItemUtility.CreateTriggerRunnerContext(parent);
+            BeforeFlipActions.AttachNewParent(instructionSetParent);
+            AfterFlipActions.AttachNewParent(instructionSetParent);
+        }
+
+        private Coordinates ResolveFlipTarget(ISequenceContainer context) {
+            ContextCoordinates contextCoordinates = ItemUtility.RetrieveContextCoordinates(context);
+            Coordinates target = contextCoordinates?.Coordinates;
+
+            if (contextCoordinates == null) {
+                target = telescopeMediator.GetCurrentPosition();
+                Logger.Warning("No target information available for programmable meridian flip. Taking current telescope coordinates instead for the flip.");
+            }
+
+            if (target != null && target.RA == 0 && target.Dec == 0) {
+                target = telescopeMediator.GetCurrentPosition();
+                Logger.Warning("Target coordinates are all zero. Most likely not intended. Taking current telescope coordinates instead for the programmable meridian flip.");
+            }
+
+            return target;
+        }
+
+        private TimeSpan CalculateScheduledFlipDelay() {
+            TimeSpan timeToFlip = CalculateMinimumTimeRemaining();
+            if (timeToFlip > TimeSpan.FromHours(2)) {
+                Logger.Info("Programmable Meridian Flip - Detected delayed flip state. Clamping wait time to zero.");
+                return TimeSpan.Zero;
+            }
+
+            return timeToFlip;
+        }
+
+        private async Task ExecuteActionSet(SequentialContainer actionSet, string stageId, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            SetActiveStage(stageId, actionSet.Name);
+            actionSet.ResetAll();
+            await actionSet.Run(progress, token);
+
+            if (actionSet.Status == SequenceEntityStatus.FAILED || HasFailedItems(actionSet)) {
+                throw new SequenceEntityFailedException($"{actionSet.Name} failed to execute");
+            }
+        }
+
+        private async Task WaitForFlipDeadline(DateTime flipDeadlineUtc, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            string waitForFlipWindowDescription = Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"];
+            TimeSpan remaining = flipDeadlineUtc - GetUtcNow();
+            if (remaining < TimeSpan.Zero) {
+                Logger.Warning($"Programmable Meridian Flip - Before-flip actions exceeded the saved flip deadline by {-remaining}. Flipping immediately.");
+                remaining = TimeSpan.Zero;
+            }
+
+            UpdateWaitForFlipWindowStatus(waitForFlipWindowDescription, remaining, progress);
+            while (remaining.TotalSeconds >= 1) {
+                TimeSpan delta = await CoreUtil.Delay(1000, token);
+                remaining = remaining - delta;
+                UpdateWaitForFlipWindowStatus(waitForFlipWindowDescription, remaining, progress);
+            }
+        }
+
+        private async Task ExecuteMeridianFlipCore(Coordinates target, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            bool flipSuccessful = false;
+            await telescopeMediator.RaiseBeforeMeridianFlip(new BeforeMeridianFlipEventArgs(target));
+
+            try {
+                progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblFlippingScope"] });
+                Logger.Info($"Programmable Meridian Flip - Scope will flip to coordinates RA: {target.RAString} Dec: {target.DecString} Epoch: {target.Epoch}");
+                flipSuccessful = await telescopeMediator.MeridianFlip(target, token);
+
+                SetActiveStage(StageInitialSettleAndSyncDome, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description"]);
+                await Settle(progress, token);
+                await SynchronizeDome(progress, token);
+
+                if (!flipSuccessful) {
+                    throw new SequenceEntityFailedException(Loc.Instance["LblMeridianFlipFailed"]);
+                }
+            } finally {
+                await telescopeMediator.RaiseAfterMeridianFlip(new AfterMeridianFlipEventArgs(flipSuccessful, target));
+            }
+        }
+
+        private async Task SynchronizeDome(IProgress<ApplicationStatus> progress, CancellationToken token) {
+            var domeInfo = domeMediator.GetInfo();
+            if (!domeInfo.Connected || !domeInfo.CanSetAzimuth) {
+                return;
+            }
+
+            progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblSynchronizingDome"] });
+            try {
+                if (domeFollower.IsFollowing) {
+                    Logger.Info("Programmable Meridian Flip - Waiting for dome to synchronize to scope");
+                    await domeFollower.WaitForDomeSynchronization(token);
+                } else {
+                    Logger.Info("Programmable Meridian Flip - Synchronizing dome to scope since dome following is not enabled");
+                    if (!await domeFollower.TriggerTelescopeSync()) {
+                        Notification.ShowWarning(Loc.Instance["LblDomeSyncFailureDuringMeridianFlip"]);
+                        Logger.Warning("Programmable Meridian Flip - Synchronize dome operation didn't complete successfully. Moving on");
+                    }
+                }
+            } catch (Exception ex) {
+                Notification.ShowWarning(Loc.Instance["LblDomeSyncFailureDuringMeridianFlip"]);
+                Logger.Error("Programmable Meridian Flip - Synchronize dome operation didn't complete successfully. Moving on", ex);
+            }
+        }
+
+        private async Task Settle(IProgress<ApplicationStatus> progress, CancellationToken token) {
+            TimeSpan remaining = TimeSpan.FromSeconds(profileService.ActiveProfile.MeridianFlipSettings.SettleTime);
+            Logger.Info($"Programmable Meridian Flip - Settling scope for {profileService.ActiveProfile.MeridianFlipSettings.SettleTime} seconds");
+            while (remaining.TotalSeconds >= 1) {
+                progress?.Report(new ApplicationStatus() { Status = $"{Loc.Instance["LblSettle"]} {remaining:hh\\:mm\\:ss}" });
+                TimeSpan delta = await CoreUtil.Delay(1000, token);
+                remaining = TimeSpan.FromSeconds(remaining.TotalSeconds - delta.TotalSeconds);
+            }
+        }
+
+        private Task RotateImageAfterFlip(IProgress<ApplicationStatus> progress) {
+            progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblRotateImageAfterFlip"] });
+            imagingMediator.SetImageRotation(imagingMediator.GetImageRotation() + 180);
+            return Task.CompletedTask;
+        }
+
+        private void SetActiveStage(string stageId, string stageTitle) {
+            CompleteStage(activeStageId);
+            ActiveStageId = stageId;
+            ActiveStageTitle = stageTitle;
+            SetStageStatus(stageId, SequenceEntityStatus.RUNNING);
+        }
+
+        private void UpdateWaitForFlipWindowStatus(string stageTitle, TimeSpan remaining, IProgress<ApplicationStatus> progress) {
+            string status = $"{stageTitle} {remaining:hh\\:mm\\:ss}";
+            ActiveStageTitle = status;
+            progress?.Report(new ApplicationStatus() { Status = status });
+        }
+
+        private void ResetWorkflowStageStatuses() {
+            StopTrackingStage.Status = SequenceEntityStatus.CREATED;
+            WaitForFlipWindowStage.Status = SequenceEntityStatus.CREATED;
+            ResumeTrackingAndFlipStage.Status = SequenceEntityStatus.CREATED;
+            SettleStage.Status = SequenceEntityStatus.CREATED;
+        }
+
+        private void CompleteStage(string stageId) {
+            SetStageStatus(stageId, SequenceEntityStatus.FINISHED);
+        }
+
+        private void SetStageStatus(string stageId, SequenceEntityStatus status) {
+            TriggerStageState stage = GetStageState(stageId);
+            if (stage != null) {
+                stage.Status = status;
+            }
+        }
+
+        private TriggerStageState GetStageState(string stageId) {
+            return stageId switch {
+                StageStopTracking => StopTrackingStage,
+                StageWaitForFlipWindow => WaitForFlipWindowStage,
+                StageResumeTrackingAndFlip => ResumeTrackingAndFlipStage,
+                StageInitialSettleAndSyncDome => SettleStage,
+                _ => null
+            };
+        }
+
+        private void ClearActiveStage() {
+            ActiveStageId = null;
+            ActiveStageTitle = null;
+        }
+
+        private DateTime GetUtcNow() {
+            return DateTime.UtcNow;
+        }
+
+        private static bool HasFailedItems(ISequenceContainer container) {
+            foreach (ISequenceItem item in container.GetItemsSnapshot()) {
+                if (item.Status == SequenceEntityStatus.FAILED) {
+                    return true;
+                }
+
+                if (item is ISequenceContainer childContainer && HasFailedItems(childContainer)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static TimeSpan EstimateContainerDuration(ISequenceContainer container) {
+            if (container == null) {
+                return TimeSpan.Zero;
+            }
+
+            TimeSpan total = TimeSpan.Zero;
+            foreach (ISequenceItem item in container.GetItemsSnapshot()) {
+                if (item.Status == SequenceEntityStatus.DISABLED) {
+                    continue;
+                }
+
+                if (item is ISequenceContainer childContainer) {
+                    total += EstimateContainerDuration(childContainer);
+                } else {
+                    total += item.GetEstimatedDuration();
+                }
+            }
+
+            return total;
+        }
+    }
+
+    /// <summary>
+    /// Lightweight status holder for fixed trigger workflow stages so sequencer progress templates can be reused in the trigger UI.
+    /// </summary>
+    public sealed class TriggerStageState : BaseINPC {
+        private SequenceEntityStatus status = SequenceEntityStatus.CREATED;
+
+        public SequenceEntityStatus Status {
+            get => status;
+            set {
+                status = value;
+                RaisePropertyChanged();
+            }
+        }
+    }
+}

--- a/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
+++ b/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
@@ -213,6 +213,8 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 EarliestFlipTime = flipDeadlineLocal;
                 LatestFlipTime = flipDeadlineLocal;
 
+                LogExecutionSummary(target, timeToFlip, flipDeadlineLocal);
+
                 if (!ReferenceEquals(BeforeFlipActions.Parent, runtimeParent)) {
                     BeforeFlipActions.AttachNewParent(runtimeParent);
                 }
@@ -223,18 +225,21 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
                 SetActiveStage(ProgrammableMeridianFlipStage.StopTracking, Loc.Instance["LblStopTracking"]);
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblStopTracking"] });
+                Logger.Info("Programmable Meridian Flip - Stopping tracking before running pre-flip actions");
                 telescopeMediator.SetTrackingEnabled(false);
                 trackingStopped = true;
 
                 await ExecuteActionSet(BeforeFlipActions, ProgrammableMeridianFlipStage.BeforeFlipActions, progress, token);
 
                 SetActiveStage(ProgrammableMeridianFlipStage.WaitForFlipWindow, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"]);
+                Logger.Info("Programmable Meridian Flip - Keeping tracking stopped while waiting for the flip window");
                 telescopeMediator.SetTrackingEnabled(false);
                 trackingStopped = true;
                 await WaitForFlipDeadline(flipDeadlineUtc, progress, token);
 
                 SetActiveStage(ProgrammableMeridianFlipStage.ResumeTrackingAndFlip, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description"]);
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblResumeTracking"] });
+                Logger.Info("Programmable Meridian Flip - Resuming tracking before initiating the flip");
                 telescopeMediator.SetTrackingEnabled(true);
                 trackingStopped = false;
 
@@ -263,6 +268,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
                 if (!completed) {
                     if (trackingStopped) {
+                        Logger.Info("Programmable Meridian Flip - Restoring tracking after incomplete programmable meridian flip");
                         telescopeMediator.SetTrackingEnabled(true);
                     }
                 }
@@ -272,6 +278,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 }
 
                 progress?.Report(new ApplicationStatus());
+                Logger.Info($"Programmable Meridian Flip - Exiting programmable meridian flip. Completed: {completed}");
             }
         }
 
@@ -393,6 +400,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
         private async Task ExecuteActionSet(SequentialContainer actionSet, ProgrammableMeridianFlipStage stage, IProgress<ApplicationStatus> progress, CancellationToken token) {
             SetActiveStage(stage, actionSet.Name);
+            Logger.Info($"Programmable Meridian Flip - Running {actionSet.Name}: {CountEnabledItems(actionSet)} enabled item(s), estimated duration {EstimateContainerDuration(actionSet)}");
             actionSet.ResetAll();
             await actionSet.Run(progress, token);
 
@@ -425,6 +433,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblFlippingScope"] });
                 Logger.Info($"Programmable Meridian Flip - Scope will flip to coordinates RA: {target.RAString} Dec: {target.DecString} Epoch: {target.Epoch}");
                 flipSuccessful = await telescopeMediator.MeridianFlip(target, token);
+                Logger.Trace($"Programmable Meridian Flip - Successful flip: {flipSuccessful}");
 
                 SetActiveStage(ProgrammableMeridianFlipStage.Settle, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description"]);
                 await Settle(progress, token);
@@ -474,8 +483,31 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
         private Task RotateImageAfterFlip(IProgress<ApplicationStatus> progress) {
             progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblRotateImageAfterFlip"] });
+            Logger.Info("Programmable Meridian Flip - Rotating image after flip by 180 degrees");
             imagingMediator.SetImageRotation(imagingMediator.GetImageRotation() + 180);
             return Task.CompletedTask;
+        }
+
+        private void LogExecutionSummary(Coordinates target, TimeSpan timeToFlip, DateTime flipDeadlineLocal) {
+            var settings = profileService.ActiveProfile.MeridianFlipSettings;
+            var telescopeInfo = telescopeMediator.GetInfo();
+
+            Logger.Info("Programmable Meridian Flip - Initializing programmable meridian flip. " +
+                $"Target: {FormatCoordinates(target)}; " +
+                $"Remaining wait time: {timeToFlip}; " +
+                $"Flip deadline: {flipDeadlineLocal:yyyy-MM-dd HH:mm:ss}; " +
+                $"Settings: PauseBeforeMeridian={settings.PauseTimeBeforeMeridian} min, MinutesAfterMeridian={settings.MinutesAfterMeridian} min, MaxMinutesAfterMeridian={settings.MaxMinutesAfterMeridian} min, UseSideOfPier={settings.UseSideOfPier}, SettleTime={settings.SettleTime} sec, RotateImageAfterFlip={settings.RotateImageAfterFlip}; " +
+                $"Profile seeding defaults: AutoFocusAfterFlip={settings.AutoFocusAfterFlip}, Recenter={settings.Recenter}; " +
+                $"Action plan: BeforeActions={CountEnabledItems(BeforeFlipActions)} enabled item(s) / {EstimateContainerDuration(BeforeFlipActions)}, AfterActions={CountEnabledItems(AfterFlipActions)} enabled item(s) / {EstimateContainerDuration(AfterFlipActions)}; " +
+                $"Telescope state: Tracking={telescopeInfo.TrackingEnabled}, SideOfPier={telescopeInfo.SideOfPier}, TimeToMeridianFlip={telescopeInfo.TimeToMeridianFlip} h, AtPark={telescopeInfo.AtPark}, AtHome={telescopeInfo.AtHome}");
+        }
+
+        private static string FormatCoordinates(Coordinates coordinates) {
+            if (coordinates == null) {
+                return "unknown";
+            }
+
+            return $"RA: {coordinates.RAString} Dec: {coordinates.DecString} Epoch: {coordinates.Epoch}";
         }
 
         private void SetActiveStage(ProgrammableMeridianFlipStage stage, string stageTitle) {
@@ -536,6 +568,27 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
             }
 
             return false;
+        }
+
+        private static int CountEnabledItems(ISequenceContainer container) {
+            if (container == null) {
+                return 0;
+            }
+
+            int total = 0;
+            foreach (ISequenceItem item in container.GetItemsSnapshot()) {
+                if (item.Status == SequenceEntityStatus.DISABLED) {
+                    continue;
+                }
+
+                if (item is ISequenceContainer childContainer) {
+                    total += CountEnabledItems(childContainer);
+                } else {
+                    total++;
+                }
+            }
+
+            return total;
         }
 
         private static TimeSpan EstimateContainerDuration(ISequenceContainer container) {

--- a/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
+++ b/NINA.Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTrigger.cs
@@ -51,12 +51,15 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
     [Export(typeof(ISequenceTrigger))]
     [JsonObject(MemberSerialization.OptIn)]
     public class ProgrammableMeridianFlipTrigger : MeridianFlipTrigger {
-        private const string StageStopTracking = "StopTracking";
-        private const string StageBeforeFlipActions = "BeforeFlipActions";
-        private const string StageWaitForFlipWindow = "WaitForFlipWindow";
-        private const string StageResumeTrackingAndFlip = "ResumeTrackingAndFlip";
-        private const string StageInitialSettleAndSyncDome = "InitialSettleAndSyncDome";
-        private const string StageAfterFlipActions = "AfterFlipActions";
+        private enum ProgrammableMeridianFlipStage {
+            None,
+            StopTracking,
+            BeforeFlipActions,
+            WaitForFlipWindow,
+            ResumeTrackingAndFlip,
+            Settle,
+            AfterFlipActions
+        }
 
         private readonly IApplicationResourceDictionary resourceDictionary;
         private readonly IGuiderMediator guiderMediator;
@@ -70,7 +73,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
         private readonly IWindowServiceFactory windowServiceFactory;
         private bool isExpanded = true;
         private bool shouldSeedDefaults = true;
-        private string activeStageId;
+        private ProgrammableMeridianFlipStage activeStage = ProgrammableMeridianFlipStage.None;
         private string activeStageTitle;
 
         [ImportingConstructor]
@@ -150,15 +153,6 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
         }
 
         [JsonIgnore]
-        public string ActiveStageId {
-            get => activeStageId;
-            private set {
-                activeStageId = value;
-                RaisePropertyChanged();
-            }
-        }
-
-        [JsonIgnore]
         public string ActiveStageTitle {
             get => activeStageTitle;
             private set {
@@ -168,16 +162,16 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
         }
 
         [JsonIgnore]
-        public TriggerStageState StopTrackingStage { get; } = new TriggerStageState();
+        public WorkflowStageState StopTrackingStage { get; } = new WorkflowStageState();
 
         [JsonIgnore]
-        public TriggerStageState WaitForFlipWindowStage { get; } = new TriggerStageState();
+        public WorkflowStageState WaitForFlipWindowStage { get; } = new WorkflowStageState();
 
         [JsonIgnore]
-        public TriggerStageState ResumeTrackingAndFlipStage { get; } = new TriggerStageState();
+        public WorkflowStageState ResumeTrackingAndFlipStage { get; } = new WorkflowStageState();
 
         [JsonIgnore]
-        public TriggerStageState SettleStage { get; } = new TriggerStageState();
+        public WorkflowStageState SettleStage { get; } = new WorkflowStageState();
 
         [OnDeserialized]
         public void OnDeserialized(StreamingContext context) {
@@ -201,7 +195,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
             Coordinates target = ResolveFlipTarget(context ?? Parent);
             TimeSpan timeToFlip = CalculateScheduledFlipDelay();
-            DateTime flipDeadlineUtc = GetUtcNow().Add(timeToFlip);
+            DateTime flipDeadlineUtc = DateTime.UtcNow.Add(timeToFlip);
             bool trackingStopped = false;
             bool completed = false;
             DateTime flipDeadlineLocal = DateTime.Now.Add(timeToFlip);
@@ -227,26 +221,26 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                     AfterFlipActions.AttachNewParent(runtimeParent);
                 }
 
-                SetActiveStage(StageStopTracking, Loc.Instance["LblStopTracking"]);
+                SetActiveStage(ProgrammableMeridianFlipStage.StopTracking, Loc.Instance["LblStopTracking"]);
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblStopTracking"] });
                 telescopeMediator.SetTrackingEnabled(false);
                 trackingStopped = true;
 
-                await ExecuteActionSet(BeforeFlipActions, StageBeforeFlipActions, progress, token);
+                await ExecuteActionSet(BeforeFlipActions, ProgrammableMeridianFlipStage.BeforeFlipActions, progress, token);
 
-                SetActiveStage(StageWaitForFlipWindow, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"]);
+                SetActiveStage(ProgrammableMeridianFlipStage.WaitForFlipWindow, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"]);
                 telescopeMediator.SetTrackingEnabled(false);
                 trackingStopped = true;
                 await WaitForFlipDeadline(flipDeadlineUtc, progress, token);
 
-                SetActiveStage(StageResumeTrackingAndFlip, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description"]);
+                SetActiveStage(ProgrammableMeridianFlipStage.ResumeTrackingAndFlip, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_ResumeTrackingAndFlip_Description"]);
                 progress?.Report(new ApplicationStatus() { Status = Loc.Instance["LblResumeTracking"] });
                 telescopeMediator.SetTrackingEnabled(true);
                 trackingStopped = false;
 
                 await ExecuteMeridianFlipCore(target, progress, token);
 
-                await ExecuteActionSet(AfterFlipActions, StageAfterFlipActions, progress, token);
+                await ExecuteActionSet(AfterFlipActions, ProgrammableMeridianFlipStage.AfterFlipActions, progress, token);
 
                 if (profileService.ActiveProfile.MeridianFlipSettings.RotateImageAfterFlip) {
                     await RotateImageAfterFlip(progress);
@@ -397,8 +391,8 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
             return timeToFlip;
         }
 
-        private async Task ExecuteActionSet(SequentialContainer actionSet, string stageId, IProgress<ApplicationStatus> progress, CancellationToken token) {
-            SetActiveStage(stageId, actionSet.Name);
+        private async Task ExecuteActionSet(SequentialContainer actionSet, ProgrammableMeridianFlipStage stage, IProgress<ApplicationStatus> progress, CancellationToken token) {
+            SetActiveStage(stage, actionSet.Name);
             actionSet.ResetAll();
             await actionSet.Run(progress, token);
 
@@ -409,7 +403,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
         private async Task WaitForFlipDeadline(DateTime flipDeadlineUtc, IProgress<ApplicationStatus> progress, CancellationToken token) {
             string waitForFlipWindowDescription = Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"];
-            TimeSpan remaining = flipDeadlineUtc - GetUtcNow();
+            TimeSpan remaining = flipDeadlineUtc - DateTime.UtcNow;
             if (remaining < TimeSpan.Zero) {
                 Logger.Warning($"Programmable Meridian Flip - Before-flip actions exceeded the saved flip deadline by {-remaining}. Flipping immediately.");
                 remaining = TimeSpan.Zero;
@@ -432,7 +426,7 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
                 Logger.Info($"Programmable Meridian Flip - Scope will flip to coordinates RA: {target.RAString} Dec: {target.DecString} Epoch: {target.Epoch}");
                 flipSuccessful = await telescopeMediator.MeridianFlip(target, token);
 
-                SetActiveStage(StageInitialSettleAndSyncDome, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description"]);
+                SetActiveStage(ProgrammableMeridianFlipStage.Settle, Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_InitialSettleAndSyncDome_Description"]);
                 await Settle(progress, token);
                 await SynchronizeDome(progress, token);
 
@@ -484,11 +478,11 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
             return Task.CompletedTask;
         }
 
-        private void SetActiveStage(string stageId, string stageTitle) {
-            CompleteStage(activeStageId);
-            ActiveStageId = stageId;
+        private void SetActiveStage(ProgrammableMeridianFlipStage stage, string stageTitle) {
+            CompleteStage(activeStage);
+            activeStage = stage;
             ActiveStageTitle = stageTitle;
-            SetStageStatus(stageId, SequenceEntityStatus.RUNNING);
+            SetStageStatus(stage, SequenceEntityStatus.RUNNING);
         }
 
         private void UpdateWaitForFlipWindowStatus(string stageTitle, TimeSpan remaining, IProgress<ApplicationStatus> progress) {
@@ -504,34 +498,30 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
             SettleStage.Status = SequenceEntityStatus.CREATED;
         }
 
-        private void CompleteStage(string stageId) {
-            SetStageStatus(stageId, SequenceEntityStatus.FINISHED);
+        private void CompleteStage(ProgrammableMeridianFlipStage stage) {
+            SetStageStatus(stage, SequenceEntityStatus.FINISHED);
         }
 
-        private void SetStageStatus(string stageId, SequenceEntityStatus status) {
-            TriggerStageState stage = GetStageState(stageId);
-            if (stage != null) {
-                stage.Status = status;
+        private void SetStageStatus(ProgrammableMeridianFlipStage stage, SequenceEntityStatus status) {
+            WorkflowStageState stageState = GetStageState(stage);
+            if (stageState != null) {
+                stageState.Status = status;
             }
         }
 
-        private TriggerStageState GetStageState(string stageId) {
-            return stageId switch {
-                StageStopTracking => StopTrackingStage,
-                StageWaitForFlipWindow => WaitForFlipWindowStage,
-                StageResumeTrackingAndFlip => ResumeTrackingAndFlipStage,
-                StageInitialSettleAndSyncDome => SettleStage,
+        private WorkflowStageState GetStageState(ProgrammableMeridianFlipStage stage) {
+            return stage switch {
+                ProgrammableMeridianFlipStage.StopTracking => StopTrackingStage,
+                ProgrammableMeridianFlipStage.WaitForFlipWindow => WaitForFlipWindowStage,
+                ProgrammableMeridianFlipStage.ResumeTrackingAndFlip => ResumeTrackingAndFlipStage,
+                ProgrammableMeridianFlipStage.Settle => SettleStage,
                 _ => null
             };
         }
 
         private void ClearActiveStage() {
-            ActiveStageId = null;
+            activeStage = ProgrammableMeridianFlipStage.None;
             ActiveStageTitle = null;
-        }
-
-        private DateTime GetUtcNow() {
-            return DateTime.UtcNow;
         }
 
         private static bool HasFailedItems(ISequenceContainer container) {
@@ -568,19 +558,19 @@ namespace NINA.Sequencer.Trigger.MeridianFlip {
 
             return total;
         }
-    }
 
-    /// <summary>
-    /// Lightweight status holder for fixed trigger workflow stages so sequencer progress templates can be reused in the trigger UI.
-    /// </summary>
-    public sealed class TriggerStageState : BaseINPC {
-        private SequenceEntityStatus status = SequenceEntityStatus.CREATED;
+        /// <summary>
+        /// Lightweight status holder for fixed trigger workflow stages so sequencer progress templates can be reused in the trigger UI.
+        /// </summary>
+        public sealed class WorkflowStageState : BaseINPC {
+            private SequenceEntityStatus status = SequenceEntityStatus.CREATED;
 
-        public SequenceEntityStatus Status {
-            get => status;
-            set {
-                status = value;
-                RaisePropertyChanged();
+            public SequenceEntityStatus Status {
+                get => status;
+                set {
+                    status = value;
+                    RaisePropertyChanged();
+                }
             }
         }
     }

--- a/NINA.Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafe.cs
+++ b/NINA.Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafe.cs
@@ -30,6 +30,7 @@ namespace NINA.Sequencer.Trigger.SafetyMonitor {
         private readonly ISafetyMonitorMediator safetyMonitorMediator;
         private readonly IApplicationResourceDictionary resourceDictionary;
         private readonly object triggerLock = new object();
+        private bool isExpanded = true;
         private bool shouldTrigger;
         private bool triggerIsRunning;
         private bool hasSeenConnected;
@@ -48,6 +49,7 @@ namespace NINA.Sequencer.Trigger.SafetyMonitor {
             BeforeWaitForSafe = (SequentialContainer)cloneMe.BeforeWaitForSafe.Clone();
             AfterWaitForSafe = (SequentialContainer)cloneMe.AfterWaitForSafe.Clone();
             WaitUntilSafe = (WaitUntilSafe)cloneMe.WaitUntilSafe.Clone();
+            IsExpanded = cloneMe.IsExpanded;
         }
 
 
@@ -102,6 +104,15 @@ namespace NINA.Sequencer.Trigger.SafetyMonitor {
             set;
         }
 
+        [JsonProperty]
+        public bool IsExpanded {
+            get => isExpanded;
+            set {
+                isExpanded = value;
+                RaisePropertyChanged();
+            }
+        }
+
         [Newtonsoft.Json.JsonIgnore]
         public WaitUntilSafe WaitUntilSafe { get; private set; }
 
@@ -110,11 +121,14 @@ namespace NINA.Sequencer.Trigger.SafetyMonitor {
             ISequenceContainer originalBeforeWaitForSafeParent = BeforeWaitForSafe.Parent;
             ISequenceContainer originalAfterWaitForSafeParent = AfterWaitForSafe.Parent;
             ISequenceContainer runtimeParent = ItemUtility.CreateTriggerRunnerContext(context ?? Parent);
+            bool restoreCollapsedAfterExecution = !IsExpanded;
 
             lock (triggerLock) {
                 shouldTrigger = false;
                 triggerIsRunning = true;
             }
+
+            IsExpanded = true;
 
             try {
                 // Run the unsafe instruction sets against an isolated context proxy. That keeps
@@ -145,6 +159,10 @@ namespace NINA.Sequencer.Trigger.SafetyMonitor {
 
                     triggerIsRunning = false;
                     shouldTrigger = IsUnsafe();
+                }
+
+                if (restoreCollapsedAfterExecution) {
+                    IsExpanded = false;
                 }
             }
         }

--- a/NINA.Test/Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTriggerTest.cs
@@ -1,0 +1,411 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Core.Utility.WindowService;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyDome;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyGuider;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.PlateSolving.Interfaces;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.Interfaces;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.Autofocus;
+using NINA.Sequencer.SequenceItem.Platesolving;
+using NINA.Sequencer.Trigger;
+using NINA.Sequencer.Trigger.MeridianFlip;
+using NINA.WPF.Base.Interfaces;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace NINA.Test.Sequencer.Trigger.MeridianFlip {
+
+    [TestFixture]
+    public class ProgrammableMeridianFlipTriggerTest {
+        private Mock<IProfileService> profileServiceMock;
+        private Mock<ITelescopeMediator> telescopeMediatorMock;
+        private Mock<IApplicationStatusMediator> applicationStatusMediatorMock;
+        private Mock<IFocuserMediator> focuserMediatorMock;
+        private Mock<ICameraMediator> cameraMediatorMock;
+        private Mock<IMeridianFlipVMFactory> meridianFlipVMFactoryMock;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
+        private Mock<IGuiderMediator> guiderMediatorMock;
+        private Mock<IImagingMediator> imagingMediatorMock;
+        private Mock<IDomeMediator> domeMediatorMock;
+        private Mock<IDomeFollower> domeFollowerMock;
+        private Mock<IFilterWheelMediator> filterWheelMediatorMock;
+        private Mock<IImageHistoryVM> historyMock;
+        private Mock<IAutoFocusVMFactory> autoFocusVMFactoryMock;
+        private Mock<IPlateSolverFactory> plateSolverFactoryMock;
+        private Mock<IWindowServiceFactory> windowServiceFactoryMock;
+        private Mock<IApplicationResourceDictionary> resourceDictionaryMock;
+        private TelescopeInfo telescopeInfo;
+
+        [SetUp]
+        public void Setup() {
+            profileServiceMock = new Mock<IProfileService>();
+            telescopeMediatorMock = new Mock<ITelescopeMediator>();
+            applicationStatusMediatorMock = new Mock<IApplicationStatusMediator>();
+            cameraMediatorMock = new Mock<ICameraMediator>();
+            focuserMediatorMock = new Mock<IFocuserMediator>();
+            meridianFlipVMFactoryMock = new Mock<IMeridianFlipVMFactory>();
+            safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
+            guiderMediatorMock = new Mock<IGuiderMediator>();
+            imagingMediatorMock = new Mock<IImagingMediator>();
+            domeMediatorMock = new Mock<IDomeMediator>();
+            domeFollowerMock = new Mock<IDomeFollower>();
+            filterWheelMediatorMock = new Mock<IFilterWheelMediator>();
+            historyMock = new Mock<IImageHistoryVM>();
+            autoFocusVMFactoryMock = new Mock<IAutoFocusVMFactory>();
+            plateSolverFactoryMock = new Mock<IPlateSolverFactory>();
+            windowServiceFactoryMock = new Mock<IWindowServiceFactory>();
+            resourceDictionaryMock = new Mock<IApplicationResourceDictionary>();
+
+            telescopeInfo = new TelescopeInfo() {
+                Connected = true,
+                TrackingEnabled = true,
+                TimeToMeridianFlip = 0
+            };
+
+            resourceDictionaryMock.Setup(x => x[It.IsAny<string>()]).Returns(new GeometryGroup());
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(() => telescopeInfo);
+            telescopeMediatorMock.Setup(x => x.SetTrackingEnabled(It.IsAny<bool>()))
+                .Callback<bool>(enabled => telescopeInfo.TrackingEnabled = enabled)
+                .Returns(true);
+            telescopeMediatorMock.Setup(x => x.MeridianFlip(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            telescopeMediatorMock.Setup(x => x.RaiseBeforeMeridianFlip(It.IsAny<BeforeMeridianFlipEventArgs>())).Returns(Task.CompletedTask);
+            telescopeMediatorMock.Setup(x => x.RaiseAfterMeridianFlip(It.IsAny<AfterMeridianFlipEventArgs>())).Returns(Task.CompletedTask);
+            telescopeMediatorMock.Setup(x => x.GetCurrentPosition()).Returns(new Coordinates(Angle.ByHours(10), Angle.ByDegree(20), Epoch.JNOW));
+            cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo() { Connected = false });
+            focuserMediatorMock.Setup(x => x.GetInfo()).Returns(new FocuserInfo() { Connected = false });
+
+            guiderMediatorMock.Setup(x => x.GetInfo()).Returns(new GuiderInfo() { Connected = false });
+            guiderMediatorMock.Setup(x => x.StopGuiding(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+            guiderMediatorMock.Setup(x => x.StartGuiding(It.IsAny<bool>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            guiderMediatorMock.Setup(x => x.AutoSelectGuideStar(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            guiderMediatorMock.Setup(x => x.GetDevice()).Returns(new Mock<IGuider>().Object);
+
+            domeMediatorMock.Setup(x => x.GetInfo()).Returns(new DomeInfo() { Connected = false });
+            imagingMediatorMock.Setup(x => x.GetImageRotation()).Returns(0);
+        }
+
+        [Test]
+        public void AfterParentChanged_SeedsDefaultsFromProfileOnce() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0, autofocusAfterFlip: true, recenter: true);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            SequentialContainer parent = new SequentialContainer();
+
+            sut.BeforeFlipActions.Items.Should().BeEmpty();
+            sut.AfterFlipActions.Items.Should().BeEmpty();
+
+            parent.Add(sut);
+
+            sut.BeforeFlipActions.Items.Should().BeEmpty();
+            sut.AfterFlipActions.Items.Should().HaveCount(2);
+            sut.AfterFlipActions.Items[0].Should().BeOfType<RunAutofocus>();
+            sut.AfterFlipActions.Items[1].Should().BeOfType<Center>();
+        }
+
+        [Test]
+        public void Clone_CopiesNestedActionsWithoutReseeding() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0, autofocusAfterFlip: true, recenter: true);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            SequentialContainer originalParent = new SequentialContainer();
+            SequentialContainer cloneParent = new SequentialContainer();
+
+            originalParent.Add(sut);
+            sut.AfterFlipActions.Add(new RecordingInstruction());
+            sut.IsExpanded = false;
+
+            ProgrammableMeridianFlipTrigger clone = (ProgrammableMeridianFlipTrigger)sut.Clone();
+            cloneParent.Add(clone);
+
+            clone.Should().NotBeSameAs(sut);
+            clone.BeforeFlipActions.Should().NotBeSameAs(sut.BeforeFlipActions);
+            clone.AfterFlipActions.Should().NotBeSameAs(sut.AfterFlipActions);
+            clone.AfterFlipActions.Items.Should().HaveCount(3);
+            clone.IsExpanded.Should().BeFalse();
+        }
+
+        [Test]
+        public void ShouldTrigger_IncludesBeforeFlipActionDuration() {
+            SetupMeridianFlipSettings(minutesAfter: 5, maxMinutesAfter: 10, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            Mock<ISequenceItem> nextItemMock = new Mock<ISequenceItem>();
+
+            telescopeInfo.TimeToMeridianFlip = TimeSpan.FromMinutes(8).TotalHours;
+            sut.BeforeFlipActions.Add(new RecordingInstruction() { EstimatedDuration = TimeSpan.FromMinutes(7) });
+            nextItemMock.Setup(x => x.GetEstimatedDuration()).Returns(TimeSpan.FromMinutes(1));
+
+            sut.ShouldTrigger(null, nextItemMock.Object).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Execute_StopsTrackingBeforeBeforeFlipActionsAndRunsCustomStagesInOrder() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            List<string> order = new List<string>();
+            bool? expandedDuringBeforeActions = null;
+            sut.IsExpanded = false;
+
+            telescopeMediatorMock.Setup(x => x.SetTrackingEnabled(It.IsAny<bool>()))
+                .Callback<bool>(enabled => {
+                    telescopeInfo.TrackingEnabled = enabled;
+                    order.Add(enabled ? "TrackingOn" : "TrackingOff");
+                })
+                .Returns(true);
+            telescopeMediatorMock.Setup(x => x.MeridianFlip(It.IsAny<Coordinates>(), It.IsAny<CancellationToken>()))
+                .Callback(() => order.Add("Flip"))
+                .ReturnsAsync(true);
+
+            sut.BeforeFlipActions.Add(new RecordingInstruction() {
+                ExecuteAction = () => {
+                    expandedDuringBeforeActions = sut.IsExpanded;
+                    order.Add(telescopeInfo.TrackingEnabled ? "BeforeTrackingOn" : "BeforeTrackingOff");
+                    telescopeInfo.TimeToMeridianFlip = TimeSpan.FromHours(6).TotalHours;
+                }
+            });
+            sut.AfterFlipActions.Add(new RecordingInstruction() {
+                ExecuteAction = () => order.Add("After")
+            });
+
+            await sut.Execute(new SequentialContainer(), new Progress<ApplicationStatus>(), CancellationToken.None);
+
+            order.Should().ContainInOrder("TrackingOff", "BeforeTrackingOff", "TrackingOn", "Flip", "After");
+            expandedDuringBeforeActions.Should().BeTrue();
+            sut.IsExpanded.Should().BeFalse();
+            telescopeInfo.TrackingEnabled.Should().BeTrue();
+            guiderMediatorMock.Verify(x => x.StopGuiding(It.IsAny<CancellationToken>()), Times.Never);
+            guiderMediatorMock.Verify(x => x.AutoSelectGuideStar(It.IsAny<CancellationToken>()), Times.Never);
+            guiderMediatorMock.Verify(x => x.StartGuiding(It.IsAny<bool>(), It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Test]
+        public async Task Execute_ReportsRemainingWaitTimeThroughActiveStageTitle() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            string waitForFlipWindowDescription = Loc.Instance["Lbl_SequenceTrigger_ProgrammableMeridianFlipTrigger_WaitForFlipWindow_Description"];
+
+            telescopeInfo.TimeToMeridianFlip = TimeSpan.FromSeconds(5).TotalHours;
+
+            Task executeTask = sut.Execute(new SequentialContainer(), new Progress<ApplicationStatus>(), cts.Token);
+
+            bool observedCountdown = SpinWait.SpinUntil(
+                () => sut.ActiveStageId == "WaitForFlipWindow"
+                    && sut.ActiveStageTitle != null
+                    && sut.ActiveStageTitle.StartsWith($"{waitForFlipWindowDescription} ", StringComparison.Ordinal),
+                TimeSpan.FromSeconds(2));
+
+            observedCountdown.Should().BeTrue();
+            sut.ActiveStageTitle.Should().NotBe(waitForFlipWindowDescription);
+
+            await cts.CancelAsync();
+
+            Func<Task> act = async () => await executeTask;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Test]
+        public async Task Execute_TracksVisibleStageStatusesAndResetsThemAfterExecution() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            TaskCompletionSource beforeStarted = new TaskCompletionSource();
+            TaskCompletionSource releaseBefore = new TaskCompletionSource();
+
+            telescopeInfo.TimeToMeridianFlip = 0;
+            sut.BeforeFlipActions.Add(new RecordingInstruction() {
+                ExecuteAsync = async token => {
+                    beforeStarted.TrySetResult();
+                    await releaseBefore.Task.WaitAsync(token);
+                }
+            });
+
+            Task executeTask = sut.Execute(new SequentialContainer(), new Progress<ApplicationStatus>(), CancellationToken.None);
+
+            await beforeStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            sut.StopTrackingStage.Status.Should().Be(SequenceEntityStatus.FINISHED);
+            sut.BeforeFlipActions.Status.Should().Be(SequenceEntityStatus.RUNNING);
+            sut.WaitForFlipWindowStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.ResumeTrackingAndFlipStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.SettleStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+
+            releaseBefore.TrySetResult();
+            await executeTask;
+
+            sut.StopTrackingStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.BeforeFlipActions.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.WaitForFlipWindowStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.ResumeTrackingAndFlipStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.SettleStage.Status.Should().Be(SequenceEntityStatus.CREATED);
+            sut.AfterFlipActions.Status.Should().Be(SequenceEntityStatus.CREATED);
+        }
+
+        [Test]
+        public async Task Execute_DoesNotEvaluateParentTriggerSetDuringBeforeFlipActionsExecution() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer context = new SequentialContainer();
+            ObservingTrigger siblingTrigger = new ObservingTrigger();
+            RecordingInstruction instruction = new RecordingInstruction();
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+
+            root.Add(context);
+            context.Add(siblingTrigger);
+            context.Add(sut);
+            sut.BeforeFlipActions.Add(instruction);
+
+            await sut.Execute(context, new Progress<ApplicationStatus>(), CancellationToken.None);
+
+            instruction.ExecuteCount.Should().Be(1);
+            siblingTrigger.ShouldTriggerCount.Should().Be(0);
+            siblingTrigger.ShouldTriggerAfterCount.Should().Be(0);
+        }
+
+        [Test]
+        public void Validate_ReportsCustomActionIssuesAndOnlyBlocksOnDisconnectedTelescope() {
+            SetupMeridianFlipSettings(minutesAfter: 0, maxMinutesAfter: 0, pauseBefore: 0, useSideOfPier: false, settleTime: 0);
+            ProgrammableMeridianFlipTrigger sut = CreateSut();
+            sut.BeforeFlipActions = new IssueReportingSequentialContainer("before issue");
+            sut.AfterFlipActions = new IssueReportingSequentialContainer("after issue");
+
+            sut.Validate().Should().BeTrue();
+            sut.Issues.Should().Equal("before issue", "after issue");
+
+            telescopeInfo.Connected = false;
+
+            sut.Validate().Should().BeFalse();
+            sut.Issues.Should().Contain(Loc.Instance["LblTelescopeNotConnected"]);
+            sut.Issues.Should().Contain("before issue");
+            sut.Issues.Should().Contain("after issue");
+        }
+
+        private ProgrammableMeridianFlipTrigger CreateSut() {
+            return new ProgrammableMeridianFlipTrigger(
+                profileServiceMock.Object,
+                cameraMediatorMock.Object,
+                telescopeMediatorMock.Object,
+                focuserMediatorMock.Object,
+                applicationStatusMediatorMock.Object,
+                meridianFlipVMFactoryMock.Object,
+                safetyMonitorMediatorMock.Object,
+                guiderMediatorMock.Object,
+                imagingMediatorMock.Object,
+                domeMediatorMock.Object,
+                domeFollowerMock.Object,
+                filterWheelMediatorMock.Object,
+                historyMock.Object,
+                autoFocusVMFactoryMock.Object,
+                plateSolverFactoryMock.Object,
+                windowServiceFactoryMock.Object,
+                resourceDictionaryMock.Object);
+        }
+
+        private void SetupMeridianFlipSettings(double minutesAfter, double maxMinutesAfter, double pauseBefore, bool useSideOfPier, int settleTime, bool recenter = false, bool autofocusAfterFlip = false, bool rotateImageAfterFlip = false) {
+            Mock<IMeridianFlipSettings> settings = new Mock<IMeridianFlipSettings>();
+            settings.SetupGet(m => m.MinutesAfterMeridian).Returns(minutesAfter);
+            settings.SetupGet(m => m.MaxMinutesAfterMeridian).Returns(maxMinutesAfter);
+            settings.SetupGet(m => m.PauseTimeBeforeMeridian).Returns(pauseBefore);
+            settings.SetupGet(m => m.UseSideOfPier).Returns(useSideOfPier);
+            settings.SetupGet(m => m.SettleTime).Returns(settleTime);
+            settings.SetupGet(m => m.Recenter).Returns(recenter);
+            settings.SetupGet(m => m.AutoFocusAfterFlip).Returns(autofocusAfterFlip);
+            settings.SetupGet(m => m.RotateImageAfterFlip).Returns(rotateImageAfterFlip);
+            profileServiceMock.SetupGet(m => m.ActiveProfile.MeridianFlipSettings).Returns(settings.Object);
+        }
+
+        private sealed class RecordingInstruction : NINA.Sequencer.SequenceItem.SequenceItem {
+            public Action? ExecuteAction { get; set; }
+            public Func<CancellationToken, Task>? ExecuteAsync { get; set; }
+            public TimeSpan EstimatedDuration { get; set; }
+            public int ExecuteCount { get; private set; }
+
+            public override object Clone() {
+                return new RecordingInstruction() {
+                    ExecuteAction = ExecuteAction,
+                    ExecuteAsync = ExecuteAsync,
+                    EstimatedDuration = EstimatedDuration
+                };
+            }
+
+            public override async Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+                ExecuteCount++;
+                if (ExecuteAsync != null) {
+                    await ExecuteAsync(token);
+                }
+
+                ExecuteAction?.Invoke();
+            }
+
+            public override TimeSpan GetEstimatedDuration() {
+                return EstimatedDuration;
+            }
+        }
+
+        private sealed class ObservingTrigger : SequenceTrigger {
+            public int ShouldTriggerCount { get; private set; }
+            public int ShouldTriggerAfterCount { get; private set; }
+
+            public override object Clone() {
+                return new ObservingTrigger();
+            }
+
+            public override bool ShouldTrigger(ISequenceItem previousItem, ISequenceItem nextItem) {
+                ShouldTriggerCount++;
+                return false;
+            }
+
+            public override bool ShouldTriggerAfter(ISequenceItem previousItem, ISequenceItem nextItem) {
+                ShouldTriggerAfterCount++;
+                return false;
+            }
+
+            public override Task Execute(ISequenceContainer context, IProgress<ApplicationStatus> progress, CancellationToken token) {
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class IssueReportingSequentialContainer : SequentialContainer {
+            private readonly string issue;
+
+            public IssueReportingSequentialContainer(string issue) {
+                this.issue = issue;
+            }
+
+            public override bool Validate() {
+                Issues.Clear();
+                Issues.Add(issue);
+                return false;
+            }
+        }
+    }
+}

--- a/NINA.Test/Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/MeridianFlip/ProgrammableMeridianFlipTriggerTest.cs
@@ -220,7 +220,7 @@ namespace NINA.Test.Sequencer.Trigger.MeridianFlip {
             Task executeTask = sut.Execute(new SequentialContainer(), new Progress<ApplicationStatus>(), cts.Token);
 
             bool observedCountdown = SpinWait.SpinUntil(
-                () => sut.ActiveStageId == "WaitForFlipWindow"
+                () => sut.WaitForFlipWindowStage.Status == SequenceEntityStatus.RUNNING
                     && sut.ActiveStageTitle != null
                     && sut.ActiveStageTitle.StartsWith($"{waitForFlipWindowDescription} ", StringComparison.Ordinal),
                 TimeSpan.FromSeconds(2));

--- a/NINA.Test/Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafeTest.cs
+++ b/NINA.Test/Sequencer/Trigger/SafetyMonitor/TriggerOnUnsafeTest.cs
@@ -65,6 +65,8 @@ namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
         /// </summary>
         [Test]
         public void Clone_CopiesMetadataAndNestedSteps() {
+            sut.IsExpanded = false;
+
             TriggerOnUnsafe clone = (TriggerOnUnsafe)sut.Clone();
 
             clone.Should().NotBeSameAs(sut);
@@ -75,6 +77,7 @@ namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
             clone.BeforeWaitForSafe.Should().NotBeSameAs(sut.BeforeWaitForSafe);
             clone.AfterWaitForSafe.Should().NotBeSameAs(sut.AfterWaitForSafe);
             clone.WaitUntilSafe.Should().NotBeSameAs(sut.WaitUntilSafe);
+            clone.IsExpanded.Should().BeFalse();
         }
 
         /// <summary>
@@ -180,6 +183,22 @@ namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
             sut.WaitUntilSafe.Status.Should().Be(SequenceEntityStatus.CREATED);
             sut.AfterWaitForSafe.Status.Should().Be(SequenceEntityStatus.CREATED);
             sut.TriggerRunner.GetItemsSnapshot().Should().HaveCount(3);
+        }
+
+        [Test]
+        public async Task Execute_WhenCollapsed_ExpandsDuringRunAndRestoresCollapsedState() {
+            safetyMonitorInfo.Connected = true;
+            safetyMonitorInfo.IsSafe = true;
+            bool? expandedDuringBeforeWaitForSafe = null;
+            sut.IsExpanded = false;
+            sut.BeforeWaitForSafe.Add(new TestInstruction() {
+                ExecuteAction = () => expandedDuringBeforeWaitForSafe = sut.IsExpanded
+            });
+
+            await sut.Execute(new SequentialContainer(), Mock.Of<IProgress<ApplicationStatus>>(), CancellationToken.None);
+
+            expandedDuringBeforeWaitForSafe.Should().BeTrue();
+            sut.IsExpanded.Should().BeFalse();
         }
 
         /// <summary>
@@ -301,6 +320,7 @@ namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
 
         private sealed class TestInstruction : NINA.Sequencer.SequenceItem.SequenceItem {
             public int ExecuteCount { get; private set; }
+            public Action? ExecuteAction { get; init; }
 
             public override object Clone() {
                 return new TestInstruction();
@@ -308,6 +328,7 @@ namespace NINA.Test.Sequencer.Trigger.SafetyMonitor {
 
             public override Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
                 ExecuteCount++;
+                ExecuteAction?.Invoke();
                 return Task.CompletedTask;
             }
         }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -94,6 +94,7 @@ This allows you to safely return to a stable release if needed.
     - Added a new **Trigger On Unsafe** safety monitor trigger. It can run configured instructions when the safety monitor reports unsafe or disconnects after it has been connected, then wait until the safety monitor reports safe again before running follow-up instructions.
     - When triggered, the currently running instruction is interrupted and reset so safety handling can take over immediately.
     - Added a new **Custom Trigger** that uses an existing trigger as its trigger source and runs user-configured instructions when that source would normally fire.
+    - Added a new **Programmable Meridian Flip** trigger that combines a built-in meridian flip with user-configurable before and after instruction sets while preserving the planned flip time after tracking is stopped.
 
 ### **Device Management**
 - **ASCOM Alpaca Direct Drivers**


### PR DESCRIPTION
## Purpose

Add a `Programmable Meridian Flip` trigger with configurable before/after actions, seeded from existing flip settings and update the trigger UIs to show staged fixed/custom steps with clearer container-like editing areas and runtime step progress.

## How Was It Tested?

- Manual UI verification of programmable meridian flip / trigger on unsafe / custom trigger editor behavior, drag/drop, add-menu insertion, auto-expand during execution, and staged progress updates.

## AI / Tooling Disclosure

OpenAI Codex

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None

## Screenshots

- Programmable Meridian Flip (new trigger)
<img width="1429" height="464" alt="image" src="https://github.com/user-attachments/assets/8cf30bf4-8ab9-4653-9de1-9b0c095b2393" />  

- Custom Trigger (updated UI)
<img width="1450" height="183" alt="image" src="https://github.com/user-attachments/assets/2aa17fe3-784d-46a7-b048-0716d8efaa19" />  

- Trigger on Unsafe (updated UI)
<img width="1429" height="341" alt="image" src="https://github.com/user-attachments/assets/266525e3-2240-4c92-91fb-ceb766b06a24" />  


## Additional Notes

- existing `Meridian Flip` trigger remains unchanged in behavior
- new programmable trigger uses hardwired flip execution with configurable before/after actions
- trigger editor XAML was refactored to share staged/container-like UI pieces across programmable meridian flip, trigger on unsafe, and custom trigger