### PR TITLE
Make native RAW saving optional for Nikon and Canon cameras

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -1295,7 +1295,7 @@ when the lines are not aligned there is some Polar Alignment error</value>
     <value>Enable bit scaling</value>
   </data>
   <data name="LblEnableBitScalingTooltip" xml:space="preserve">
-    <value>Save 8/10/12/14 bit images with scaling to 16 bits. (Only relevant for Altair, Moravian, Omegon, RisingCam, SVBony and ToupTek cameras, when using the native driver)</value>
+    <value>Save 8/10/12/14 bit images with scaling to 16 bits. Relevant only for native Altair, Canon, Moravian, Nikon, Omegon, RisingCam, SVBony and ToupTek drivers.</value>
   </data>
   <data name="LblEnabled" xml:space="preserve">
     <value>Enabled</value>

--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -2772,6 +2772,12 @@ Calculated HFR: {2}
   <data name="LblSaveImageAsDSLRNote" xml:space="preserve">
     <value>This setting is ignored for DSLRs when using the native driver. The camera's RAW format will be saved instead!</value>
   </data>
+  <data name="LblSaveNativeCameraRaw" xml:space="preserve">
+    <value>Save native camera RAW</value>
+  </data>
+  <data name="LblSaveNativeCameraRawTooltip" xml:space="preserve">
+    <value>When enabled, native Nikon and Canon camera images are saved as camera RAW files. When disabled, images are saved using Options > Imaging > File Settings.</value>
+  </data>
   <data name="LblSaveSelectedProfileAndDontAskAgain" xml:space="preserve">
     <value>Save selected profile and don't ask again next time</value>
   </data>

