### PR TITLE
Fix fencepost error in parsing QHY firmware version numbers

### DIFF
--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -326,7 +326,7 @@ namespace QHYCCD {
                 uint year = 0, month = 0, day = 0, subday = 0;
                 CheckReturn(GetQHYCCDSDKVersion(ref year, ref month, ref day, ref subday), MethodBase.GetCurrentMethod());
 
-                return year.ToString() + "-" + month.ToString() + "-" + day.ToString() + "-" + subday.ToString();
+                return $"{year}-{month}-{day}-{subday}";
             }
         }
 
@@ -355,7 +355,7 @@ namespace QHYCCD {
                             version += ", ";
                         }
 
-                        version = i + ": " + Convert.ToString(buf[0]) + "-" + Convert.ToString(buf[1]) + "-" + Convert.ToString(buf[2]) + "-" + Convert.ToString(buf[3]);
+                        version = $"{i}: {buf[0]}-{buf[1]}-{buf[2]}-{buf[3]}";
                     } else {
                         break;
                     }

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -336,12 +336,8 @@ namespace QHYCCD {
                 byte[] buf = new byte[10];
 
                 if (GetQHYCCDFWVersion(handle, buf) != QHYCCD_ERROR) {
-                    int ver = buf[0] >> 4;
-                    if (ver <= 9) {
-                        version = Convert.ToString(ver + 16) + "-" + Convert.ToString(buf[0] & -241) + "-" + Convert.ToString(buf[1]);
-                    } else {
-                        version = Convert.ToString(ver) + "-" + Convert.ToString(buf[0] & -241) + "-" + Convert.ToString(buf[1]);
-                    }
+                    int major = buf[0] >> 4;
+                    version = $"{(major <= 9 ? major + 16 : major)}-{buf[0] & 0x0F}-{buf[1]}";
                 }
 
                 return version;

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -337,7 +337,7 @@ namespace QHYCCD {
 
                 if (GetQHYCCDFWVersion(handle, buf) != QHYCCD_ERROR) {
                     int ver = buf[0] >> 4;
-                    if (ver < 9) {
+                    if (ver <= 9) {
                         version = Convert.ToString(ver + 16) + "-" + Convert.ToString(buf[0] & -241) + "-" + Convert.ToString(buf[1]);
                     } else {
                         version = Convert.ToString(ver) + "-" + Convert.ToString(buf[0] & -241) + "-" + Convert.ToString(buf[1]);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@ This allows you to safely return to a stable release if needed.
 - XISF metadata import now reads Bayer offsets, focal ratio, target coordinates, and wind speed/gust units correctly.
 - Manual rotator moves now clean up their moving state correctly when the rotation prompt is cancelled.
 - Fixed an issue where custom popout windows and message boxes could briefly render incorrectly when opened.
+- Firmware version is now correctly displayed for certain QHY camera models.
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

This corrects an off-by-one parsing error for firmware version on certain QHY camera models. ERIS-type cameras (QHY600, 268, etc.) seemed to be the ones affected. This resulted in a bogus firmware version being displayed and logged in NINA.

I also took this opportunity to make the firmware, FPGA, and SDK version gathering functions more efficient either in process or in form.

## 🧪 How Was It Tested?

QHY600, QHY183

## 🤖 AI / Tooling Disclosure

None

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [x ] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
