### PR TITLE
fix nullreference on alpaca direct devices

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/AlpacaDirectCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AlpacaDirectCamera.cs
@@ -206,15 +206,15 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public AsyncObservableCollection<BinningMode> BinningModes => ((ICamera)device).BinningModes;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void AbortExposure() {
             ((ICamera)device).AbortExposure();

--- a/NINA.Equipment/Equipment/MyDome/AlpacaDirectDome.cs
+++ b/NINA.Equipment/Equipment/MyDome/AlpacaDirectDome.cs
@@ -124,15 +124,15 @@ namespace NINA.Equipment.Equipment.MyDome {
 
         public bool Slewing => ((IDome)device).Slewing;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public Task SlewToAzimuth(double azimuth, CancellationToken ct) {
             return ((IDome)device).SlewToAzimuth(azimuth, ct);

--- a/NINA.Equipment/Equipment/MyFilterWheel/AlpacaDirectFilterWheel.cs
+++ b/NINA.Equipment/Equipment/MyFilterWheel/AlpacaDirectFilterWheel.cs
@@ -107,15 +107,15 @@ namespace NINA.Equipment.Equipment.MyFilterWheel {
 
         public AsyncObservableCollection<FilterInfo> Filters => ((IFilterWheel)device).Filters;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void Disconnect() {
             ((IDevice)device).Disconnect();

--- a/NINA.Equipment/Equipment/MyFlatDevice/AlpacaDirectCoverCalibrator.cs
+++ b/NINA.Equipment/Equipment/MyFlatDevice/AlpacaDirectCoverCalibrator.cs
@@ -111,15 +111,15 @@ namespace NINA.Equipment.Equipment.MyFlatDevice {
 
         public bool SupportsOnOff => ((IFlatDevice)device).SupportsOnOff;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public Task<bool> Open(CancellationToken ct, int delay = 300) {
             return ((IFlatDevice)device).Open(ct, delay);

--- a/NINA.Equipment/Equipment/MyFocuser/AlpacaDirectFocuser.cs
+++ b/NINA.Equipment/Equipment/MyFocuser/AlpacaDirectFocuser.cs
@@ -114,15 +114,15 @@ namespace NINA.Equipment.Equipment.MyFocuser {
 
         public double Temperature => ((IFocuser)device).Temperature;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public Task Move(int position, CancellationToken ct, int waitInMs = 1000) {
             return ((IFocuser)device).Move(position, ct, waitInMs);

--- a/NINA.Equipment/Equipment/MyRotator/AlpacaDirectRotator.cs
+++ b/NINA.Equipment/Equipment/MyRotator/AlpacaDirectRotator.cs
@@ -111,15 +111,15 @@ namespace NINA.Equipment.Equipment.MyRotator {
 
         public float StepSize => ((IRotator)device).StepSize;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void Sync(float skyAngle) {
             ((IRotator)device).Sync(skyAngle);

--- a/NINA.Equipment/Equipment/MySafetyMonitor/AlpacaDirectSafetyMonitor.cs
+++ b/NINA.Equipment/Equipment/MySafetyMonitor/AlpacaDirectSafetyMonitor.cs
@@ -99,15 +99,15 @@ namespace NINA.Equipment.Equipment.MySafetyMonitor {
 
         public bool IsSafe => ((ISafetyMonitor)device).IsSafe;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void Disconnect() {
             ((IDevice)device).Disconnect();

--- a/NINA.Equipment/Equipment/MySwitch/AlpacaDirectSwitch.cs
+++ b/NINA.Equipment/Equipment/MySwitch/AlpacaDirectSwitch.cs
@@ -50,7 +50,7 @@ namespace NINA.Equipment.Equipment.MySwitch.Ascom {
 
             RaisePropertyChanged(e.PropertyName);
         }
-        
+
         private IProfileService profileService;
         private AlpacaDirectSettings settings;
 
@@ -100,15 +100,15 @@ namespace NINA.Equipment.Equipment.MySwitch.Ascom {
 
         public ICollection<ISwitch> Switches => ((ISwitchHub)device).Switches;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void Disconnect() {
             ((IDevice)device).Disconnect();

--- a/NINA.Equipment/Equipment/MyTelescope/AlpacaDirectTelescope.cs
+++ b/NINA.Equipment/Equipment/MyTelescope/AlpacaDirectTelescope.cs
@@ -104,13 +104,13 @@ namespace NINA.Equipment.Equipment.MyTelescope {
             return ((IDevice)device).Action(actionName, actionParameters);
         }
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
         public Coordinates Coordinates => ((ITelescope)device).Coordinates;
 
@@ -208,7 +208,7 @@ namespace NINA.Equipment.Equipment.MyTelescope {
 
         public DateTime UTCDate => ((ITelescope)device).UTCDate;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public PierSide DestinationSideOfPier(Coordinates coordinates) {
             return ((ITelescope)device).DestinationSideOfPier(coordinates);

--- a/NINA.Equipment/Equipment/MyWeatherData/AlpacaDirectObservingConditions.cs
+++ b/NINA.Equipment/Equipment/MyWeatherData/AlpacaDirectObservingConditions.cs
@@ -124,15 +124,15 @@ namespace NINA.Equipment.Equipment.MyWeatherData {
 
         public double WindSpeed => ((IWeatherData)device).WindSpeed;
 
-        public bool Connected => ((IDevice)device).Connected;
+        public bool Connected => ((IDevice)device)?.Connected ?? false;
 
-        public string Description => ((IDevice)device).Description;
+        public string Description => ((IDevice)device)?.Description ?? string.Empty;
 
-        public string DriverInfo => ((IDevice)device).DriverInfo;
+        public string DriverInfo => ((IDevice)device)?.DriverInfo ?? string.Empty;
 
-        public string DriverVersion => ((IDevice)device).DriverVersion;
+        public string DriverVersion => ((IDevice)device)?.DriverVersion ?? string.Empty;
 
-        public IList<string> SupportedActions => ((IDevice)device).SupportedActions;
+        public IList<string> SupportedActions => ((IDevice)device)?.SupportedActions ?? [];
 
         public void Disconnect() {
             ((IDevice)device).Disconnect();


### PR DESCRIPTION
## 🚀 Purpose

When accessing the properties on an IDevice instance, they should not throw an exception when no alpaca direct device is connected. Every other device simply returns an empty string or list. The alpaca direct devices now behave the same. I found this issue because my api plugin serializes IDevice instances and would throw an exception when it encountered an Alpaca direct device.

## 🧪 How Was It Tested?

Confirmed that it now works with my api. Not all unit tests pass but the ones that fail belong to the NINA.Sequencer package, so I don't think they are related

## 🤖 AI / Tooling Disclosure

None

## ✅ PR Checklist

- [ ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [ ] Plugin API compatibility reviewed  
  - [ ] No breaking changes to interfaces  
  - [ ] No changes to method/class signatures (especially optional parameters)
- [ ] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

None

## 📸 Screenshots

None

## 📝 Additional Notes

I did not change the behavior for properties not included in the IDevice interface. It is not a problem that these are not available while a device is not connected, because they would not give meaningful information.
