### PR TITLE
If implemented, use ASCOM driver's LastExpsoure properties for image time and duration metadata

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
@@ -13,30 +13,25 @@
 #endregion "copyright"
 
 using ASCOM;
-using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Com.DriverAccess;
-using NINA.Profile.Interfaces;
+using ASCOM.Common.DeviceInterfaces;
+using NINA.Core.Locale;
+using NINA.Core.Model.Equipment;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Model;
+using NINA.Equipment.Utility;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Profile.Interfaces;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using SensorType = NINA.Core.Enum.SensorType;
-using NINA.Core.Model.Equipment;
-using NINA.Equipment.Utility;
-using NINA.Core.Locale;
-using NINA.Equipment.Model;
-using NINA.Image.Interfaces;
-using NINA.Image.ImageData;
-using NINA.Equipment.Interfaces;
-using NINA.Core.Enum;
-using ASCOM.Common.Alpaca;
-using ASCOM.Alpaca.Discovery;
 
 namespace NINA.Equipment.Equipment.MyCamera {
 
@@ -408,7 +403,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                         try {
                             val = device.GainMin;
                         } catch (ASCOM.NotImplementedException) {
-                            _canGetGainMinMax = false;                        
+                            _canGetGainMinMax = false;
                         } catch (ASCOM.InvalidOperationException) {
                             _canGetGainMinMax = false;
                         }
@@ -709,7 +704,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             NumY = newY;
         }
 
-        private IList<int> offsets = new List<int>();
+        private readonly IList<int> offsets = new List<int>();
         private bool offsetValueMode = true;
         private bool canSetOffset = false;
         private DateTime lastExposureEndTime;