--- a/NINA.Image/FileFormat/FileSaveInfo.cs
+++ b/NINA.Image/FileFormat/FileSaveInfo.cs
@@ -29,19 +29,22 @@ namespace NINA.Image.FileFormat {
         public FITSCompressionTypeEnum FITSCompressionType { get; set; } = FITSCompressionTypeEnum.NONE;
         public bool FITSAddFzExtension { get; set; } = false;
         public bool FITSUseLegacyWriter { get; set; } = true;
+        public bool SaveNativeCameraRaw { get; set; } = true;
 
         public FileSaveInfo(IProfileService profileService = null) {
             if (profileService != null) {
-                FilePath = profileService.ActiveProfile.ImageFileSettings.FilePath;
-                FilePattern = profileService.ActiveProfile.ImageFileSettings.FilePattern;
-                FileType = profileService.ActiveProfile.ImageFileSettings.FileType;
-                TIFFCompressionType = profileService.ActiveProfile.ImageFileSettings.TIFFCompressionType;
-                XISFCompressionType = profileService.ActiveProfile.ImageFileSettings.XISFCompressionType;
-                XISFByteShuffling = profileService.ActiveProfile.ImageFileSettings.XISFByteShuffling;
-                XISFChecksumType = profileService.ActiveProfile.ImageFileSettings.XISFChecksumType;
-                FITSCompressionType = profileService.ActiveProfile.ImageFileSettings.FITSCompressionType;
-                FITSAddFzExtension = profileService.ActiveProfile.ImageFileSettings.FITSAddFzExtension;
-                FITSUseLegacyWriter = profileService.ActiveProfile.ImageFileSettings.FITSUseLegacyWriter;
+                var profile = profileService.ActiveProfile;
+                FilePath = profile.ImageFileSettings.FilePath;
+                FilePattern = profile.ImageFileSettings.FilePattern;
+                FileType = profile.ImageFileSettings.FileType;
+                TIFFCompressionType = profile.ImageFileSettings.TIFFCompressionType;
+                XISFCompressionType = profile.ImageFileSettings.XISFCompressionType;
+                XISFByteShuffling = profile.ImageFileSettings.XISFByteShuffling;
+                XISFChecksumType = profile.ImageFileSettings.XISFChecksumType;
+                FITSCompressionType = profile.ImageFileSettings.FITSCompressionType;
+                FITSAddFzExtension = profile.ImageFileSettings.FITSAddFzExtension;
+                FITSUseLegacyWriter = profile.ImageFileSettings.FITSUseLegacyWriter;
+                SaveNativeCameraRaw = profile.CameraSettings?.SaveNativeCameraRaw ?? true;
             }
         }
 

--- a/NINA.Image/ImageData/BaseImageData.cs
+++ b/NINA.Image/ImageData/BaseImageData.cs
@@ -326,7 +326,7 @@ namespace NINA.Image.ImageData {
             var pattern = fileSaveInfo.FilePattern;
             string actualPath = string.Empty;
             try {
-                if (pattern.Contains(ImagePatternKeys.SensorTemp) && double.IsNaN(MetaData.Camera.Temperature) && !string.IsNullOrEmpty(Data.RAWType)) {
+                if (pattern.Contains(ImagePatternKeys.SensorTemp) && double.IsNaN(MetaData.Camera.Temperature) && ShouldSaveNativeRaw(fileSaveInfo, forceFileType)) {
                     // For DSLRs we need to retrieve the temperature after the file is written. Hence we replace the pattern with this special placeholder
                     pattern = pattern.Replace(ImagePatternKeys.SensorTemp, "$$DSLR_SENSORTEMP$$");
                 }
@@ -385,7 +385,7 @@ namespace NINA.Image.ImageData {
                 string path = string.Empty;
                 fileSaveInfo.FilePath = Path.Combine(fileSaveInfo.FilePath, fileName);
 
-                if (!forceFileType && Data.RAWData != null) {
+                if (ShouldSaveNativeRaw(fileSaveInfo, forceFileType)) {
                     fileSaveInfo.FileType = FileTypeEnum.RAW;
                     path = SaveRAW(fileSaveInfo.FilePath);
                 } else {
@@ -407,6 +407,13 @@ namespace NINA.Image.ImageData {
 
                 return path;
             }, cancelToken);
+        }
+
+        private bool ShouldSaveNativeRaw(FileSaveInfo fileSaveInfo, bool forceFileType) {
+            return !forceFileType
+                && fileSaveInfo.SaveNativeCameraRaw
+                && Data.RAWData != null
+                && !string.IsNullOrWhiteSpace(Data.RAWType);
         }
 
         private string SaveRAW(string path) {

--- a/NINA.Image/ImageData/BaseImageData.cs
+++ b/NINA.Image/ImageData/BaseImageData.cs
@@ -629,7 +629,7 @@ namespace NINA.Image.ImageData {
                 using (var ms = new MemoryStream()) {
                     await fs.CopyToAsync(ms);
                     var rawType = Path.GetExtension(path).ToLower().Substring(1);
-                    var data = await rawConverter.Convert(s: ms, bitDepth: bitDepth, rawType: rawType, metaData: new ImageMetaData(), token: ct);
+                    var data = await rawConverter.Convert(s: ms, bitDepth: bitDepth, bitScaling: false, rawType: rawType, metaData: new ImageMetaData(), token: ct);
                     return data;
                 }
             }

--- a/NINA.Image/ImageData/DebayeredImage.cs
+++ b/NINA.Image/ImageData/DebayeredImage.cs
@@ -88,7 +88,7 @@ namespace NINA.Image.ImageData {
 
         public override IRenderedImage ReRender() {
             var reRenderedImage = base.ReRender();
-            return reRenderedImage.Debayer(saveColorChannels: this.SaveColorChannels, saveLumChannel: this.SaveLumChannel);
+            return reRenderedImage.Debayer(saveColorChannels: this.SaveColorChannels, saveLumChannel: this.SaveLumChannel, bayerPattern: this.BayerPattern);
         }
     }
 }

--- a/NINA.Image/ImageData/ExposureData.cs
+++ b/NINA.Image/ImageData/ExposureData.cs
@@ -84,6 +84,7 @@ namespace NINA.Image.ImageData {
             Create32BitData = create32BitData;
         }
 
+
         public override async Task<IImageData> ToImageData(IProgress<ApplicationStatus> progress = default, CancellationToken cancelToken = default) {
             switch(flatArray) {
                 case int[] integers:
@@ -253,7 +254,24 @@ namespace NINA.Image.ImageData {
         private readonly byte[] rawBytes;
         private readonly IRawConverter rawConverter;
         private readonly string rawType;
+        private readonly bool bitScaling;
 
+        public RAWExposureData(
+            IRawConverter rawConverter,
+            byte[] rawBytes,
+            string rawType,
+            int bitDepth,
+            bool bitScaling,
+            ImageMetaData metaData,
+            IImageDataFactory imageDataFactory)
+            : base(bitDepth, metaData, imageDataFactory) {
+            this.rawConverter = rawConverter;
+            this.rawBytes = rawBytes;
+            this.rawType = rawType;
+            this.bitScaling = bitScaling;
+        }
+
+        [Obsolete("Use the constructor with the bitScaling parameter.")]
         public RAWExposureData(
             IRawConverter rawConverter,
             byte[] rawBytes,
@@ -261,10 +279,7 @@ namespace NINA.Image.ImageData {
             int bitDepth,
             ImageMetaData metaData,
             IImageDataFactory imageDataFactory)
-            : base(bitDepth, metaData, imageDataFactory) {
-            this.rawConverter = rawConverter;
-            this.rawBytes = rawBytes;
-            this.rawType = rawType;
+            : this(rawConverter, rawBytes, rawType, bitDepth, bitScaling: false, metaData, imageDataFactory) {
         }
 
         public override async Task<IImageData> ToImageData(IProgress<ApplicationStatus> progress = default, CancellationToken cancelToken = default) {
@@ -275,6 +290,7 @@ namespace NINA.Image.ImageData {
                         s: memoryStream,
                         rawType: this.rawType,
                         bitDepth: this.BitDepth,
+                        bitScaling: this.bitScaling,
                         metaData: this.MetaData,
                         token: cancelToken);
                     return data;
@@ -307,7 +323,7 @@ namespace NINA.Image.ImageData {
         }
 
         public RAWExposureData CreateRAWExposureData(byte[] rawBytes, string rawType, int bitDepth, ImageMetaData metaData) {
-            return new RAWExposureData(RawConverterFactory.CreateInstance(imageDataFactory), rawBytes, rawType, bitDepth, metaData, imageDataFactory);
+            return new RAWExposureData(RawConverterFactory.CreateInstance(imageDataFactory), rawBytes, rawType, bitDepth, profileService.ActiveProfile.CameraSettings.BitScaling, metaData, imageDataFactory);
         }
 
 #pragma warning disable CS0618

--- a/NINA.Image/Interfaces/IRawConverter.cs
+++ b/NINA.Image/Interfaces/IRawConverter.cs
@@ -14,6 +14,7 @@
 
 using NINA.Image.ImageData;
 using NINA.Image.Interfaces;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,9 +23,20 @@ namespace NINA.Image.Interfaces {
 
     public interface IRawConverter {
 
+        [Obsolete("Use Convert with the bitScaling parameter.")]
         Task<IImageData> Convert(
             MemoryStream s,
             int bitDepth,
+            string rawType,
+            ImageMetaData metaData,
+            CancellationToken token = default) {
+            return Convert(s, bitDepth, bitScaling: false, rawType, metaData, token);
+        }
+
+        Task<IImageData> Convert(
+            MemoryStream s,
+            int bitDepth,
+            bool bitScaling,
             string rawType,
             ImageMetaData metaData,
             CancellationToken token = default);

--- a/NINA.Image/RawConverter/LibRawConverter.cs
+++ b/NINA.Image/RawConverter/LibRawConverter.cs
@@ -12,6 +12,7 @@
 
 #endregion "copyright"
 
+using NINA.Core.Enum;
 using NINA.Core.Utility;
 using NINA.Image.ImageData;
 using NINA.Image.Interfaces;
@@ -26,10 +27,19 @@ namespace NINA.Image.RawConverter {
     internal class LibRawConverter : IRawConverter {
         private const string LibRawDllName = "libraw_0_22_1.dll";
 
-        // Offsets are from LibRaw 0.22.1's public libraw_types.h and must be updated with the versioned DLL.
+        // These offsets read LibRaw structs directly because not every needed field has a stable C getter.
+        // Keep them in sync with the bundled DLL and LibRaw 0.22.1's public libraw/libraw_types.h:
+        // https://github.com/LibRaw/LibRaw/blob/0.22.1/libraw/libraw_types.h
+        // LibRaw 0.22.1 source release: https://www.libraw.org/download
+        // LibRaw iparams field semantics: https://www.libraw.org/docs/API-datastruct.html
         private const int ImageSizesOffset = 8;
         private const int RawDataOffset = 193768;
         private const int RawImageOffset = 8;
+        private const int ImageParamsColorsOffset = 340;
+        private const int ImageParamsFiltersOffset = 344;
+        private const int ImageParamsColorDescriptionOffset = 420;
+        private const uint LeafCatchlightFilters = 1;
+        private const uint XTransFilters = 9;
 
         private static readonly object loadLock = new object();
         private static bool dllLoaded;
@@ -102,6 +112,7 @@ namespace NINA.Image.RawConverter {
             var rawImage = ReadRawDataPointer(processor, RawImageOffset);
             if (rawImage != IntPtr.Zero) {
                 var pixels = CopyUshortFrame(rawImage, frame);
+                ApplyBayerPatternMetadata(processor, metaData);
                 return CreateImageData(pixels, rawBytes, rawType, frame.Width, frame.Height, bitDepth, metaData);
             }
 
@@ -136,6 +147,73 @@ namespace NINA.Image.RawConverter {
             }
 
             return new ActiveFrame(left, top, width, height, rowStride);
+        }
+
+        private static void ApplyBayerPatternMetadata(IntPtr processor, ImageMetaData metaData) {
+            if (metaData.Camera.BayerPattern == BayerPatternEnum.None) {
+                return;
+            }
+
+            if (TryReadVisibleBayerPattern(processor, out var bayerPattern)) {
+                metaData.Camera.SensorType = bayerPattern;
+                metaData.Camera.BayerOffsetX = 0;
+                metaData.Camera.BayerOffsetY = 0;
+            }
+        }
+
+        private static bool TryReadVisibleBayerPattern(IntPtr processor, out SensorType bayerPattern) {
+            bayerPattern = SensorType.Monochrome;
+
+            var imageParams = LibRawNative.GetImageParams(processor);
+            if (imageParams == IntPtr.Zero) {
+                return false;
+            }
+
+            var colors = Marshal.ReadInt32(imageParams, ImageParamsColorsOffset);
+            var filters = (uint)Marshal.ReadInt32(imageParams, ImageParamsFiltersOffset);
+            // filters == 0 is full-color/monochrome data; 1 and 9 are special non-2x2 Bayer layouts.
+            if (colors < 3 || filters == 0 || filters == LeafCatchlightFilters || filters == XTransFilters) {
+                return false;
+            }
+
+            // cdesc maps COLOR's numeric index to a channel letter; it is not the Bayer pattern by itself.
+            var colorDescription = new byte[5];
+            Marshal.Copy(IntPtr.Add(imageParams, ImageParamsColorDescriptionOffset), colorDescription, 0, colorDescription.Length);
+
+            // LibRaw COLOR(row,col) is defined relative to the visible image area, not the full sensor.
+            // That matches the frame copied above after applying top/left margins and keeps odd-margin
+            // cameras from reporting the wrong Bayer phase at N.I.N.A.'s pixel (0,0).
+            // Source: https://www.libraw.org/node/2144
+            Span<char> pattern = stackalloc char[4];
+            var patternIndex = 0;
+            for (var row = 0; row < 2; row++) {
+                for (var column = 0; column < 2; column++) {
+                    var colorIndex = LibRawNative.Color(processor, row, column);
+                    if (colorIndex < 0 || colorIndex >= colorDescription.Length || colorDescription[colorIndex] == 0) {
+                        return false;
+                    }
+
+                    pattern[patternIndex++] = char.ToUpperInvariant((char)colorDescription[colorIndex]);
+                }
+            }
+
+            return TryGetBayerPattern(new string(pattern), out bayerPattern);
+        }
+
+        private static bool TryGetBayerPattern(string pattern, out SensorType bayerPattern) {
+            bayerPattern = pattern switch {
+                "RGGB" => SensorType.RGGB,
+                "BGGR" => SensorType.BGGR,
+                "GBRG" => SensorType.GBRG,
+                "GRBG" => SensorType.GRBG,
+                "GRGB" => SensorType.GRGB,
+                "GBGR" => SensorType.GBGR,
+                "RGBG" => SensorType.RGBG,
+                "BGRG" => SensorType.BGRG,
+                _ => SensorType.Monochrome
+            };
+
+            return bayerPattern != SensorType.Monochrome;
         }
 
         private static int FirstPositive(params ushort[] values) {
@@ -227,6 +305,9 @@ namespace NINA.Image.RawConverter {
 
         private static class LibRawNative {
 
+            // C API documentation for these helpers:
+            // https://www.libraw.org/docs/API-C.html
+
             [DllImport(LibRawDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "libraw_init")]
             public static extern IntPtr Init(uint flags);
 
@@ -235,6 +316,12 @@ namespace NINA.Image.RawConverter {
 
             [DllImport(LibRawDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "libraw_unpack")]
             public static extern int Unpack(IntPtr processor);
+
+            [DllImport(LibRawDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "libraw_get_iparams")]
+            public static extern IntPtr GetImageParams(IntPtr processor);
+
+            [DllImport(LibRawDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "libraw_COLOR")]
+            public static extern int Color(IntPtr processor, int row, int column);
 
             [DllImport(LibRawDllName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "libraw_close")]
             public static extern void Close(IntPtr processor);

--- a/NINA.Image/RawConverter/LibRawConverter.cs
+++ b/NINA.Image/RawConverter/LibRawConverter.cs
@@ -54,6 +54,7 @@ namespace NINA.Image.RawConverter {
         public Task<IImageData> Convert(
             MemoryStream s,
             int bitDepth,
+            bool bitScaling,
             string rawType,
             ImageMetaData metaData,
             CancellationToken token = default) {
@@ -80,7 +81,7 @@ namespace NINA.Image.RawConverter {
 
                         token.ThrowIfCancellationRequested();
 
-                        return CreateImageData(processor, rawBytes, rawType, bitDepth, metaData);
+                        return CreateImageData(processor, rawBytes, rawType, bitDepth, bitScaling, metaData);
                     } finally {
                         if (processor != IntPtr.Zero) {
                             LibRawNative.Close(processor);
@@ -105,15 +106,19 @@ namespace NINA.Image.RawConverter {
             }
         }
 
-        private IImageData CreateImageData(IntPtr processor, byte[] rawBytes, string rawType, int bitDepth, ImageMetaData metaData) {
+        private IImageData CreateImageData(IntPtr processor, byte[] rawBytes, string rawType, int bitDepth, bool bitScaling, ImageMetaData metaData) {
             var sizes = Marshal.PtrToStructure<LibRawImageSizes>(IntPtr.Add(processor, ImageSizesOffset));
             var frame = GetActiveFrame(sizes);
 
             var rawImage = ReadRawDataPointer(processor, RawImageOffset);
             if (rawImage != IntPtr.Zero) {
-                var pixels = CopyUshortFrame(rawImage, frame);
+                var copiedFrame = CopyUshortFrame(rawImage, frame, bitDepth, bitScaling);
+                if (copiedFrame.EffectiveBitDepth != bitDepth) {
+                    Logger.Warning($"LibRaw RAW bit depth setting {bitDepth} adjusted to {copiedFrame.EffectiveBitDepth}; maximum unpacked pixel value is {copiedFrame.MaxPixelValue}.");
+                }
+
                 ApplyBayerPatternMetadata(processor, metaData);
-                return CreateImageData(pixels, rawBytes, rawType, frame.Width, frame.Height, bitDepth, metaData);
+                return CreateImageData(copiedFrame.Pixels, rawBytes, rawType, frame.Width, frame.Height, copiedFrame.OutputBitDepth, metaData);
             }
 
             throw new NotSupportedException("LibRaw did not return an unpacked CFA RAW image buffer.");
@@ -216,6 +221,24 @@ namespace NINA.Image.RawConverter {
             return bayerPattern != SensorType.Monochrome;
         }
 
+        private static int NormalizeBitDepth(int configuredBitDepth) {
+            return configuredBitDepth is >= 1 and <= 16 ? configuredBitDepth : 16;
+        }
+
+        private static int GetRequiredBitDepth(ushort value) {
+            var bitDepth = 0;
+            do {
+                bitDepth++;
+                value >>= 1;
+            } while (value > 0);
+
+            return bitDepth;
+        }
+
+        private static ushort GetMaxValueForBitDepth(int bitDepth) {
+            return bitDepth >= 16 ? ushort.MaxValue : (ushort)((1 << bitDepth) - 1);
+        }
+
         private static int FirstPositive(params ushort[] values) {
             foreach (var value in values) {
                 if (value > 0) {
@@ -243,18 +266,51 @@ namespace NINA.Image.RawConverter {
             throw new InvalidOperationException($"{operation} failed: {message}");
         }
 
-        private static unsafe ushort[] CopyUshortFrame(IntPtr image, ActiveFrame frame) {
+        private static unsafe CopiedFrame CopyUshortFrame(IntPtr image, ActiveFrame frame, int bitDepth, bool bitScaling) {
             var pixels = new ushort[frame.Width * frame.Height];
             var source = (ushort*)image.ToPointer();
+            var effectiveBitDepth = NormalizeBitDepth(bitDepth);
+            var maxValueForEffectiveBitDepth = GetMaxValueForBitDepth(effectiveBitDepth);
+            var shift = bitScaling ? 16 - effectiveBitDepth : 0;
+            var writtenPixels = 0;
+            ushort maxPixelValue = 0;
+
             fixed (ushort* destination = pixels) {
                 for (var y = 0; y < frame.Height; y++) {
                     var sourceRow = source + ((frame.Top + y) * frame.RowStride) + frame.Left;
                     var destinationRow = destination + (y * frame.Width);
-                    Buffer.MemoryCopy(sourceRow, destinationRow, frame.Width * sizeof(ushort), frame.Width * sizeof(ushort));
+                    for (var x = 0; x < frame.Width; x++) {
+                        var value = sourceRow[x];
+                        if (value > maxPixelValue) {
+                            maxPixelValue = value;
+                        }
+
+                        // A too-low profile bit depth would shift real high-range RAW values too far left.
+                        // Use the unpacked data as a hard lower bound while copying into managed memory.
+                        if (value > maxValueForEffectiveBitDepth) {
+                            var previousShift = shift;
+                            effectiveBitDepth = GetRequiredBitDepth(value);
+                            maxValueForEffectiveBitDepth = GetMaxValueForBitDepth(effectiveBitDepth);
+                            shift = bitScaling ? 16 - effectiveBitDepth : 0;
+
+                            if (bitScaling && previousShift > shift) {
+                                ShiftCopiedPixelsRight(destination, writtenPixels, previousShift - shift);
+                            }
+                        }
+
+                        destinationRow[x] = bitScaling && shift > 0 ? (ushort)(value << shift) : value;
+                        writtenPixels++;
+                    }
                 }
             }
 
-            return pixels;
+            return new CopiedFrame(pixels, maxPixelValue, effectiveBitDepth, bitScaling ? 16 : effectiveBitDepth);
+        }
+
+        private static unsafe void ShiftCopiedPixelsRight(ushort* pixels, int length, int shift) {
+            for (var i = 0; i < length; i++) {
+                pixels[i] = (ushort)(pixels[i] >> shift);
+            }
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 184)]
@@ -301,6 +357,20 @@ namespace NINA.Image.RawConverter {
             public int Width { get; }
             public int Height { get; }
             public int RowStride { get; }
+        }
+
+        private readonly struct CopiedFrame {
+            public CopiedFrame(ushort[] pixels, ushort maxPixelValue, int effectiveBitDepth, int outputBitDepth) {
+                Pixels = pixels;
+                MaxPixelValue = maxPixelValue;
+                EffectiveBitDepth = effectiveBitDepth;
+                OutputBitDepth = outputBitDepth;
+            }
+
+            public ushort[] Pixels { get; }
+            public ushort MaxPixelValue { get; }
+            public int EffectiveBitDepth { get; }
+            public int OutputBitDepth { get; }
         }
 
         private static class LibRawNative {

--- a/NINA.Profile/CameraSettings.cs
+++ b/NINA.Profile/CameraSettings.cs
@@ -45,6 +45,7 @@ namespace NINA.Profile {
             fileCameraFolder = string.Empty;
             fileCameraAlwaysListen = false;
             bitScaling = true;
+            saveNativeCameraRaw = true;
             timeout = 60;
             dewHeaterOn = false;
 
@@ -345,6 +346,19 @@ namespace NINA.Profile {
             set {
                 if (bitScaling != value) {
                     bitScaling = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool saveNativeCameraRaw;
+
+        [DataMember]
+        public bool SaveNativeCameraRaw {
+            get => saveNativeCameraRaw;
+            set {
+                if (saveNativeCameraRaw != value) {
+                    saveNativeCameraRaw = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Profile/Interfaces/ICameraSettings.cs
+++ b/NINA.Profile/Interfaces/ICameraSettings.cs
@@ -44,6 +44,7 @@ namespace NINA.Profile.Interfaces {
         uint FLIFlushCount { get; set; }
         BinningMode FLIFloodBin { get; set; }
         bool BitScaling { get; set; }
+        bool SaveNativeCameraRaw { get; set; }
         double CoolingDuration { get; set; }
         double WarmingDuration { get; set; }
         double? Temperature { get; set; }

--- a/NINA.Test/Image/ImageData/BaseImageDataBehaviorTest.cs
+++ b/NINA.Test/Image/ImageData/BaseImageDataBehaviorTest.cs
@@ -47,6 +47,78 @@ namespace NINA.Test.Image.ImageData {
         }
 
         /// <summary>
+        /// Verifies raw file loading does not inherit the camera bit-scaling preference.
+        /// </summary>
+        [Test]
+        public async Task FromFile_RawFilePassesBitScalingFalseToRawConverter() {
+            string directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "BaseImageDataBehaviorTest", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try {
+                string rawPath = Path.Combine(directory, "raw.DNG");
+                File.WriteAllBytes(rawPath, new byte[] { 10, 20, 30 });
+
+                bool? capturedBitScaling = null;
+                var expectedImageData = Mock.Of<IImageData>();
+                var rawConverter = new Mock<IRawConverter>();
+                rawConverter
+                    .Setup(x => x.Convert(
+                        It.IsAny<MemoryStream>(),
+                        12,
+                        It.IsAny<bool>(),
+                        "dng",
+                        It.IsAny<ImageMetaData>(),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<MemoryStream, int, bool, string, ImageMetaData, CancellationToken>(
+                        (_, _, bitScaling, _, _, _) => capturedBitScaling = bitScaling)
+                    .ReturnsAsync(expectedImageData);
+
+                var loaded = await BaseImageData.FromFile(rawPath, 12, isBayered: true, rawConverter.Object, Mock.Of<IImageDataFactory>());
+
+                loaded.Should().BeSameAs(expectedImageData);
+                capturedBitScaling.Should().BeFalse();
+            } finally {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the legacy RAWExposureData constructor keeps old callers on unscaled RAW conversion.
+        /// </summary>
+        [Test]
+        public async Task RawExposureData_ObsoleteConstructorPassesBitScalingFalseToRawConverter() {
+            bool? capturedBitScaling = null;
+            var expectedImageData = Mock.Of<IImageData>();
+            var rawConverter = new Mock<IRawConverter>();
+            rawConverter
+                .Setup(x => x.Convert(
+                    It.IsAny<MemoryStream>(),
+                    12,
+                    It.IsAny<bool>(),
+                    "dng",
+                    It.IsAny<ImageMetaData>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<MemoryStream, int, bool, string, ImageMetaData, CancellationToken>(
+                    (_, _, bitScaling, _, _, _) => capturedBitScaling = bitScaling)
+                .ReturnsAsync(expectedImageData);
+
+#pragma warning disable CS0618
+            var exposureData = new RAWExposureData(
+                rawConverter.Object,
+                new byte[] { 10, 20, 30 },
+                "dng",
+                12,
+                new ImageMetaData(),
+                Mock.Of<IImageDataFactory>());
+#pragma warning restore CS0618
+
+            var imageData = await exposureData.ToImageData();
+
+            imageData.Should().BeSameAs(expectedImageData);
+            capturedBitScaling.Should().BeFalse();
+        }
+
+        /// <summary>
         /// Verifies image filename pattern data combines capture metadata and star analysis values without evaluating DateMinus12 near DateTime.MinValue.
         /// </summary>
         [Test]

--- a/NINA.Test/Image/ImageData/BaseImageDataBehaviorTest.cs
+++ b/NINA.Test/Image/ImageData/BaseImageDataBehaviorTest.cs
@@ -63,10 +63,10 @@ namespace NINA.Test.Image.ImageData {
         }
 
         /// <summary>
-        /// Verifies raw saves prefer original RAW bytes unless the caller explicitly forces the requested file type.
+        /// Verifies raw saves prefer original RAW bytes while the native camera RAW option is enabled.
         /// </summary>
         [Test]
-        public async Task SaveToDisk_RawDataUsesOriginalBytesUnlessFileTypeIsForced() {
+        public async Task SaveToDisk_RawDataUsesOriginalBytesWhenNativeRawSaveIsEnabled() {
             string directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "BaseImageDataSaveTest", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(directory);
 
@@ -76,7 +76,8 @@ namespace NINA.Test.Image.ImageData {
                 var saveInfo = new FileSaveInfo {
                     FilePath = directory,
                     FilePattern = "raw-frame",
-                    FileType = NINA.Core.Enum.FileTypeEnum.TIFF
+                    FileType = FileTypeEnum.XISF,
+                    SaveNativeCameraRaw = true
                 };
 
                 string savedPath = await imageData.SaveToDisk(saveInfo, CancellationToken.None, forceFileType: false);
@@ -86,6 +87,50 @@ namespace NINA.Test.Image.ImageData {
             } finally {
                 Directory.Delete(directory, recursive: true);
             }
+        }
+
+        /// <summary>
+        /// Verifies raw-capable camera data is saved in the selected file format when native RAW saving is disabled.
+        /// </summary>
+        [Test]
+        public async Task SaveToDisk_RawDataUsesRequestedFileTypeWhenNativeRawSaveIsDisabled() {
+            string directory = Path.Combine(TestContext.CurrentContext.WorkDirectory, "BaseImageDataSaveTest", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            try {
+                var imageArray = new ImageArray(new ushort[] { 1, 2, 3, 4 }, rawData: new byte[] { 10, 20, 30 }, rawType: "cr2");
+                BaseImageData imageData = CreateImageData(CreateMetadata(), hfr: double.NaN, detectedStars: -1, imageArray);
+                var saveInfo = new FileSaveInfo {
+                    FilePath = directory,
+                    FilePattern = "converted-frame",
+                    FileType = FileTypeEnum.XISF,
+                    SaveNativeCameraRaw = false
+                };
+
+                string savedPath = await imageData.SaveToDisk(saveInfo, CancellationToken.None, forceFileType: false);
+
+                Path.GetExtension(savedPath).Should().Be(".xisf");
+                File.Exists(savedPath).Should().BeTrue();
+                File.ReadAllBytes(savedPath).Should().NotEqual(new byte[] { 10, 20, 30 });
+            } finally {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies FileSaveInfo carries the camera-scoped native RAW save preference into the image save layer.
+        /// </summary>
+        [Test]
+        public void FileSaveInfo_CopiesNativeRawSaveSettingFromActiveProfile() {
+            var profile = new NINA.Profile.Profile();
+            profile.CameraSettings.SaveNativeCameraRaw = false;
+
+            var profileService = new Mock<IProfileService>();
+            profileService.SetupGet(x => x.ActiveProfile).Returns(profile);
+
+            var saveInfo = new FileSaveInfo(profileService.Object);
+
+            saveInfo.SaveNativeCameraRaw.Should().BeFalse();
         }
 
         /// <summary>

--- a/NINA.Test/Image/ImageData/DebayeredImageBehaviorTest.cs
+++ b/NINA.Test/Image/ImageData/DebayeredImageBehaviorTest.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using NINA.Core.Enum;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NUnit.Framework;
+
+namespace NINA.Test.Image.ImageData {
+
+    [TestFixture]
+    public class DebayeredImageBehaviorTest {
+
+        [Test]
+        public void ReRender_PreservesBayerPatternAndChannelData() {
+            var utility = new global::NINA.Test.ImageDataFactoryTestUtility();
+            ushort[] pixels = {
+                100, 2000, 300, 4000,
+                5000, 600, 7000, 800,
+                900, 10000, 1100, 12000,
+                13000, 1400, 15000, 1600
+            };
+            var imageData = utility.ImageDataFactory.CreateBaseImageData(
+                input: pixels,
+                width: 4,
+                height: 4,
+                bitDepth: 16,
+                isBayered: true,
+                metaData: new ImageMetaData());
+
+            var original = imageData.RenderImage().Debayer(
+                saveColorChannels: true,
+                saveLumChannel: true,
+                bayerPattern: SensorType.GBRG);
+
+            var reRendered = original.ReRender();
+
+            reRendered.Should().BeAssignableTo<IDebayeredImage>();
+            var reRenderedDebayered = (IDebayeredImage)reRendered;
+            reRenderedDebayered.BayerPattern.Should().Be(SensorType.GBRG);
+            reRenderedDebayered.SaveColorChannels.Should().BeTrue();
+            reRenderedDebayered.SaveLumChannel.Should().BeTrue();
+            reRenderedDebayered.DebayeredData.Red.Should().Equal(original.DebayeredData.Red);
+            reRenderedDebayered.DebayeredData.Green.Should().Equal(original.DebayeredData.Green);
+            reRenderedDebayered.DebayeredData.Blue.Should().Equal(original.DebayeredData.Blue);
+            reRenderedDebayered.DebayeredData.Lum.Should().Equal(original.DebayeredData.Lum);
+        }
+    }
+}

--- a/NINA.Test/Image/RawConverter/LibRawConverterBehaviorTest.cs
+++ b/NINA.Test/Image/RawConverter/LibRawConverterBehaviorTest.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NINA.Core.Enum;
+using NINA.Image.ImageData;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+
+namespace NINA.Test.Image.RawConverter {
+
+    [TestFixture]
+    public class LibRawConverterBehaviorTest {
+
+        /// <summary>
+        /// Verifies LibRaw visible-area color codes are translated into the Bayer pattern used by N.I.N.A.'s debayer pipeline.
+        /// </summary>
+        [TestCase("RGGB", SensorType.RGGB)]
+        [TestCase("GBRG", SensorType.GBRG)]
+        [TestCase("GRBG", SensorType.GRBG)]
+        [TestCase("BGGR", SensorType.BGGR)]
+        [TestCase("RGBG", SensorType.RGBG)]
+        [TestCase("GRGB", SensorType.GRGB)]
+        [TestCase("GBGR", SensorType.GBGR)]
+        [TestCase("BGRG", SensorType.BGRG)]
+        public void TryGetBayerPattern_MapsVisibleLibRawPatternToSensorType(string visiblePattern, SensorType expectedSensorType) {
+            (bool mapped, SensorType sensorType) = TryGetBayerPattern(visiblePattern);
+
+            mapped.Should().BeTrue();
+            sensorType.Should().Be(expectedSensorType);
+        }
+
+        /// <summary>
+        /// Verifies unsupported CFA color descriptions are not misreported as Bayer patterns.
+        /// </summary>
+        [Test]
+        public void TryGetBayerPattern_RejectsUnsupportedPattern() {
+            (bool mapped, SensorType sensorType) = TryGetBayerPattern("GCMY");
+
+            mapped.Should().BeFalse();
+            sensorType.Should().Be(SensorType.Monochrome);
+        }
+
+        private static (bool Mapped, SensorType SensorType) TryGetBayerPattern(string visiblePattern) {
+            Type converterType = typeof(ImageDataFactory).Assembly.GetType(
+                "NINA.Image.RawConverter.LibRawConverter",
+                throwOnError: true)!;
+            MethodInfo method = converterType.GetMethod(
+                "TryGetBayerPattern",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            object[] parameters = { visiblePattern, SensorType.Monochrome };
+            var mapped = (bool)method.Invoke(null, parameters)!;
+            return (mapped, (SensorType)parameters[1]);
+        }
+    }
+}

--- a/NINA.Test/Image/RawConverter/LibRawConverterBehaviorTest.cs
+++ b/NINA.Test/Image/RawConverter/LibRawConverterBehaviorTest.cs
@@ -1,9 +1,14 @@
 using FluentAssertions;
 using NINA.Core.Enum;
 using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
 using NUnit.Framework;
 using System;
+using System.Runtime.InteropServices;
+using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NINA.Test.Image.RawConverter {
 
@@ -39,6 +44,65 @@ namespace NINA.Test.Image.RawConverter {
             sensorType.Should().Be(SensorType.Monochrome);
         }
 
+        [Test]
+        public void CopyUshortFrame_ScalesConfiguredBitDepthTo16BitWhenEnabled() {
+            var source = new ushort[] { 1, 128, 4095 };
+
+            var copiedFrame = CopyUshortFrame(source, width: 3, height: 1, bitDepth: 12, bitScaling: true);
+
+            copiedFrame.OutputBitDepth.Should().Be(16);
+            copiedFrame.EffectiveBitDepth.Should().Be(12);
+            copiedFrame.MaxPixelValue.Should().Be(4095);
+            copiedFrame.Pixels.Should().Equal(16, 2048, 65520);
+        }
+
+        [Test]
+        public void CopyUshortFrame_LeavesPixelsAndBitDepthUnchangedWhenScalingIsDisabled() {
+            var source = new ushort[] { 1, 128, 4095 };
+
+            var copiedFrame = CopyUshortFrame(source, width: 3, height: 1, bitDepth: 12, bitScaling: false);
+
+            copiedFrame.OutputBitDepth.Should().Be(12);
+            copiedFrame.EffectiveBitDepth.Should().Be(12);
+            copiedFrame.MaxPixelValue.Should().Be(4095);
+            copiedFrame.Pixels.Should().Equal(1, 128, 4095);
+        }
+
+        [Test]
+        public void CopyUshortFrame_UsesObservedBitDepthWhenConfiguredBitDepthIsTooLow() {
+            var source = new ushort[] { 1, 12000 };
+
+            var copiedFrame = CopyUshortFrame(source, width: 2, height: 1, bitDepth: 12, bitScaling: true);
+
+            copiedFrame.OutputBitDepth.Should().Be(16);
+            copiedFrame.EffectiveBitDepth.Should().Be(14);
+            copiedFrame.MaxPixelValue.Should().Be(12000);
+            copiedFrame.Pixels.Should().Equal(4, 48000);
+        }
+
+        [Test]
+        public void CopyUshortFrame_RaisesUnscaledOutputBitDepthWhenConfiguredBitDepthIsTooLow() {
+            var source = new ushort[] { 1, 12000 };
+
+            var copiedFrame = CopyUshortFrame(source, width: 2, height: 1, bitDepth: 12, bitScaling: false);
+
+            copiedFrame.OutputBitDepth.Should().Be(14);
+            copiedFrame.EffectiveBitDepth.Should().Be(14);
+            copiedFrame.MaxPixelValue.Should().Be(12000);
+            copiedFrame.Pixels.Should().Equal(1, 12000);
+        }
+
+        [Test]
+        public async Task ObsoleteConvertOverload_DisablesBitScalingForCompatibility() {
+            IRawConverter converter = new RawConverterStub();
+
+#pragma warning disable CS0618
+            await converter.Convert(new MemoryStream(new byte[] { 1 }), 12, "dng", new ImageMetaData(), CancellationToken.None);
+#pragma warning restore CS0618
+
+            ((RawConverterStub)converter).BitScaling.Should().BeFalse();
+        }
+
         private static (bool Mapped, SensorType SensorType) TryGetBayerPattern(string visiblePattern) {
             Type converterType = typeof(ImageDataFactory).Assembly.GetType(
                 "NINA.Image.RawConverter.LibRawConverter",
@@ -50,6 +114,56 @@ namespace NINA.Test.Image.RawConverter {
             object[] parameters = { visiblePattern, SensorType.Monochrome };
             var mapped = (bool)method.Invoke(null, parameters)!;
             return (mapped, (SensorType)parameters[1]);
+        }
+
+        private static (ushort[] Pixels, ushort MaxPixelValue, int EffectiveBitDepth, int OutputBitDepth) CopyUshortFrame(
+            ushort[] source,
+            int width,
+            int height,
+            int bitDepth,
+            bool bitScaling) {
+            Type converterType = typeof(ImageDataFactory).Assembly.GetType(
+                "NINA.Image.RawConverter.LibRawConverter",
+                throwOnError: true)!;
+            Type activeFrameType = converterType.GetNestedType("ActiveFrame", BindingFlags.NonPublic)!;
+            object activeFrame = Activator.CreateInstance(
+                activeFrameType,
+                0,
+                0,
+                width,
+                height,
+                width)!;
+            MethodInfo method = converterType.GetMethod(
+                "CopyUshortFrame",
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+            var handle = GCHandle.Alloc(source, GCHandleType.Pinned);
+            try {
+                object result = method.Invoke(null, new object[] { handle.AddrOfPinnedObject(), activeFrame, bitDepth, bitScaling })!;
+                Type resultType = result.GetType();
+                return (
+                    (ushort[])resultType.GetProperty("Pixels")!.GetValue(result)!,
+                    (ushort)resultType.GetProperty("MaxPixelValue")!.GetValue(result)!,
+                    (int)resultType.GetProperty("EffectiveBitDepth")!.GetValue(result)!,
+                    (int)resultType.GetProperty("OutputBitDepth")!.GetValue(result)!);
+            } finally {
+                handle.Free();
+            }
+        }
+
+        private sealed class RawConverterStub : IRawConverter {
+            public bool? BitScaling { get; private set; }
+
+            public Task<IImageData> Convert(
+                MemoryStream s,
+                int bitDepth,
+                bool bitScaling,
+                string rawType,
+                ImageMetaData metaData,
+                CancellationToken token = default) {
+                BitScaling = bitScaling;
+                return Task.FromResult<IImageData>(default!);
+            }
         }
     }
 }

--- a/NINA/View/Equipment/Camera/CameraTemplateSelector.cs
+++ b/NINA/View/Equipment/Camera/CameraTemplateSelector.cs
@@ -27,6 +27,7 @@ namespace NINA.View.Equipment {
         public DataTemplate LegacySbig { get; set; }
         public DataTemplate Moravian { get; set; }
         public DataTemplate Canon { get; set; }
+        public DataTemplate Nikon { get; set; }
         public DataTemplate Atik { get; set; }
         public DataTemplate Zwo { get; set; }
         public DataTemplate Generic { get; set; }
@@ -47,6 +48,8 @@ namespace NINA.View.Equipment {
                 return Moravian;
             } else if (item is EDCamera) {
                 return Canon;
+            } else if (item is NikonCamera) {
+                return Nikon ?? Default;
             } else if (item is AtikCamera) {
                 return Atik;
             } else if (item is ASICamera) {

--- a/NINA/View/Equipment/Camera/CameraView.xaml
+++ b/NINA/View/Equipment/Camera/CameraView.xaml
@@ -361,6 +361,7 @@
                                     Generic="{StaticResource Default}"
                                     LegacySbig="{StaticResource Default}"
                                     Moravian="{StaticResource Moravian}"
+                                    Nikon="{StaticResource Default}"
                                     Postfix="{x:Static wpfutil:DataTemplatePostfix.CameraDetails}"
                                     QhyCcd="{StaticResource QhyCcd}"
                                     SVBony="{StaticResource Default}"
@@ -690,6 +691,49 @@
                                             FontStyle="Italic"
                                             Text="{ns:Loc LblMirrorLockupDelayTooltip}"
                                             TextAlignment="Right" />
+                                        <DockPanel Margin="0,6,0,0">
+                                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblSaveNativeCameraRaw}">
+                                                <TextBlock.ToolTip>
+                                                    <ToolTip ToolTipService.ShowOnDisabled="False">
+                                                        <TextBlock Text="{ns:Loc LblSaveNativeCameraRawTooltip}" />
+                                                    </ToolTip>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                            <CheckBox
+                                                Width="200"
+                                                HorizontalAlignment="Right"
+                                                IsChecked="{Binding DataContext.ActiveProfile.CameraSettings.SaveNativeCameraRaw, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=TwoWay}">
+                                                <CheckBox.ToolTip>
+                                                    <ToolTip ToolTipService.ShowOnDisabled="False">
+                                                        <TextBlock Text="{ns:Loc LblSaveNativeCameraRawTooltip}" />
+                                                    </ToolTip>
+                                                </CheckBox.ToolTip>
+                                            </CheckBox>
+                                        </DockPanel>
+                                    </StackPanel>
+                                </DataTemplate>
+
+                                <DataTemplate x:Key="Nikon">
+                                    <StackPanel Orientation="Vertical">
+                                        <DockPanel Margin="0,0,0,6">
+                                            <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblSaveNativeCameraRaw}">
+                                                <TextBlock.ToolTip>
+                                                    <ToolTip ToolTipService.ShowOnDisabled="False">
+                                                        <TextBlock Text="{ns:Loc LblSaveNativeCameraRawTooltip}" />
+                                                    </ToolTip>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                            <CheckBox
+                                                Width="200"
+                                                HorizontalAlignment="Right"
+                                                IsChecked="{Binding DataContext.ActiveProfile.CameraSettings.SaveNativeCameraRaw, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=TwoWay}">
+                                                <CheckBox.ToolTip>
+                                                    <ToolTip ToolTipService.ShowOnDisabled="False">
+                                                        <TextBlock Text="{ns:Loc LblSaveNativeCameraRawTooltip}" />
+                                                    </ToolTip>
+                                                </CheckBox.ToolTip>
+                                            </CheckBox>
+                                        </DockPanel>
                                     </StackPanel>
                                 </DataTemplate>
 
@@ -1003,6 +1047,7 @@
                                     Generic="{StaticResource Generic}"
                                     LegacySbig="{StaticResource LegacySbig}"
                                     Moravian="{StaticResource Moravian2}"
+                                    Nikon="{StaticResource Nikon}"
                                     Postfix="{x:Static wpfutil:DataTemplatePostfix.CameraSettings}"
                                     QhyCcd="{StaticResource QhyCcd}"
                                     SVBony="{StaticResource SVBony}"

--- a/NINA/View/Options/ImagingView.xaml
+++ b/NINA/View/Options/ImagingView.xaml
@@ -47,7 +47,6 @@
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="30" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="40" />
                     <RowDefinition Height="Auto" />
@@ -64,209 +63,188 @@
                     Grid.ColumnSpan="2"
                     ItemsSource="{Binding DataContext.FileTypes, ElementName=UC}"
                     SelectedItem="{Binding FileType}" />
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.ColumnSpan="3"
-                    Orientation="Horizontal">
-                    <Path
-                        Width="25"
-                        Margin="5"
-                        Data="{StaticResource ExclamationCircledSVG}"
-                        Fill="{StaticResource ButtonForegroundBrush}"
-                        Stretch="Uniform"
-                        UseLayoutRounding="True" />
-                    <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblSaveImageAsDSLRNote}" />
-                </StackPanel>
 
-                <GroupBox
-                    Grid.Row="2"
+                <Grid
+                    Grid.Row="1"
                     Grid.Column="0"
-                    Grid.ColumnSpan="3">
-                    <GroupBox.Header>
-                        <TextBlock FontSize="12" Text="{ns:Loc LblFileFormatOptions}" />
-                    </GroupBox.Header>
+                    Grid.ColumnSpan="3"
+                    Margin="0,5,0,0">
 
                     <!--  TIFF  -->
                     <Grid>
-                        <StackPanel>
-                            <StackPanel.Style>
-                                <Style TargetType="StackPanel">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="TIFF">
-                                            <Setter Property="Visibility" Value="Visible" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </StackPanel.Style>
-                            <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
-                                <TextBlock
-                                    MinWidth="200"
-                                    VerticalAlignment="Center"
-                                    Text="{ns:Loc LblCompression}" />
-                                <ComboBox
-                                    MinWidth="150"
-                                    Margin="0,0,0,0"
-                                    ItemsSource="{Binding DataContext.TIFFCompressionTypes, ElementName=UC}"
-                                    SelectedItem="{Binding TIFFCompressionType}" />
-                            </StackPanel>
-                        </StackPanel>
-                        <StackPanel>
-                            <StackPanel.Style>
-                                <Style TargetType="StackPanel">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="FITS">
-                                            <Setter Property="Visibility" Value="Visible" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </StackPanel.Style>
-
-                            <!--  FITS  -->
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition />
-                                </Grid.RowDefinitions>
-
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock
-                                        MinWidth="100"
-                                        VerticalAlignment="Center"
-                                        Text="{ns:Loc LblUseCfitsio}">
-                                        <TextBlock.ToolTip>
-                                            <TextBlock Text="{ns:Loc LblUseCfitsioTooltip}" />
-                                        </TextBlock.ToolTip>
-                                    </TextBlock>
-                                    <CheckBox
-                                        Margin="5,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        IsChecked="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanConverter}}">
-                                        <CheckBox.ToolTip>
-                                            <TextBlock Text="{ns:Loc LblUseCfitsioTooltip}" />
-                                        </CheckBox.ToolTip>
-                                    </CheckBox>
-                                </StackPanel>
-
-                                <StackPanel
-                                    Grid.Row="1"
-                                    Margin="0,5,0,0"
-                                    Orientation="Horizontal"
-                                    Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
-                                    <TextBlock
-                                        MinWidth="100"
-                                        VerticalAlignment="Center"
-                                        Text="{ns:Loc LblCompression}" />
-                                    <ComboBox
-                                        MinWidth="100"
-                                        Margin="5,0,0,0"
-                                        ItemsSource="{Binding DataContext.FITSCompressionTypes, ElementName=UC}"
-                                        SelectedItem="{Binding FITSCompressionType}" />
-                                </StackPanel>
-
-                                <StackPanel
-                                    Grid.Row="1"
-                                    Grid.Column="1"
-                                    Margin="5,5,0,0"
-                                    Orientation="Horizontal"
-                                    Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
-                                    <TextBlock
-                                        MinWidth="100"
-                                        VerticalAlignment="Center"
-                                        Text="{ns:Loc LblAddFzExtension}" />
-                                    <CheckBox
-                                        Margin="5,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        IsChecked="{Binding FITSAddFzExtension}">
-                                        <CheckBox.ToolTip>
-                                            <TextBlock Text="{ns:Loc LblAddFzExtensionTooltip}" />
-                                        </CheckBox.ToolTip>
-                                    </CheckBox>
-                                </StackPanel>
-                            </Grid>
-                        </StackPanel>
-
-                        <!--  XISF  -->
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition />
-                                <ColumnDefinition />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition />
-                                <RowDefinition />
-                            </Grid.RowDefinitions>
-                            <Grid.Style>
-                                <Style TargetType="Grid">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="XISF">
-                                            <Setter Property="Visibility" Value="Visible" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </Grid.Style>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock
-                                    MinWidth="100"
-                                    VerticalAlignment="Center"
-                                    Text="{ns:Loc LblCompression}" />
-                                <ComboBox
-                                    MinWidth="150"
-                                    Margin="5,0,0,0"
-                                    ItemsSource="{Binding DataContext.XISFCompressionTypes, ElementName=UC}"
-                                    SelectedItem="{Binding XISFCompressionType}" />
-                            </StackPanel>
-
-                            <StackPanel
-                                Grid.Column="1"
-                                Margin="20,0,0,0"
-                                Orientation="Horizontal">
-                                <TextBlock
-                                    MinWidth="100"
-                                    VerticalAlignment="Center"
-                                    Text="{ns:Loc LblByteShuffling}" />
-                                <CheckBox
-                                    Margin="5,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    IsChecked="{Binding XISFByteShuffling}" />
-                            </StackPanel>
-
-                            <StackPanel
-                                Grid.Row="1"
-                                Margin="0,5,0,0"
-                                Orientation="Horizontal">
-                                <TextBlock
-                                    MinWidth="100"
-                                    VerticalAlignment="Center"
-                                    Text="{ns:Loc LblChecksum}" />
-                                <ComboBox
-                                    MinWidth="150"
-                                    Margin="5,0,0,0"
-                                    ItemsSource="{Binding DataContext.XISFChecksumTypes, ElementName=UC}"
-                                    SelectedItem="{Binding XISFChecksumType}" />
-                            </StackPanel>
-                        </Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="TIFF">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblCompression}" />
+                        <ComboBox
+                            Grid.Column="1"
+                            MinWidth="150"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding DataContext.TIFFCompressionTypes, ElementName=UC}"
+                            SelectedItem="{Binding TIFFCompressionType}" />
                     </Grid>
-                </GroupBox>
+
+                    <!--  FITS  -->
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="FITS">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblUseCfitsio}">
+                            <TextBlock.ToolTip>
+                                <TextBlock Text="{ns:Loc LblUseCfitsioTooltip}" />
+                            </TextBlock.ToolTip>
+                        </TextBlock>
+                        <CheckBox
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            IsChecked="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanConverter}}">
+                            <CheckBox.ToolTip>
+                                <TextBlock Text="{ns:Loc LblUseCfitsioTooltip}" />
+                            </CheckBox.ToolTip>
+                        </CheckBox>
+
+                        <TextBlock
+                            Grid.Row="1"
+                            Margin="0,5,0,0"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblCompression}"
+                            Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
+                        <ComboBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            MinWidth="100"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding DataContext.FITSCompressionTypes, ElementName=UC}"
+                            SelectedItem="{Binding FITSCompressionType}"
+                            Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
+
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="3"
+                            Margin="0,5,0,0"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblAddFzExtension}"
+                            Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
+                        <CheckBox
+                            Grid.Row="1"
+                            Grid.Column="4"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Left"
+                            IsChecked="{Binding FITSAddFzExtension}"
+                            Visibility="{Binding FITSUseLegacyWriter, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                            <CheckBox.ToolTip>
+                                <TextBlock Text="{ns:Loc LblAddFzExtensionTooltip}" />
+                            </CheckBox.ToolTip>
+                        </CheckBox>
+                    </Grid>
+
+                    <!--  XISF  -->
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=SelectedValue, ElementName=cbFileTypes}" Value="XISF">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblCompression}" />
+                        <ComboBox
+                            Grid.Column="1"
+                            MinWidth="150"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding DataContext.XISFCompressionTypes, ElementName=UC}"
+                            SelectedItem="{Binding XISFCompressionType}" />
+
+                        <TextBlock
+                            Grid.Column="3"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblByteShuffling}" />
+                        <CheckBox
+                            Grid.Column="4"
+                            HorizontalAlignment="Left"
+                            IsChecked="{Binding XISFByteShuffling}" />
+
+                        <TextBlock
+                            Grid.Row="1"
+                            Margin="0,5,0,0"
+                            VerticalAlignment="Center"
+                            Text="{ns:Loc LblChecksum}" />
+                        <ComboBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            MinWidth="150"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Left"
+                            ItemsSource="{Binding DataContext.XISFChecksumTypes, ElementName=UC}"
+                            SelectedItem="{Binding XISFChecksumType}" />
+                    </Grid>
+                </Grid>
 
                 <TextBlock
-                    Grid.Row="3"
+                    Grid.Row="2"
                     Grid.Column="0"
                     VerticalAlignment="Center"
                     Text="{ns:Loc LblImageFilePath}" />
                 <TextBox
-                    Grid.Row="3"
+                    Grid.Row="2"
                     Grid.Column="1"
                     VerticalAlignment="Center"
                     Text="{Binding FilePath}" />
                 <Button
-                    Grid.Row="3"
+                    Grid.Row="2"
                     Grid.Column="2"
                     Width="40"
                     Height="20"
@@ -285,7 +263,7 @@
 
 
                 <Expander
-                    Grid.Row="4"
+                    Grid.Row="3"
                     Grid.ColumnSpan="3"
                     IsExpanded="{Binding Source={StaticResource OptionsProxy}, Path=Data.FilePatternsExpanded, UpdateSourceTrigger=PropertyChanged}">
                     <Expander.Header>
@@ -388,7 +366,7 @@
 
 
 
-                <Grid Grid.Row="5" Grid.ColumnSpan="4">
+                <Grid Grid.Row="4" Grid.ColumnSpan="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
@@ -469,7 +447,7 @@
                 </Grid>
 
                 <Grid
-                    Grid.Row="6"
+                    Grid.Row="5"
                     Grid.ColumnSpan="3"
                     Margin="0,5,0,0">
                     <Grid.Resources>

--- a/NINA/ViewModel/ImageControlVM.cs
+++ b/NINA/ViewModel/ImageControlVM.cs
@@ -611,9 +611,11 @@ namespace NINA.ViewModel {
                     var bayerPattern = cameraInfo.SensorType;
                     if (profileService.ActiveProfile.CameraSettings.BayerPattern != BayerPatternEnum.Auto) {
                         bayerPattern = (SensorType)profileService.ActiveProfile.CameraSettings.BayerPattern;
-                    } else if (!cameraInfo.Connected) {
+                    } else {
+                        // Raw decoders can report the Bayer phase at the visible image origin.
+                        // Prefer that concrete pattern over Auto defaults, but ignore placeholder sensor categories.
                         var imageSensorType = data.MetaData?.Camera?.SensorType;
-                        if (imageSensorType.HasValue) {
+                        if (imageSensorType.HasValue && imageSensorType.Value != SensorType.Monochrome && imageSensorType.Value != SensorType.Color) {
                             bayerPattern = imageSensorType.Value;
                         }
                     }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,7 +50,7 @@ This allows you to safely return to a stable release if needed.
 - The manual focuser step buttons now use configurable multipliers. Users can adjust the small step (default 0.5x) and large step (default 5.0x) multipliers in Options > Imaging > Autofocus.
 - Debayer algorithm has been optimized to work fast even on older CPUs
 - DSLR RAW conversion now uses LibRaw instead of the legacy DCRaw and FreeImage converters.
-- Native Nikon and Canon camera drivers can now be configured to save images using the selected file format instead of always saving native camera RAW files.
+- Native Nikon and Canon camera drivers can now be configured to use the file format selection, such as FITS or XISF, instead of always saving native camera RAW files.
 - Sky brightness readings in the Weather device windows have been increased from 2 decimal places to 5 so that measurements obtained in low light conditions are adequately displayed.
 - Improved Sky Atlas search performance.
 - **Autofocus & Star Measurements**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,7 @@ This allows you to safely return to a stable release if needed.
 - The manual focuser step buttons now use configurable multipliers. Users can adjust the small step (default 0.5x) and large step (default 5.0x) multipliers in Options > Imaging > Autofocus.
 - Debayer algorithm has been optimized to work fast even on older CPUs
 - DSLR RAW conversion now uses LibRaw instead of the legacy DCRaw and FreeImage converters.
+- Native Nikon and Canon camera drivers can now be configured to save images using the selected file format instead of always saving native camera RAW files.
 - Sky brightness readings in the Weather device windows have been increased from 2 decimal places to 5 so that measurements obtained in low light conditions are adequately displayed.
 - Improved Sky Atlas search performance.
 - **Autofocus & Star Measurements**


### PR DESCRIPTION
## Purpose

Adds a camera-specific option for Nikon and Canon native drivers to control whether images are saved as native camera RAW files or using the selected file format from Options > Imaging > File Settings.

This preserves the existing default behavior while allowing users to opt into the same file-format flow used by other camera drivers.

Additional Libraw related improvements:
- Read the bayer pattern information and map it to our meta data
- Bit scale the data if the option is enabled

## How Was It Tested?

Tests Pending

## AI / Tooling Disclosure

OpenAI Codex was used to assist with implementation.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to plugin interfaces
  - [x] No changes to plugin method/class signatures
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## Related Issues

None.

## Screenshots

Not included.

## Additional Notes

The new setting defaults to enabled to preserve existing Nikon/Canon behavior. When disabled, native RAW data is no longer forced and the selected file format is used instead.