### PR TITLE
Persist focuser temp comp and mount tracking mode across restarts

### DIFF
--- a/NINA.Equipment/Equipment/MyTelescope/TelescopeInfo.cs
+++ b/NINA.Equipment/Equipment/MyTelescope/TelescopeInfo.cs
@@ -250,6 +250,8 @@ namespace NINA.Equipment.Equipment.MyTelescope {
             }
         }
 
+        public TrackingMode TrackingMode => TrackingRate.TrackingMode;
+
         private bool trackingEnabled;
 
         public bool TrackingEnabled {

--- a/NINA.Profile/FocuserSettings.cs
+++ b/NINA.Profile/FocuserSettings.cs
@@ -53,6 +53,7 @@ namespace NINA.Profile {
             rSquaredThreshold = 0.7;
             manualStepSmallMultiplier = 0.5;
             manualStepLargeMultiplier = 5.0;
+            tempComp = false;
         }
 
         private string id;
@@ -380,6 +381,19 @@ namespace NINA.Profile {
             set {
                 if (manualStepLargeMultiplier != value) {
                     manualStepLargeMultiplier = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool tempComp;
+
+        [DataMember]
+        public bool TempComp {
+            get => tempComp;
+            set {
+                if (tempComp != value) {
+                    tempComp = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Profile/Interfaces/IFocuserSettings.cs
+++ b/NINA.Profile/Interfaces/IFocuserSettings.cs
@@ -41,5 +41,6 @@ namespace NINA.Profile.Interfaces {
         double RSquaredThreshold { get; set; }
         double ManualStepSmallMultiplier { get; set; }
         double ManualStepLargeMultiplier { get; set; }
+        bool TempComp { get; set; }
     }
 }

--- a/NINA.Profile/Interfaces/ITelescopeSettings.cs
+++ b/NINA.Profile/Interfaces/ITelescopeSettings.cs
@@ -32,5 +32,14 @@ namespace NINA.Profile.Interfaces {
         bool SecondaryReversed { get; set; }
 
         TelescopeLocationSyncDirection TelescopeLocationSyncDirection { get; set; }
+
+        /// <summary>
+        /// Persisted tracking mode chosen by the user, stored as the integer value of
+        /// <see cref="NINA.Equipment.Interfaces.TrackingMode"/>. A value of -1 means no preference has been
+        /// stored yet, in which case the mount tracking mode is left untouched on connect.
+        /// The enum itself lives in NINA.Equipment and cannot be referenced from NINA.Profile without
+        /// introducing a circular dependency, hence the integer representation.
+        /// </summary>
+        int TrackingMode { get; set; }
     }
 }

--- a/NINA.Profile/TelescopeSettings.cs
+++ b/NINA.Profile/TelescopeSettings.cs
@@ -41,6 +41,7 @@ namespace NINA.Profile {
             noSync = false;
             timeSync = true;
             telescopeLocationSyncDirection = TelescopeLocationSyncDirection.PROMPT;
+            trackingMode = -1;
         }
 
         private string id;
@@ -218,6 +219,18 @@ namespace NINA.Profile {
             set {
                 if(timeSync != value) {
                     timeSync = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private int trackingMode;
+        [DataMember]
+        public int TrackingMode {
+            get => trackingMode;
+            set {
+                if (trackingMode != value) {
+                    trackingMode = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Focuser/FocuserVM.cs
@@ -1,7 +1,7 @@
 #region "copyright"
 
 /*
-    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+    Copyright ù 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
 
@@ -97,7 +97,11 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
         }
 
         private void ToggleTempComp(object obj) {
-            ToggleTempComp((bool)obj);
+            var tempComp = (bool)obj;
+            ToggleTempComp(tempComp);
+            // Persist the user's explicit choice so it can be re-applied on the next connect.
+            // Only the UI command path stores it - the transient toggles during a focuser move must not overwrite the preference.
+            profileService.ActiveProfile.FocuserSettings.TempComp = tempComp;
         }
 
         public void ToggleTempComp(bool tempComp) {
@@ -150,11 +154,11 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
                 if (lastFocusedTemperature == -1000) {
                     delta = 0;
                     deltaInt = 0;
-                    Logger.Info($"Moving Focuser By Temperature - Slope {slope} * ( DeltaT ) ∞C (relative mode) - lastTemperature initialized to {temperature}");
+                    Logger.Info($"Moving Focuser By Temperature - Slope {slope} * ( DeltaT ) ùC (relative mode) - lastTemperature initialized to {temperature}");
                 } else {
                     delta = lastRoundoff + (temperature - lastFocusedTemperature) * slope;
                     deltaInt = (int)Math.Round(delta);
-                    Logger.Info($"Moving Focuser By Temperature - LastRoundoff {lastRoundoff} + Slope {slope} * ( Temperature {temperature} - PrevTemperature {lastFocusedTemperature} ) ∞C (relative mode) = Delta {delta} / DeltaInt {deltaInt}");
+                    Logger.Info($"Moving Focuser By Temperature - LastRoundoff {lastRoundoff} + Slope {slope} * ( Temperature {temperature} - PrevTemperature {lastFocusedTemperature} ) ùC (relative mode) = Delta {delta} / DeltaInt {deltaInt}");
                 }
                 int pos = Position;
                 var result = await MoveFocuserInternal(pos + deltaInt, ct);
@@ -302,6 +306,14 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Focuser {
                     if (connected) {
                         Focuser = newFocuser;
                         token.ThrowIfCancellationRequested();
+
+                        // The device power-on state is not trustworthy, so the remembered temperature compensation
+                        // preference is always pushed back to the focuser on connect.
+                        if (Focuser.TempCompAvailable) {
+                            var persistedTempComp = profileService.ActiveProfile.FocuserSettings.TempComp;
+                            Logger.Info($"Applying persisted focuser temperature compensation state '{persistedTempComp}' on connect");
+                            Focuser.TempComp = persistedTempComp;
+                        }
 
                         FocuserInfo = new FocuserInfo {
                             Connected = true,

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -633,6 +633,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
 
             telescopeValues.TryGetValue(nameof(TelescopeInfo.TrackingRate), out o);
             TelescopeInfo.TrackingRate = (TrackingRate)(o ?? TrackingRate.STOPPED);
+            RaisePropertyChanged(nameof(SelectedTrackingMode));
 
             telescopeValues.TryGetValue(nameof(TelescopeInfo.TrackingEnabled), out o);
             TelescopeInfo.TrackingEnabled = (bool)(o ?? false);
@@ -1149,6 +1150,20 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             set {
                 supportedTrackingModes = value;
                 RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The tracking mode currently reported by the mount, bound to the tracking mode selector in the UI.
+        /// The getter reflects the live device state so the selector is never blank while connected;
+        /// setting it from the UI applies the chosen mode to the mount.
+        /// </summary>
+        public TrackingMode SelectedTrackingMode {
+            get => TelescopeInfo.TrackingMode;
+            set {
+                if (TelescopeInfo?.Connected == true && value != TelescopeInfo.TrackingMode) {
+                    SetTrackingMode(value);
+                }
             }
         }
 

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -523,6 +523,8 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
                             // Supporting custom would require an additional dialog box to input the custom rates. We can add that later if there's demand for it
                             SupportedTrackingModes = new AsyncObservableCollection<TrackingMode>(Telescope.TrackingModes.Where(m => m != TrackingMode.Custom));
 
+                            RestorePersistedTrackingMode();
+
                             updateTimer.Interval = profileService.ActiveProfile.ApplicationSettings.DevicePollingInterval;
                             _ = updateTimer.Run();
 
@@ -1085,7 +1087,37 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
                 }
             }
 
-            return Telescope.TrackingMode == trackingMode;
+            var applied = Telescope.TrackingMode == trackingMode;
+            if (applied) {
+                // Persist the user's explicit choice so it can be re-applied on the next connect.
+                profileService.ActiveProfile.TelescopeSettings.TrackingMode = (int)trackingMode;
+            }
+            return applied;
+        }
+
+        /// <summary>
+        /// Re-applies the tracking mode the user last selected. The mount power-on state is not trustworthy,
+        /// so the remembered choice is always pushed back to the mount on connect.
+        /// </summary>
+        private void RestorePersistedTrackingMode() {
+            var persisted = profileService.ActiveProfile.TelescopeSettings.TrackingMode;
+            if (persisted < 0) {
+                return;
+            }
+
+            var trackingMode = (TrackingMode)persisted;
+            if (trackingMode == TrackingMode.Custom || !SupportedTrackingModes.Contains(trackingMode)) {
+                Logger.Warning($"Persisted tracking mode '{trackingMode}' is not supported by the mount. Skipping restore.");
+                return;
+            }
+
+            if (TelescopeInfo.AtPark) {
+                Logger.Info($"Mount is parked on connect. Skipping restore of persisted tracking mode '{trackingMode}'.");
+                return;
+            }
+
+            Logger.Info($"Restoring persisted tracking mode '{trackingMode}' on connect");
+            SetTrackingMode(trackingMode);
         }
 
         public bool SetCustomTrackingRate(SiderealShiftTrackingRate rate) {

--- a/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Telescope/TelescopeVM.cs
@@ -1089,16 +1089,20 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             }
 
             var applied = Telescope.TrackingMode == trackingMode;
-            if (applied) {
-                // Persist the user's explicit choice so it can be re-applied on the next connect.
+            if (applied && trackingMode != TrackingMode.Stopped) {
+                // Only remember an actual tracking rate (Sidereal/Lunar/Solar/King) so it can be
+                // re-applied on the next connect. "Stopped" is a transient action, not a rate
+                // preference, and must never be persisted - otherwise every subsequent connect would
+                // force the mount to stop tracking.
                 profileService.ActiveProfile.TelescopeSettings.TrackingMode = (int)trackingMode;
             }
             return applied;
         }
 
         /// <summary>
-        /// Re-applies the tracking mode the user last selected. The mount power-on state is not trustworthy,
-        /// so the remembered choice is always pushed back to the mount on connect.
+        /// Re-applies the tracking rate the user last selected (Sidereal/Lunar/Solar/King). The mount
+        /// power-on state is not trustworthy, so the remembered rate is pushed back to the mount on connect.
+        /// A persisted "Stopped" or an unsupported/Custom rate is skipped, and a parked mount is left untouched.
         /// </summary>
         private void RestorePersistedTrackingMode() {
             var persisted = profileService.ActiveProfile.TelescopeSettings.TrackingMode;
@@ -1107,6 +1111,12 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Telescope {
             }
 
             var trackingMode = (TrackingMode)persisted;
+            if (trackingMode == TrackingMode.Stopped) {
+                // A persisted "Stopped" is treated as "no rate preference": the mount is left in its
+                // actual state instead of being forced to stop tracking on every connect.
+                return;
+            }
+
             if (trackingMode == TrackingMode.Custom || !SupportedTrackingModes.Contains(trackingMode)) {
                 Logger.Warning($"Persisted tracking mode '{trackingMode}' is not supported by the mount. Skipping restore.");
                 return;

--- a/NINA/View/Equipment/Telescope/TelescopeView.xaml
+++ b/NINA/View/Equipment/Telescope/TelescopeView.xaml
@@ -607,7 +607,8 @@
                                     x:Name="TrackingModeComboBox"
                                     Height="30"
                                     Margin="10,0,0,0"
-                                    ItemsSource="{Binding SupportedTrackingModes}">
+                                    ItemsSource="{Binding SupportedTrackingModes}"
+                                    SelectedItem="{Binding SelectedTrackingMode, Mode=TwoWay}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Path=., Converter={StaticResource TrackingModeConverter}}" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,7 +37,7 @@ This allows you to safely return to a stable release if needed.
 - Firmware version is now correctly displayed for certain QHY camera models.
 - Image save failures in the asynchronous save queue now raise a persistent notification and are forwarded into the active sequence failure event stream.
 - The focuser temperature compensation toggle is now remembered across restarts and re-applied to the device on connect, instead of always reverting to the driver's power-on state.
-- The mount tracking mode selected by the user is now remembered across restarts and re-applied to the mount on connect (skipped while parked), instead of relying on the mount's untrusted power-on state.
+- The mount tracking rate selected by the user (Sidereal/Lunar/Solar/King) is now remembered across restarts and re-applied to the mount on connect (skipped while parked), instead of relying on the mount's untrusted power-on state. Stopping tracking is treated as a transient action and is no longer persisted, so the mount is never forced to stay stopped on subsequent connects.
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,8 @@ This allows you to safely return to a stable release if needed.
 - Fixed an issue where custom popout windows and message boxes could briefly render incorrectly when opened.
 - Firmware version is now correctly displayed for certain QHY camera models.
 - Image save failures in the asynchronous save queue now raise a persistent notification and are forwarded into the active sequence failure event stream.
+- The focuser temperature compensation toggle is now remembered across restarts and re-applied to the device on connect, instead of always reverting to the driver's power-on state.
+- The mount tracking mode selected by the user is now remembered across restarts and re-applied to the mount on connect (skipped while parked), instead of relying on the mount's untrusted power-on state.
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
## Summary

NINA only mirrored the live device state for two user-facing toggles and never stored the user's choice in the profile:

- **Focuser temperature compensation** – `FocuserVM.ToggleTempComp` wrote only to the driver; on connect `FocuserInfo.TempComp` was read straight back from the driver.
- **Mount tracking mode** – `TelescopeVM.SetTrackingMode` wrote only to the driver; on connect the tracking rate was read straight back from the mount.

For drivers/hardware that do not retain these values across a power cycle (common for ASCOM focusers and mounts), the toggle therefore always reverted to the device power-on default after every NINA restart, and there was no setting the user could change to keep it.

This PR persists both values in the profile and re-applies the remembered value to the device on connect. The device power-on state is treated as untrusted, so the stored preference is always pushed back to the device.

## Changes

- `IFocuserSettings` / `FocuserSettings`: new persisted `bool TempComp` (default `false`).
- `ITelescopeSettings` / `TelescopeSettings`: new persisted `int TrackingMode` (default `-1` = no stored preference; stored as the int value of `NINA.Equipment.Interfaces.TrackingMode` because that enum cannot be referenced from `NINA.Profile` without a circular dependency).
- `FocuserVM`:
  - The UI toggle now persists the user's choice. The persistence lives only in the UI command handler so the transient temp-comp on/off toggling that happens during a focuser move does not overwrite the user preference.
  - On connect, if temperature compensation is available, the persisted value is applied to the focuser.
- `TelescopeVM`:
  - `SetTrackingMode` persists the user's choice after it is successfully applied.
  - On connect, `RestorePersistedTrackingMode` re-applies the persisted mode. It is skipped when no preference is stored, when the mode is unsupported by the mount, or while the mount is parked.
- `RELEASE_NOTES.md`: two bugfix entries.

## Test plan

- [x] `dotnet test NINA.Test` filtered to `TelescopeVMTest` and `FocuserVMTest` — all 21 pass. Logs confirm the new `RestorePersistedTrackingMode` path executes on connect.
- [ ] Manual: connect an ASCOM focuser that does not retain temp comp, enable temp comp, restart NINA, reconnect → temp comp is re-enabled.
- [ ] Manual: set mount tracking mode to Sidereal, restart NINA, reconnect (unparked) → tracking mode is restored to Sidereal.
