### PR TITLE
Fix QHY cooler not being turned off on connect

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -928,25 +928,32 @@ namespace NINA.Equipment.Equipment.MyCamera {
                     Info.CoolerPwmStep = step;
                     Logger.Debug($"QHYCCD: CoolerPwmMin={Info.CoolerPwmMin}, CoolerPwmMax={Info.CoolerPwmMax}, CoolerPwmStep={Info.CoolerPwmStep}");
 
-                    /*
-                     * Initialize cooler's target temperature to 0C
-                     */
                     if (!internalReconnect) {
+                        /*
+                         * Force the TEC off on connect. QHY cameras keep their cooler
+                         * running (firmware automatic temperature control) across a
+                         * disconnect/reconnect, so a session that left the camera cooling
+                         * would come back up still cooling. Turning it off here is the
+                         * intended, safe power-on behaviour.
+                         *
+                         * This must NOT go through the CoolerOn property setter or
+                         * CancelCoolingSync(): Connected is only set to true at the very
+                         * end of this method, and both of those early-return while
+                         * Connected is false. That made the previous force-off a silent
+                         * no-op - the hardware TEC was never actually commanded off, yet
+                         * Info.CoolerOn (default false) made the UI show the cooler as off
+                         * while it kept cooling. Command the hardware directly and set
+                         * Info.CoolerOn without the guard (mirroring Info.CoolerTargetTemp).
+                         */
                         Info.CoolerTargetTemp = 0;
-                    }
-
-                    /*
-                     * Force any TEC cooler to off upon startup
-                     */
-                    if (!internalReconnect) {
-                        CoolerOn = false;
-                        CancelCoolingSync();
+                        Info.CoolerOn = false;
+                        _ = Sdk.SetControlValue(QhySdk.CONTROL_ID.CONTROL_MANULPWM, 0);
 
                         /*
-                         * Start the thread that operates the TEC
-                         * This thread will operate the TEC in accordance with the user turning the cooler on or off
-                         * and program the camera's TEC to cool to the desired temperature. This thread will operate
-                         * for as long as the camera is connected.
+                         * Start the thread that operates the TEC. It maintains the target
+                         * temperature while CoolerOn is true and turns the TEC off when the
+                         * user turns cooling off. It runs for as long as the camera is
+                         * connected.
                          */
                         Logger.Debug("QHYCCD: Starting CoolerWorker task");
                         coolerWorkerCts = new CancellationTokenSource();


### PR DESCRIPTION
## Summary

QHY cameras are not actually powered down on connect: the driver *intends* to force the TEC off at startup, but that code path is a silent no-op. A camera left cooling by a previous session comes back up still cooling, while the UI shows the cooler as **off** with **0% power** — a persistent mismatch between the displayed and the real cooling state.

## Root cause

In `QHYCamera.ConnectSync()` the cooler is forced off with:

```csharp
if (!internalReconnect) {
    CoolerOn = false;
    CancelCoolingSync();
    ...
}
```

But this block runs **before** `Connected` is set to `true` (which only happens at the very end of `ConnectSync`). Both guards bail out while `Connected` is false:

- the `CoolerOn` property setter is wrapped in `if (Connected && CanSetTemperature)`, so `CoolerOn = false` does nothing;
- `CancelCoolingSync()` starts with `if (!Connected || !Info.HasCooler) return;`, so its `SetControlValue(CONTROL_MANULPWM, 0)` is **never executed**.

So the hardware TEC is never actually commanded off. QHY cameras keep their cooler running (firmware automatic temperature control) across a disconnect/reconnect, so the camera keeps cooling. Meanwhile `Info.CoolerOn` is `false` by default, so the UI reports the cooler as off at 0% power even though the sensor is still being held at the previous set point.

## Fix

Turn the TEC off directly on connect, without going through the `Connected`-guarded setter / `CancelCoolingSync()`:

```csharp
Info.CoolerTargetTemp = 0;
Info.CoolerOn = false;
_ = Sdk.SetControlValue(QhySdk.CONTROL_ID.CONTROL_MANULPWM, 0);
```

The hardware is genuinely powered off and the UI matches reality (cooler off, power drops to 0, sensor warms up). `internalReconnect` (read-mode switch) behaviour is unchanged.

## Test plan

- [x] Builds clean (`NINA.Equipment`, Release/x64), no new warnings.
- [ ] Connect a QHY camera that was left cooling by a previous session; confirm the TEC is actually turned off on connect and the UI (cooler on/off, power, temperature curve) reflects the real state.
- [ ] Verify normal cool-down / warm-up and read-mode switching still work.

## AI disclosure

This change was prepared with AI assistance and reviewed by a human.
