### PR TITLE
Preserve QHY gain and offset across read mode changes

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -379,6 +379,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
             set {
                 if (Connected && CanSetOffset) {
                     if (Sdk.SetControlValue(QhySdk.CONTROL_ID.CONTROL_OFFSET, value)) {
+                        Info.CurOffset = value;
                         RaisePropertyChanged();
                     }
                 }
@@ -478,13 +479,15 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
                                 // SetQHYCCDReadMode + InitQHYCCD reinitialize the camera and reset its
                                 // control values (gain, offset, ...) to the new read mode's power-on
-                                // defaults. Capture the currently requested gain/offset here and re-apply
-                                // them after the switch; otherwise the next exposure - the first one taken
-                                // after a read mode change - is digitized with the reset defaults instead
-                                // of the requested values (observed as a wrong-gain/offset first frame
-                                // immediately following a read mode change).
+                                // defaults. Re-apply the last commanded gain/offset after the switch;
+                                // otherwise exposures taken after a read mode change are digitized with
+                                // the reset defaults instead of the requested values (observed as
+                                // wrong-gain/offset frames following a read mode change). Both values are
+                                // read from our own cache (Info.CurGain / Info.CurOffset) rather than the
+                                // hardware, so the correct values are restored even if the hardware is
+                                // already in a reset state at this point.
                                 double requestedGain = Info.CurGain;
-                                double requestedOffset = Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_OFFSET);
+                                int requestedOffset = Info.CurOffset;
 
                                 if ((rv = Sdk.SetReadMode(mode)) != QhySdk.QHYCCD_SUCCESS) {
                                     Logger.Error($"QHYCCD: SetQHYCCDReadMode() failed. Returned {rv}");
@@ -928,6 +931,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
                 Logger.Debug($"QHYCCD: OffMin={Info.OffMin}, OffMax={Info.OffMax}, OffStep={Info.OffStep}");
 
                 QuirkInflatedOffset();
+
+                /*
+                 * Seed the cached offset from the hardware so it can be re-applied
+                 * after a read mode change (which resets control values) even before
+                 * the first explicit offset command of a session.
+                 */
+                Info.CurOffset = (int)Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_OFFSET);
 
                 /*
                  * Fetch our min and max PWM settings for

--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -476,6 +476,16 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
                                 Logger.Debug($"QHYCCD: ReadoutMode: Setting readout mode to {mode} ({modeName})");
 
+                                // SetQHYCCDReadMode + InitQHYCCD reinitialize the camera and reset its
+                                // control values (gain, offset, ...) to the new read mode's power-on
+                                // defaults. Capture the currently requested gain/offset here and re-apply
+                                // them after the switch; otherwise the next exposure - the first one taken
+                                // after a read mode change - is digitized with the reset defaults instead
+                                // of the requested values (observed as a wrong-gain/offset first frame
+                                // immediately following a read mode change).
+                                double requestedGain = Info.CurGain;
+                                double requestedOffset = Sdk.GetControlValue(QhySdk.CONTROL_ID.CONTROL_OFFSET);
+
                                 if ((rv = Sdk.SetReadMode(mode)) != QhySdk.QHYCCD_SUCCESS) {
                                     Logger.Error($"QHYCCD: SetQHYCCDReadMode() failed. Returned {rv}");
                                     return;
@@ -487,6 +497,13 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
                                 Sdk.InitCamera();
                                 SetImageResolution();
+
+                                if (CanSetGain && !Sdk.SetControlValue(QhySdk.CONTROL_ID.CONTROL_GAIN, requestedGain)) {
+                                    Logger.Error($"QHYCCD: Failed to restore gain {requestedGain} after read mode change");
+                                }
+                                if (CanSetOffset && !Sdk.SetControlValue(QhySdk.CONTROL_ID.CONTROL_OFFSET, requestedOffset)) {
+                                    Logger.Error($"QHYCCD: Failed to restore offset {requestedOffset} after read mode change");
+                                }
                             }
                         }
                     }

--- a/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
+++ b/NINA.Equipment/SDK/CameraSDKs/QHYSDK/QhyccdSdk.cs
@@ -1351,6 +1351,13 @@ namespace QHYCCD {
             public double CurGain;
 
             /// <summary>
+            /// Internally-stored offset setting. Cached on every successful offset
+            /// command so it can be re-applied after a read mode change, which
+            /// reinitializes the camera and resets its control values.
+            /// </summary>
+            public int CurOffset;
+
+            /// <summary>
             /// Camera has temperature sensor?
             /// </summary>
             public bool HasChipTemp;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,7 @@ This allows you to safely return to a stable release if needed.
 - Manual rotator moves now clean up their moving state correctly when the rotation prompt is cancelled.
 - Fixed an issue where custom popout windows and message boxes could briefly render incorrectly when opened.
 - Firmware version is now correctly displayed for certain QHY camera models.
+- QHY cameras no longer capture the first frame after a read mode change with the wrong gain/offset; the requested gain/offset are now re-applied after the read mode switch, which reinitializes the camera and resets its control values.
 - Image save failures in the asynchronous save queue now raise a persistent notification and are forwarded into the active sequence failure event stream.
 
 ## Improvements


### PR DESCRIPTION
## 🚀 Purpose

Fix QHY native driver capturing the **first frame after a read mode change with the wrong gain/offset**.

On QHY cameras, changing the read mode calls `SetQHYCCDReadMode` followed by `InitQHYCCD`, which reinitializes the camera and resets its control values (gain, offset, …) to the new mode's power-on defaults. In `QHYCamera`, the requested gain/offset are applied *before* `StartExposure`, but the actual read mode switch happens *inside* `StartExposure` (via the `ReadoutMode` setter) after that — and the gain/offset were never re-applied afterward.

As a result, the first exposure taken immediately after a read mode change is digitized with the reset defaults instead of the requested values. In practice this showed up as a single mislabeled/miscalibrated frame at the start of a session: e.g. a frame whose FITS header carried the correct readout mode and exposure time, but the *previous* session's gain/offset — enough to make it useless for calibration and to land in the wrong calibration group.

The fix captures the requested gain (`Info.CurGain`) and offset right before the switch and re-applies them immediately after `InitQHYCCD`, inside the `ReadoutMode` setter, so every caller (including `StartExposure`) is covered. It is a no-op when the read mode does not actually change.

## 🧪 How Was It Tested?

- **Root cause** was traced directly in `QHYCamera.StartExposure` / the `ReadoutMode` setter, and cross-checked against the documented QHY SDK behavior that a read-mode change reinitializes the camera and resets control values.
- **Symptom** was observed on real hardware (QHY miniCam8 / IMX585): the very first frame of a sequence, after the hardware read mode changed from the previous session's mode, was written with the previous session's gain/offset while readout mode and exposure time were already correct. Every subsequent frame (no read-mode change) was correct.
- **Local build**: built the solution with the .NET 10 SDK (10.0.301) on Windows — `dotnet build NINA/NINA.csproj` in both Debug and Release completes with **0 errors**.
- **Local unit tests**: `dotnet test NINA.Test/NINA.Test.csproj -c Debug -p:PlatformTarget=x64` → **5099 passed, 16 skipped, 3 failed**. The 3 failures are unrelated to this change and are environment-dependent on my machine (a zh-CN Windows in a different geographic location):
  - `Sequencer.Conditions.AboveHorizonConditionTest.CustomHorizon_AboveHorizon_CheckFalse` and `StandardHorizon_AboveHorizon_CheckFalse` — geographic/time-dependent horizon checks.
  - `ExprConverter_HandlesSentinelsLiteralsExpressionsBooleansAndComboValues` — a localization test expecting `"{Filter_Ha}"` but getting the localized zh-CN string.
  - None touch camera/equipment code; the change is confined to `NINA.Equipment/.../QHYCamera.cs`.
- **Manual verification path** (requires a QHY camera whose read mode differs from its last-used mode): start an exposure that triggers a read-mode change and confirm the resulting FITS header now reports the requested `GAIN`/`OFFSET` on the *first* frame, not the previous values.
- **No focused unit test was added**: `QHYCamera`'s constructor takes a `uint cameraIdx` and immediately drives the real `QhySdk.Instance` singleton (`GetId`/`GetModel`/…), so the SDK cannot be substituted before construction without a constructor signature change — which the contributing guidelines ask to avoid. Happy to add one if maintainers prefer a small constructor refactor to make the SDK injectable.

## 🤖 AI / Tooling Disclosure

This change (code, release note, and this description) was prepared with the assistance of the Cursor AI agent. The submitting contributor reviewed and is responsible for the change.

## ✅ PR Checklist

- [x] All unit tests pass — *all tests unrelated to this change pass (5099); the only 3 failures are pre-existing environment-dependent tests (zh-CN locale + machine location) that are not touched by this change*
- [x] UI changes tested across Light, Dark, and Night themes (if applicable) — *N/A, no UI changes*
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [x] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable) — *N/A, no documented behavior change*

## 🔗 Related Issues

_None known._

## 📝 Additional Notes

- The fix lives in the `ReadoutMode` setter rather than in `StartExposure`, so any code path that changes the read mode preserves the requested gain/offset, not just the exposure path.
- Gain is restored from `Info.CurGain` (the value tracked by the `Gain` setter, correct even for cameras flagged with unreliable gain readback), and offset is restored from the raw `CONTROL_OFFSET` register value captured before the switch (which equals the requested offset, since the `Offset` setter writes it verbatim). This avoids the inflated-offset / unreliable-gain quirks handled elsewhere in the class.