@@ -827,7 +822,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         protected override async Task PostConnect() {
             try {
-                if(device.SensorType == ASCOM.Common.DeviceInterfaces.SensorType.Color) {
+                if (device.SensorType == ASCOM.Common.DeviceInterfaces.SensorType.Color) {
                     Disconnect();
                     throw new Exception(Loc.Instance["LblASCOMColorSensorTypeNotSupported"]);
                 }
@@ -840,12 +835,12 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
         protected override ICameraV4 GetInstance() {
-            if(!IsAlpacaDevice()) {
+            if (!IsAlpacaDevice()) {
                 return new Camera(this.Id);
             } else {
                 return new ASCOM.Alpaca.Clients.AlpacaCamera(deviceMeta.ServiceType, deviceMeta.IpAddress, deviceMeta.IpPort, deviceMeta.AlpacaDeviceNumber, false, null);
             }
-            
+
         }
 
         public bool LiveViewEnabled { get => false; set => throw new System.NotImplementedException(); }

--- a/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
@@ -54,7 +54,6 @@ namespace NINA.Equipment.Equipment.MyCamera {
             CanSetGain = true;
             CanGetGain = true;
             _canGetGainMinMax = true;
-            _hasLastExposureInfo = true;
             BinningModes = new AsyncObservableCollection<BinningMode>();
             for (short i = 1; i <= MaxBinX; i++) {
                 if (CanAsymmetricBin) {
@@ -85,7 +84,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             } catch (Exception) {
             }
 
-            //Determine Offset Capabilities
+            // Determine Offset Capabilities
             try {
                 //Check if Offset is implemented at all in ICameraV3 Driver
                 _ = device.Offset;
@@ -100,6 +99,32 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 Logger.Trace("Offset is not implemented in this driver");
                 CanSetOffset = false;
             }
+
+            // Determine LastExposure* Capabilities
+            // It seems that most drivers that do not implement these will throw NotImplementedException even when there is not yet an exposure.
+            // This is good, because it lets us know early if the properties are not available for use following an actual exposure being made.
+            // For drivers that do implement these properties but do not yet have an exposure to describe, they *should* throw InvalidOperationException
+            // but some don't and instead return bogus values such as an empty date string. We consider these to be available but they are obviously
+            // non-conformant with the ASCOM spec.
+            try {
+                _ = device.LastExposureDuration;
+                HasLastExposureDuration = true;
+            } catch (ASCOM.NotImplementedException) {
+                Logger.Trace("LastExposureDuration is not implemented in this driver");
+            } catch (ASCOM.InvalidOperationException) {
+                // It's implemented but does not yet have a value, which is expected here.
+                HasLastExposureDuration = true;
+            } catch (Exception) { }
+
+            try {
+                _ = device.LastExposureStartTime;
+                HasLastExposureStartTime = true;
+            } catch (ASCOM.NotImplementedException) {
+                Logger.Trace("LastExposureStartTime is not implemented in this driver");
+            } catch (ASCOM.InvalidOperationException) {
+                // It's implemented but does not yet have a value, which is expected here.
+                HasLastExposureStartTime = true;
+            } catch (Exception) { }
 
             if (CanSetOffset) {
                 try {
@@ -442,33 +467,32 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         public bool IsPulseGuiding => GetProperty(nameof(Camera.IsPulseGuiding), false);
 
-        private bool _hasLastExposureInfo;
+        private bool HasLastExposureDuration { get; set; } = false;
+        private bool HasLastExposureStartTime { get; set; } = false;
 
-        public double LastExposureDuration {
+        public double? LastExposureDuration {
             get {
-                double val = -1;
-                try {
-                    if (ShouldBeConnected && _hasLastExposureInfo) {
-                        val = device.LastExposureDuration;
-                    }
-                } catch (ASCOM.InvalidOperationException) {
-                } catch (ASCOM.NotImplementedException) {
-                    _hasLastExposureInfo = false;
+                double? val = null;
+
+                if (ShouldBeConnected && HasLastExposureDuration) {
+                    val = GetProperty<double>(nameof(Camera.LastExposureDuration), double.NaN);
                 }
                 return val;
             }
         }
 
-        public string LastExposureStartTime {
+        public DateTime? LastExposureStartTime {
             get {
-                string val = string.Empty;
-                try {
-                    if (ShouldBeConnected && _hasLastExposureInfo) {
-                        val = device.LastExposureStartTime;
+                DateTime? val = null;
+
+                if (ShouldBeConnected && HasLastExposureStartTime) {
+                    string startTimeStr = GetProperty<string>(nameof(Camera.LastExposureStartTime), null);
+
+                    if (DateTime.TryParse(startTimeStr, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime dt)) {
+                        val = dt;
+                    } else {
+                        Logger.Error($"Unable to parse LastExposureStartTime '{startTimeStr}'");
                     }
-                } catch (ASCOM.InvalidOperationException) {
-                } catch (ASCOM.NotImplementedException) {
-                    _hasLastExposureInfo = false;
                 }
                 return val;
             }
@@ -610,7 +634,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 while (!ImageReady) {
                     await CoreUtil.Wait(TimeSpan.FromMilliseconds(10), token);
                 }
-                lastExposureEndTime = DateTime.UtcNow;
+
+                if (HasLastExposureStartTime && HasLastExposureDuration) {
+                    lastExposureStartTime = (DateTime)LastExposureStartTime;
+                    lastExposureEndTime = lastExposureStartTime + TimeSpan.FromSeconds(LastExposureDuration ?? double.NaN);
+                } else {
+                    lastExposureEndTime = DateTime.UtcNow;
+                }
             }
         }
 
@@ -625,6 +655,10 @@ namespace NINA.Equipment.Equipment.MyCamera {
                         var metaData = new ImageMetaData();
                         metaData.FromCamera(this);
                         metaData.Image.SetExposureTimes(lastExposureStartTime, lastExposureEndTime);
+
+                        if (HasLastExposureDuration) {
+                            metaData.Image.ExposureTime = LastExposureDuration ?? double.NaN;
+                        }
 
                         return exposureDataFactory.CreateFlipped2DExposureData(
                             flipped2DArray: (Array)ImageArray,

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -888,7 +888,10 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                 BroadcastCameraInfo();
                 if (output != null) {
                     output.MetaData.FromProfile(this.profileService.ActiveProfile);
-                    output.MetaData.Image.ExposureTime = this.exposureTime;
+
+                    if (double.IsNaN(output.MetaData.Image.ExposureTime)) {
+                        output.MetaData.Image.ExposureTime = this.exposureTime;
+                    }
                 }
                 return output;
             } else {

--- a/NINA/ViewModel/ImagingVM.cs
+++ b/NINA/ViewModel/ImagingVM.cs
@@ -166,16 +166,18 @@ namespace NINA.ViewModel {
                 DateTime midpoint,
                 RMS rms,
                 string targetName) {
-            metaData.Image.Id = this.imageHistoryVM.GetNextImageId();            
-            if(metaData.Image.ExposureStart == DateTime.MinValue) {
+            metaData.Image.Id = this.imageHistoryVM.GetNextImageId();
+            if (metaData.Image.ExposureStart == DateTime.MinValue) {
                 metaData.Image.ExposureStart = start;
             }
             if (metaData.Image.ExposureMidPoint == DateTime.MinValue) {
                 metaData.Image.ExposureMidPoint = midpoint;
             }
+            if (double.IsNaN(metaData.Image.ExposureTime)) {
+                metaData.Image.ExposureTime = sequence.ExposureTime;
+            }
             metaData.Image.Binning = sequence.Binning.Name;
             metaData.Image.ExposureNumber = sequence.ProgressExposureCount;
-            metaData.Image.ExposureTime = sequence.ExposureTime;
             metaData.Image.ImageType = sequence.ImageType;
             metaData.Image.RecordedRMS = rms;
             metaData.Target.Name = targetName;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -109,7 +109,9 @@ This allows you to safely return to a stable release if needed.
 
 ### **Device Management**
 - **ASCOM Alpaca Direct Drivers**
-    - In case your ASCOM Alpaca specific device has a static IP or doesn't offer Alpaca Discovery a new static entry is available for each device type to pick from where you can specify the address to connect to instead of having to rely on discovery
+  - In case your ASCOM Alpaca specific device has a static IP or doesn't offer Alpaca Discovery a new static entry is available for each device type to pick from where you can specify the address to connect to instead of having to rely on discovery
+- **ASCOM Camera Drivers**
+  - If an ASCOM camera driver implements them, the driver-provided `LastExposureStartTime` and `LastExposureDuration` properties are used to populate the date-related and exposure duration metadata keywords in images.
 - **Altair, Mallincam, Ogma, Omegon, Risingcam, SvBony and ToupTek Filterwheel Native Driver**
   - The ToupTek based filter wheels are now available as a native driver.
   - The ToupTek based focusers are now available as a native driver.
@@ -125,7 +127,7 @@ This allows you to safely return to a stable release if needed.
 
 ### **User Interface & Usability**
 - **Sequencer**
-    - Each intstruction container now has a colored border on the left side to better differentiate between them. This can be disabled in Options > Imaging > Sequence > Colored Container Borders
+  - Each intstruction container now has a colored border on the left side to better differentiate between them. This can be disabled in Options > Imaging > Sequence > Colored Container Borders
 - **Sky Atlas Improvements**  
   - Deep sky objects can now be filtered and sorted by their upper transit time
 - **Framing Assistant Improvements** 


### PR DESCRIPTION
<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

Issue #309 raised the point that an ASCOM driver might reveal more accurate image exposure start time and duration information if the camera in use is equipped with a GPS, and if the driver does additional time-consuming tasks before the actual exposure commences. The Moravian ASCOM driver will populate `LastExposureStartTime` with GPS-sourced time value. Looking at the ZWO ASCOM driver, it will as well for some yet-to-be-released camera model that has a GPS.  Thinking more about this, some CCD drivers may do RBI flashing before the start of the exposure.

This PR alters the NINA camera ASCOM/Alpaca client to use `LastExposureStartTime` and `LastExposureDuration` if they are implemented. Their implemented presence is tested upon connection with the ASCOM/Alpaca driver and is used if they are. If not, the existing NINA-generated time and duration values are used.

## 🧪 How Was It Tested?

With the Alpaca camera OmniSim and the NINA simulator camera.

## 🤖 AI / Tooling Disclosure

None, as there is still some joy in creating small fixes like this.

## ✅ PR Checklist

- [x ] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [ x] No breaking changes to interfaces  
  - [ x] No changes to method/class signatures (especially optional parameters)
- [ x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

#309 
