### PR TITLE
FastGaussianBlur: fix minor artefacts in FastGaussianBlur

### DIFF
--- a/NINA.Image/ImageAnalysis/FastGaussianBlur.cs
+++ b/NINA.Image/ImageAnalysis/FastGaussianBlur.cs
@@ -120,7 +120,7 @@ namespace NINA.Image.ImageAnalysis {
                     dest[ti++] = (byte)Math.Floor(val * iar);
                 }
                 for (var j = r + 1; j < w - r; j++) {
-                    val += source[ri++] - dest[li++];
+                    val += source[ri++] - source[li++];
                     dest[ti++] = (byte)Math.Floor(val * iar);
                 }
                 for (var j = w - r; j < w; j++) {


### PR DESCRIPTION
Hello,
Hope you're doing well.

While working on an OpenCL version of your FastGaussianBlur function, I may have found an issue producing small artefacts.
In the function for the Horizontal blur, in the main loop (looping on pixels on a line), the operation that moves the rolling window seems to be incorrectly removing blurred data instead of the source.
https://github.com/isbeorn/nina/blob/512f0d9598c9e5588f68c3c488bba5867eafacfd/NINA.Image/ImageAnalysis/FastGaussianBlur.cs#L123
Shouldn't it be?
`val += source[ri++] - source[li++];`
As here?
https://github.com/isbeorn/nina/blob/512f0d9598c9e5588f68c3c488bba5867eafacfd/NINA.Image/ImageAnalysis/FastGaussianBlur.cs#L150

I've run small tests by extracting the result of this function from NINA:
- It tends to elongate stars and create a black centroid at their right.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f5bd4fe-5b0d-4f59-a5fc-fcd2c0448172" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bfd4d929-e8d8-4b74-907b-aad7b9c7dc07" />
- And can create black dots in the white elements bigger than the radius.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/68aabe2f-f593-428c-86b0-8deda497fe25" />

Have a nice day.