### PR TITLE
Always show core symbols and leave them as null until available/connected

### DIFF
--- a/NINA.Profile/Interfaces/ISwitchSettings.cs
+++ b/NINA.Profile/Interfaces/ISwitchSettings.cs
@@ -12,10 +12,14 @@
 
 #endregion "copyright"
 
+using System.Collections.Generic;
+
 namespace NINA.Profile.Interfaces {
 
     public interface ISwitchSettings : ISettings {
         string Id { get; set; }
         string LastDeviceName { get; set; }
+        List<string> KnownReadonlySwitchSymbols { get; set; }
+        List<string> KnownWritableSwitchSymbols { get; set; }
     }
 }

--- a/NINA.Profile/SwitchSettings.cs
+++ b/NINA.Profile/SwitchSettings.cs
@@ -13,6 +13,7 @@
 #endregion "copyright"
 
 using NINA.Profile.Interfaces;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace NINA.Profile {
@@ -31,6 +32,8 @@ namespace NINA.Profile {
         protected override void SetDefaultValues() {
             id = "No_Device";
             lastDeviceName = string.Empty;
+            knownReadonlySwitchSymbols = new List<string>();
+            knownWritableSwitchSymbols = new List<string>();
         }
 
         private string id;
@@ -54,6 +57,32 @@ namespace NINA.Profile {
             set {
                 if (lastDeviceName != value) {
                     lastDeviceName = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private List<string> knownReadonlySwitchSymbols;
+
+        [DataMember]
+        public List<string> KnownReadonlySwitchSymbols {
+            get => knownReadonlySwitchSymbols;
+            set {
+                if (knownReadonlySwitchSymbols != value) {
+                    knownReadonlySwitchSymbols = value ?? new List<string>();
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private List<string> knownWritableSwitchSymbols;
+
+        [DataMember]
+        public List<string> KnownWritableSwitchSymbols {
+            get => knownWritableSwitchSymbols;
+            set {
+                if (knownWritableSwitchSymbols != value) {
+                    knownWritableSwitchSymbols = value ?? new List<string>();
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Sequencer/Container/DeepSkyObjectContainer.cs
+++ b/NINA.Sequencer/Container/DeepSkyObjectContainer.cs
@@ -379,11 +379,10 @@ namespace NINA.Sequencer.Container {
                 }
                 await base.Execute(progress, token);
             } finally {
-                // Remove Symbols for Target; no harm if they don't exist
-                broker.RemoveSymbol(provider, "TargetName");
-                broker.RemoveSymbol(provider, "TargetRAJ2000");
-                broker.RemoveSymbol(provider, "TargetDecJ2000");
-                broker.RemoveSymbol(provider, "TargetPositionAngle");
+                broker.AddOrUpdateSymbol(provider, "TargetName", null);
+                broker.AddOrUpdateSymbol(provider, "TargetRAJ2000", null);
+                broker.AddOrUpdateSymbol(provider, "TargetDecJ2000", null);
+                broker.AddOrUpdateSymbol(provider, "TargetPositionAngle", null);
             }
         }
     }

--- a/NINA.Sequencer/Logic/SymbolBroker.cs
+++ b/NINA.Sequencer/Logic/SymbolBroker.cs
@@ -39,6 +39,7 @@ using NINA.WPF.Base.ViewModel;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -57,7 +58,7 @@ namespace NINA.Sequencer.Logic {
         IDomeConsumer, ISafetyMonitorConsumer, ICameraConsumer, IFlatDeviceConsumer, IRotatorConsumer, IGuiderConsumer {
 
         private static List<string> _symbolProviders =
-            new List<string> { "NINA", "Image", "Dome", "Camera", "Mount", "Rotator", "Weather", "Gauge", "Switch", "Focuser", "Safety", "Filter", "FilterWheel" };
+            new List<string> { "NINA", "Image", "Dome", "Camera", "Mount", "Rotator", "Weather", "Gauge", "Switch", "Focuser", "Safety", "Filter", "FilterWheel", "FlatPanel", "Guider" };
 
         private static int _internalSymbolProviderCount = _symbolProviders.Count;
 
@@ -102,6 +103,7 @@ namespace NINA.Sequencer.Logic {
         private IGuiderMediator _guiderMediator;
         private ConcurrentDictionary<string, IList<Symbol>> _hiddenSymbols = new ConcurrentDictionary<string, IList<Symbol>>();
         private long _imageSymbolVersion;
+        private ObserveAllCollection<FilterInfo> _watchedFilterList;
 
         private readonly ConcurrentDictionary<string, string> _providerOwnership = new ConcurrentDictionary<string, string>();
 
@@ -147,6 +149,9 @@ namespace NINA.Sequencer.Logic {
             foreach (string provider in _symbolProviders) {
                 RegisterSymbolProvider(provider);
             }
+            InitializeCoreSymbols();
+            InitializeProfileSymbols();
+            SubscribeToProfileSymbols();
             // Register the core functions
             RegisterCoreFunctions();
 
@@ -171,6 +176,130 @@ namespace NINA.Sequencer.Logic {
 
             // This is a singleton, created once in CompositionRoot
             Instance = this;
+        }
+
+        private void InitializeCoreSymbols() {
+            foreach (string symbol in new[] { "TargetName", "TargetRAJ2000", "TargetDecJ2000", "TargetPositionAngle" }) {
+                AddOrUpdateSymbol("NINA", symbol, null);
+            }
+
+            foreach (string symbol in new[] {
+                "HFR", "HFRStDev", "FWHM", "Eccentricity", "StarCount", "ImageId", "ExposureTime", "RMS", "Gain", "Offset", "ImageType",
+                "Mean", "Median", "StDev", "MAD", "Min", "Max", "MinOccurrences", "MaxOccurrences"
+            }) {
+                AddOrUpdateSymbol("Image", symbol, null);
+            }
+            foreach (string symbol in new[] { "HFRPixels", "HFRArcseconds", "HFRStDevPixels", "HFRStDevArcseconds", "FWHMPixels", "FWHMArcseconds" }) {
+                AddOrUpdateSymbol("Image", symbol, null, SymbolType.SYMBOL_HIDDEN);
+            }
+
+            AddOrUpdateSymbol("Mount", "Connected", null);
+            foreach (string symbol in new[] { "Altitude", "Azimuth", "AtPark", "RightAscensionJ2000", "DeclinationJ2000" }) {
+                AddOrUpdateSymbol("Mount", symbol, null);
+            }
+            AddOrUpdateSymbol("Mount", "SideOfPier", null, PierConstants);
+
+            AddOrUpdateSymbol("Switch", "Connected", null);
+            AddOrUpdateSymbol("Weather", "Connected", null);
+            foreach (string symbol in _weatherData) {
+                AddOrUpdateSymbol("Weather", SanitizeIdentifier(symbol), null);
+            }
+
+            AddOrUpdateSymbol("Focuser", "Connected", null);
+            AddOrUpdateSymbol("Focuser", "Position", null);
+            AddOrUpdateSymbol("Focuser", "Temperature", null);
+
+            AddOrUpdateSymbol("FilterWheel", "Connected", null);
+            AddOrUpdateSymbol("FilterWheel", "CurrentFilterIndex", null);
+
+            AddOrUpdateSymbol("Dome", "Connected", null);
+            AddOrUpdateSymbol("Dome", "ShutterStatus", null, ShutterConstants);
+            AddOrUpdateSymbol("Dome", "Azimuth", null);
+            AddOrUpdateSymbol("Dome", "Altitude", null);
+            AddOrUpdateSymbol("Dome", "DomeAzimuth", null, SymbolType.SYMBOL_HIDDEN);
+            AddOrUpdateSymbol("Dome", "DomeAltitude", null, SymbolType.SYMBOL_HIDDEN);
+
+            AddOrUpdateSymbol("Safety", "Connected", null);
+            AddOrUpdateSymbol("Safety", "IsSafe", null);
+
+            AddOrUpdateSymbol("Camera", "Connected", null);
+            foreach (string symbol in new[] { "Temperature", "TemperatureSetPoint", "CoolerOn", "CoolerPower" }) {
+                AddOrUpdateSymbol("Camera", symbol, null);
+            }
+            foreach (string symbol in new[] { "PixelSize", "XSize", "YSize" }) {
+                AddOrUpdateSymbol("Camera", symbol, null, SymbolType.SYMBOL_HIDDEN);
+            }
+
+            AddOrUpdateSymbol("FlatPanel", "Connected", null);
+            AddOrUpdateSymbol("FlatPanel", "LightOn", null);
+            AddOrUpdateSymbol("FlatPanel", "Brightness", null);
+            AddOrUpdateSymbol("FlatPanel", "CoverState", null, CoverConstants);
+
+            AddOrUpdateSymbol("Rotator", "Connected", null);
+            AddOrUpdateSymbol("Rotator", "Position", null);
+            AddOrUpdateSymbol("Rotator", "MechanicalPosition", null);
+
+            AddOrUpdateSymbol("Guider", "Connected", null);
+            foreach (string symbol in new[] { "RMSTotal", "RMSRA", "RMSDec", "PeakRA", "PeakDec" }) {
+                AddOrUpdateSymbol("Guider", symbol, null);
+            }
+        }
+
+        private void InitializeProfileSymbols() {
+            var switchSettings = _profileService.ActiveProfile?.SwitchSettings;
+            foreach (string symbol in switchSettings?.KnownReadonlySwitchSymbols ?? Enumerable.Empty<string>()) {
+                AddOrUpdateSymbol("Gauge", symbol, null);
+            }
+            foreach (string symbol in switchSettings?.KnownWritableSwitchSymbols ?? Enumerable.Empty<string>()) {
+                AddOrUpdateSymbol("Switch", symbol, null);
+            }
+
+            ReconcileFilterSymbols(isConnected: false);
+        }
+
+        private void SubscribeToProfileSymbols() {
+            _profileService.ProfileChanged += ProfileService_ProfileChanged;
+            UpdateWatchedFilterList();
+        }
+
+        private void UpdateWatchedFilterList() {
+            if (_watchedFilterList != null) {
+                _watchedFilterList.CollectionChanged -= FilterList_CollectionChanged;
+            }
+
+            _watchedFilterList = _profileService.ActiveProfile?.FilterWheelSettings?.FilterWheelFilters;
+            if (_watchedFilterList != null) {
+                _watchedFilterList.CollectionChanged += FilterList_CollectionChanged;
+            }
+        }
+
+        private void ProfileService_ProfileChanged(object sender, EventArgs e) {
+            RemoveAllSymbols("Gauge");
+            RemoveAllSymbols("Switch", "Connected");
+            RemoveAllSymbols("Filter");
+            InitializeCoreSymbols();
+            UpdateWatchedFilterList();
+            InitializeProfileSymbols();
+            _ = UpdateNINASymbols();
+        }
+
+        private void FilterList_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e) {
+            bool isConnected = TryGetValue("FilterWheel_Connected", out object value) && value is true;
+            ReconcileFilterSymbols(isConnected);
+        }
+
+        private void ReconcileFilterSymbols(bool isConnected) {
+            var filters = _profileService.ActiveProfile?.FilterWheelSettings?.FilterWheelFilters ?? Enumerable.Empty<FilterInfo>();
+            var desiredFilters = filters
+                .Where(filter => filter != null)
+                .GroupBy(filter => SanitizeIdentifier(filter.Name), StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.Last())
+                .ToList();
+
+            RemoveAllSymbols("Filter", desiredFilters.Select(filter => SanitizeIdentifier(filter.Name)).ToArray());
+            foreach (FilterInfo filter in desiredFilters) {
+                AddOrUpdateSymbol("Filter", SanitizeIdentifier(filter.Name), isConnected ? filter.Position : null);
+            }
         }
 
         private void AddHiddenSymbol(string source, Symbol sym) {
@@ -462,6 +591,27 @@ namespace NINA.Sequencer.Logic {
             PublishSymbolChanges(changes);
         }
 
+        private void UninitializeAllSymbols(string source, params string[] keysToKeep) {
+            List<SymbolChangedEventArgs> changes = new List<SymbolChangedEventArgs>();
+            HashSet<string> keysToKeepSet = keysToKeep?.Length > 0
+                ? new HashSet<string>(keysToKeep, StringComparer.OrdinalIgnoreCase)
+                : null;
+
+            lock (_brokerStateLock) {
+                foreach (IList<Symbol> symbols in _dataSymbols.Values) {
+                    foreach (Symbol symbol in symbols) {
+                        if (symbol.Category == source && keysToKeepSet?.Contains(symbol.Key) != true && symbol.Value != null) {
+                            object oldValue = symbol.Value;
+                            symbol.Value = null;
+                            changes.Add(new SymbolChangedEventArgs(SymbolChangeKind.Updated, CopySymbol(symbol), oldValue, null));
+                        }
+                    }
+                }
+            }
+
+            PublishSymbolChanges(changes);
+        }
+
         private bool RemoveSymbol(string source, string key) {
             SymbolChangedEventArgs change = null;
             bool success;
@@ -624,6 +774,11 @@ namespace NINA.Sequencer.Logic {
         }
 
         public void Dispose() {
+            _profileService.ProfileChanged -= ProfileService_ProfileChanged;
+            if (_watchedFilterList != null) {
+                _watchedFilterList.CollectionChanged -= FilterList_CollectionChanged;
+                _watchedFilterList = null;
+            }
         }
 
         public IReadOnlyCollection<SymbolFunction> GetFunctions() {
@@ -735,6 +890,7 @@ namespace NINA.Sequencer.Logic {
 
             var imageData = e.RenderedImage.RawImageData;
             var imageSymbolVersion = Interlocked.Increment(ref _imageSymbolVersion);
+            UninitializeAllSymbols("Image");
 
             IStarDetectionAnalysis analysis = imageData.StarDetectionAnalysis;
             if (double.IsNaN(analysis.HFR)) {
@@ -947,28 +1103,48 @@ namespace NINA.Sequencer.Logic {
 
                 AddOrUpdateSymbol("Mount", "SideOfPier", (int)deviceInfo.SideOfPier, PierConstants);
             } else {
-                RemoveSymbol("Mount", "Altitude");
-                RemoveSymbol("Mount", "Azimuth");
-                RemoveSymbol("Mount", "AtPark");
-                RemoveSymbol("Mount", "RightAscensionJ2000");
-                RemoveSymbol("Mount", "DeclinationJ2000");
-                RemoveSymbol("Mount", "SideOfPier");
+                UninitializeAllSymbols("Mount", "Connected");
             }
         }
         public void UpdateDeviceInfo(SwitchInfo deviceInfo) {
             AddOrUpdateSymbol("Switch", "Connected", deviceInfo.Connected);
             if (deviceInfo.Connected) {
-                foreach (ISwitch sw in deviceInfo.ReadonlySwitches) {
+                var readonlySwitches = deviceInfo.ReadonlySwitches ?? Enumerable.Empty<ISwitch>();
+                var writableSwitches = deviceInfo.WritableSwitches ?? Enumerable.Empty<IWritableSwitch>();
+                var readonlySymbols = readonlySwitches
+                    .Select(sw => SanitizeIdentifier(sw.Name))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(symbol => symbol, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                var writableSymbols = writableSwitches
+                    .Select(sw => SanitizeIdentifier(sw.Name))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(symbol => symbol, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                RemoveAllSymbols("Gauge", readonlySymbols.ToArray());
+                RemoveAllSymbols("Switch", writableSymbols.Prepend("Connected").ToArray());
+                foreach (ISwitch sw in readonlySwitches) {
                     string key = SanitizeIdentifier(sw.Name);
                     AddOrUpdateSymbol("Gauge", key, sw.Value);
                 }
-                foreach (ISwitch sw in deviceInfo.WritableSwitches) {
+                foreach (IWritableSwitch sw in writableSwitches) {
                     string key = SanitizeIdentifier(sw.Name);
                     AddOrUpdateSymbol("Switch", key, sw.Value);
                 }
+
+                var switchSettings = _profileService.ActiveProfile?.SwitchSettings;
+                if (switchSettings != null) {
+                    if (!(switchSettings.KnownReadonlySwitchSymbols ?? new List<string>()).SequenceEqual(readonlySymbols, StringComparer.OrdinalIgnoreCase)) {
+                        switchSettings.KnownReadonlySwitchSymbols = readonlySymbols;
+                    }
+                    if (!(switchSettings.KnownWritableSwitchSymbols ?? new List<string>()).SequenceEqual(writableSymbols, StringComparer.OrdinalIgnoreCase)) {
+                        switchSettings.KnownWritableSwitchSymbols = writableSymbols;
+                    }
+                }
             } else {
-                RemoveAllSymbols("Gauge");
-                RemoveAllSymbols(source: "Switch", keysToKeep: "Connected");
+                UninitializeAllSymbols("Gauge");
+                UninitializeAllSymbols("Switch", "Connected");
             }
         }
 
@@ -977,17 +1153,17 @@ namespace NINA.Sequencer.Logic {
             if (deviceInfo.Connected) {
                 foreach (string dataName in _weatherData) {
                     PropertyInfo info = deviceInfo.GetType().GetProperty(dataName);
+                    object value = null;
                     if (info != null) {
                         object val = info.GetValue(deviceInfo);
                         if (val is double t && !Double.IsNaN(t)) {
-                            t = Math.Round(t, 2);
-                            string key = SanitizeIdentifier(dataName);
-                            AddOrUpdateSymbol("Weather", SanitizeIdentifier(dataName), t);
+                            value = Math.Round(t, 2);
                         }
                     }
+                    AddOrUpdateSymbol("Weather", SanitizeIdentifier(dataName), value);
                 }
             } else {
-                RemoveAllSymbols(source: "Weather", keysToKeep: "Connected");
+                UninitializeAllSymbols("Weather", "Connected");
             }
         }
 
@@ -997,28 +1173,23 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("Focuser", "Position", deviceInfo.Position);
                 AddOrUpdateSymbol("Focuser", "Temperature", deviceInfo.Temperature);
             } else {
-                RemoveSymbol("Focuser", "Position");
-                RemoveSymbol("Focuser", "Temperature");
+                UninitializeAllSymbols("Focuser", "Connected");
             }
         }
 
         public void UpdateDeviceInfo(Equipment.Equipment.MyFilterWheel.FilterWheelInfo deviceInfo) {
             AddOrUpdateSymbol("FilterWheel", "Connected", deviceInfo.Connected);
             if (deviceInfo.Connected) {
-                var f = _profileService.ActiveProfile.FilterWheelSettings.FilterWheelFilters;
-                foreach (FilterInfo filterInfo in f) {
-                    AddOrUpdateSymbol("Filter", SanitizeIdentifier(filterInfo.Name), filterInfo.Position);
-                }
+                ReconcileFilterSymbols(isConnected: true);
 
                 if (deviceInfo.SelectedFilter != null) {
                     AddOrUpdateSymbol("FilterWheel", "CurrentFilterIndex", deviceInfo.SelectedFilter.Position);
+                } else {
+                    AddOrUpdateSymbol("FilterWheel", "CurrentFilterIndex", null);
                 }
             } else {
-                var f = _profileService.ActiveProfile.FilterWheelSettings.FilterWheelFilters;
-                foreach (FilterInfo filterInfo in f) {
-                    RemoveSymbol("Filter", SanitizeIdentifier(filterInfo.Name));
-                }
-                RemoveSymbol("FilterWheel", "CurrentFilterIndex");
+                ReconcileFilterSymbols(isConnected: false);
+                AddOrUpdateSymbol("FilterWheel", "CurrentFilterIndex", null);
             }
         }
 
@@ -1031,20 +1202,16 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("Dome", "DomeAzimuth", deviceInfo.Azimuth, SymbolType.SYMBOL_HIDDEN);
                 AddOrUpdateSymbol("Dome", "DomeAltitude", deviceInfo.Altitude, SymbolType.SYMBOL_HIDDEN);
             } else {
-                RemoveSymbol("Dome", "ShutterStatus");
-                RemoveSymbol("Dome", "Azimuth");
-                RemoveSymbol("Dome", "Altitude");
-                RemoveSymbol("Dome", "DomeAzimuth");
-                RemoveSymbol("Dome", "DomeAltitude");
+                UninitializeAllSymbols("Dome", "Connected");
             }
         }
 
         public void UpdateDeviceInfo(SafetyMonitorInfo deviceInfo) {
             AddOrUpdateSymbol("Safety", "Connected", deviceInfo.Connected);
             if (profileService.ActiveProfile.SafetyMonitorSettings.Id != "No_Device") {
-                AddOrUpdateSymbol("Safety", "IsSafe", deviceInfo.Connected && deviceInfo.IsSafe);
+                AddOrUpdateSymbol("Safety", "IsSafe", deviceInfo.Connected ? deviceInfo.IsSafe : null);
             } else {
-                RemoveSymbol("Safety", "IsSafe");
+                AddOrUpdateSymbol("Safety", "IsSafe", null);
             }
         }
 
@@ -1061,13 +1228,7 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("Camera", "XSize", deviceInfo.XSize, SymbolType.SYMBOL_HIDDEN);
                 AddOrUpdateSymbol("Camera", "YSize", deviceInfo.YSize, SymbolType.SYMBOL_HIDDEN);
             } else {
-                RemoveSymbol("Camera", "Temperature");
-                RemoveSymbol("Camera", "TemperatureSetPoint");
-                RemoveSymbol("Camera", "CoolerOn");
-                RemoveSymbol("Camera", "CoolerPower");
-                RemoveSymbol("Camera", "PixelSize");
-                RemoveSymbol("Camera", "XSize");
-                RemoveSymbol("Camera", "YSize");
+                UninitializeAllSymbols("Camera", "Connected");
             }
         }
 
@@ -1078,9 +1239,7 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("FlatPanel", "Brightness", deviceInfo.Brightness);
                 AddOrUpdateSymbol("FlatPanel", "CoverState", (int)deviceInfo.CoverState, CoverConstants);
             } else {
-                RemoveSymbol("FlatPanel", "LightOn");
-                RemoveSymbol("FlatPanel", "Brightness");
-                RemoveSymbol("FlatPanel", "CoverState");
+                UninitializeAllSymbols("FlatPanel", "Connected");
             }
         }
 
@@ -1090,8 +1249,7 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("Rotator", "Position", deviceInfo.Position);
                 AddOrUpdateSymbol("Rotator", "MechanicalPosition", deviceInfo.MechanicalPosition);
             } else {
-                RemoveSymbol("Rotator", "Position");
-                RemoveSymbol("Rotator", "MechanicalPosition");
+                UninitializeAllSymbols("Rotator", "Connected");
             }
         }
 
@@ -1110,11 +1268,7 @@ namespace NINA.Sequencer.Logic {
                 AddOrUpdateSymbol("Guider", "PeakRA", deviceInfo.RMSError.PeakRA.Arcseconds);
                 AddOrUpdateSymbol("Guider", "PeakDec", deviceInfo.RMSError.PeakDec.Arcseconds);
             } else {
-                RemoveSymbol("Guider", "RMSTotal");
-                RemoveSymbol("Guider", "RMSRA");
-                RemoveSymbol("Guider", "RMSDec");
-                RemoveSymbol("Guider", "PeakRA");
-                RemoveSymbol("Guider", "PeakDec");
+                UninitializeAllSymbols("Guider", "Connected");
             }
         }
     }

--- a/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
+++ b/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
@@ -207,6 +207,19 @@ namespace NINA.Test.ProfileTest {
             roundTripped.FilterWheelFilters[1].AutoFocusFilter.Should().BeFalse();
         }
 
+        [Test]
+        public void SwitchSettings_RoundTrip_PreservesKnownSymbolNames() {
+            SwitchSettings settings = new SwitchSettings {
+                KnownReadonlySwitchSymbols = new List<string> { "InputVoltage", "DewPoint" },
+                KnownWritableSwitchSymbols = new List<string> { "DewHeater", "PowerPort" }
+            };
+
+            SwitchSettings roundTripped = RoundTrip(settings);
+
+            roundTripped.KnownReadonlySwitchSymbols.Should().Equal("InputVoltage", "DewPoint");
+            roundTripped.KnownWritableSwitchSymbols.Should().Equal("DewHeater", "PowerPort");
+        }
+
         /// <summary>
         /// Verifies that sequence settings recover from missing folders and template files during profile deserialization.
         /// </summary>

--- a/NINA.Test/Sequencer/Container/DeepSkyObjectContainerTest.cs
+++ b/NINA.Test/Sequencer/Container/DeepSkyObjectContainerTest.cs
@@ -289,10 +289,10 @@ namespace NINA.Test.Sequencer.Container {
         }
 
         /// <summary>
-        /// Verifies the Execute Adds Target Symbols And Removes Them After Execution scenario for the sequencer behavior under test.
+        /// Verifies the Execute Adds Target Symbols And Uninitializes Them After Execution scenario for the sequencer behavior under test.
         /// </summary>
         [Test]
-        public async Task Execute_AddsTargetSymbolsAndRemovesThemAfterExecution() {
+        public async Task Execute_AddsTargetSymbolsAndUninitializesThemAfterExecution() {
             DeepSkyObjectContainer sut = CreateSut();
             sut.Target.TargetName = "M31";
             sut.Target.InputCoordinates.Coordinates = new Coordinates(Angle.ByHours(1.5), Angle.ByDegree(42), Epoch.J2000);
@@ -304,7 +304,11 @@ namespace NINA.Test.Sequencer.Container {
             symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetRAJ2000", It.Is<object>(value => value != null && value.GetType() == typeof(double) && Math.Abs((double)value - 1.5) < 0.0001)), Times.Once);
             symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetDecJ2000", It.Is<object>(value => value != null && value.GetType() == typeof(double) && Math.Abs((double)value - 42) < 0.0001)), Times.Once);
             symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetPositionAngle", 33d), Times.Once);
-            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.RemoveSymbol(symbolProviderMock.Object, It.IsAny<string>()), Times.Exactly(4));
+            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetName", null), Times.Once);
+            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetRAJ2000", null), Times.Once);
+            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetDecJ2000", null), Times.Once);
+            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.AddOrUpdateSymbol(symbolProviderMock.Object, "TargetPositionAngle", null), Times.Once);
+            symbolBrokerMock.As<ISymbolBrokerProviderApi>().Verify(x => x.RemoveSymbol(symbolProviderMock.Object, It.IsAny<string>()), Times.Never);
         }
 
         /// <summary>

--- a/NINA.Test/Sequencer/Logic/SymbolBrokerTest.cs
+++ b/NINA.Test/Sequencer/Logic/SymbolBrokerTest.cs
@@ -45,6 +45,7 @@ namespace NINA.Test.Sequencer.Logic {
         private Mock<ITelescopeMediator> telescopeMediatorMock;
         private Mock<IGuiderMediator> guiderMediatorMock;
         private Mock<IImagingMediator> imagingMediatorMock;
+        private Mock<ISwitchSettings> switchSettingsMock;
         private SymbolBroker broker;
 
         [SetUp]
@@ -62,10 +63,15 @@ namespace NINA.Test.Sequencer.Logic {
             telescopeMediatorMock = new Mock<ITelescopeMediator>();
             guiderMediatorMock = new Mock<IGuiderMediator>();
             imagingMediatorMock = new Mock<IImagingMediator>();
+            switchSettingsMock = new Mock<ISwitchSettings>();
+            switchSettingsMock.SetupAllProperties();
+            switchSettingsMock.Object.KnownReadonlySwitchSymbols = new List<string>();
+            switchSettingsMock.Object.KnownWritableSwitchSymbols = new List<string>();
 
             profileServiceMock.SetupGet(x => x.ActiveProfile.AstrometrySettings.Latitude).Returns(10);
             profileServiceMock.SetupGet(x => x.ActiveProfile.AstrometrySettings.Longitude).Returns(20);
             profileServiceMock.SetupGet(x => x.ActiveProfile.AstrometrySettings.Elevation).Returns(30);
+            profileServiceMock.SetupGet(x => x.ActiveProfile.SwitchSettings).Returns(switchSettingsMock.Object);
 
             broker = new SymbolBroker(profileServiceMock.Object, switchMediatorMock.Object, weatherDataMediatorMock.Object, cameraMediatorMock.Object, domeMediatorMock.Object,
                 flatDeviceMediatorMock.Object, filterWheelMediatorMock.Object, rotatorMediatorMock.Object, safetyMonitorMediatorMock.Object, focuserMediatorMock.Object,
@@ -103,6 +109,16 @@ namespace NINA.Test.Sequencer.Logic {
             }
         }
 
+        private void ValidateUninitializedSymbol(string key, bool isHidden = false) {
+            broker.TryGetSymbol(key, out var symbol).Should().BeTrue(key);
+            symbol.Should().NotBeNull();
+            symbol.Value.Should().BeNull(key);
+            symbol.Type.Should().Be(isHidden ? Symbol.SymbolType.SYMBOL_HIDDEN : Symbol.SymbolType.SYMBOL_NORMAL);
+
+            broker.TryGetValue(key, out var value).Should().BeTrue(key);
+            value.Should().BeNull(key);
+        }
+
         [Test]
         public void SymbolBroker_Instance_IsInternalSingletonFallback() {
             typeof(SymbolBroker)
@@ -129,6 +145,26 @@ namespace NINA.Test.Sequencer.Logic {
             ValidateSymbol(key: "NINA_SunAltitude", expectedSuccess: true);
             ValidateSymbol(key: "NINA_MoonIllumination", expectedSuccess: true);
             ValidateSymbol(key: "NINA_MoonAltitude", expectedSuccess: true);
+        }
+
+        [Test]
+        public void SymbolBroker_FixedCoreSymbols_AreRegisteredBeforeTheirProducersRun() {
+            foreach (string key in new[] {
+                "NINA_TargetName", "NINA_TargetRAJ2000", "NINA_TargetDecJ2000", "NINA_TargetPositionAngle",
+                "Image_HFR", "Image_FWHM", "Image_Eccentricity", "Image_StarCount", "Image_Mean",
+                "Mount_Altitude", "Switch_Connected", "Weather_Temperature", "Focuser_Position",
+                "FilterWheel_CurrentFilterIndex", "Dome_ShutterStatus", "Safety_IsSafe", "Camera_Temperature",
+                "FlatPanel_LightOn", "Rotator_Position", "Guider_RMSTotal"
+            }) {
+                ValidateUninitializedSymbol(key);
+            }
+
+            foreach (string key in new[] {
+                "Image_HFRPixels", "Image_HFRArcseconds", "Camera_PixelSize", "Camera_XSize", "Camera_YSize",
+                "Dome_DomeAzimuth", "Dome_DomeAltitude"
+            }) {
+                ValidateUninitializedSymbol(key, isHidden: true);
+            }
         }
 
         [Test]
@@ -195,13 +231,13 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Camera_Temperature", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_TemperatureSetPoint", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_CoolerOn", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_CoolerPower", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_PixelSize", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_XSize", expectedSuccess: false);
-            ValidateSymbol(key: "Camera_YSize", expectedSuccess: false);
+            ValidateUninitializedSymbol("Camera_Temperature");
+            ValidateUninitializedSymbol("Camera_TemperatureSetPoint");
+            ValidateUninitializedSymbol("Camera_CoolerOn");
+            ValidateUninitializedSymbol("Camera_CoolerPower");
+            ValidateUninitializedSymbol("Camera_PixelSize", isHidden: true);
+            ValidateUninitializedSymbol("Camera_XSize", isHidden: true);
+            ValidateUninitializedSymbol("Camera_YSize", isHidden: true);
         }
 
         [Test]
@@ -233,8 +269,8 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Focuser_Position", expectedSuccess: false);
-            ValidateSymbol(key: "Focuser_Temperature", expectedSuccess: false);
+            ValidateUninitializedSymbol("Focuser_Position");
+            ValidateUninitializedSymbol("Focuser_Temperature");
         }
 
         [Test]
@@ -266,8 +302,8 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Rotator_Position", expectedSuccess: false);
-            ValidateSymbol(key: "Rotator_Temperature", expectedSuccess: false);
+            ValidateUninitializedSymbol("Rotator_Position");
+            ValidateUninitializedSymbol("Rotator_MechanicalPosition");
         }
 
         [Test]
@@ -311,10 +347,10 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "FilterWheel_CurrentFilterIndex", expectedSuccess: false);
-            ValidateSymbol(key: "Filter_Red", expectedSuccess: false);
-            ValidateSymbol(key: "Filter_Luminance", expectedSuccess: false);
-            ValidateSymbol(key: "Filter_Blue", expectedSuccess: false);
+            ValidateUninitializedSymbol("FilterWheel_CurrentFilterIndex");
+            ValidateUninitializedSymbol("Filter_Red");
+            ValidateUninitializedSymbol("Filter_Luminance");
+            ValidateUninitializedSymbol("Filter_Blue");
         }
 
         [Test]
@@ -353,6 +389,30 @@ namespace NINA.Test.Sequencer.Logic {
             ValidateSymbol(key: "Gauge_TestSwitch2", expectedSuccess: true, expectedValue: 22.2);
             ValidateSymbol(key: "Switch_TestSwitch3", expectedSuccess: true, expectedValue: 42.1);
             ValidateSymbol(key: "Switch_TestSwitch4", expectedSuccess: true, expectedValue: 52.3);
+            switchSettingsMock.Object.KnownReadonlySwitchSymbols.Should().Equal("TestSwitch1", "TestSwitch2");
+            switchSettingsMock.Object.KnownWritableSwitchSymbols.Should().Equal("TestSwitch3", "TestSwitch4");
+        }
+
+        [Test]
+        public void SymbolBroker_StartupAndProfileChange_RestoreRememberedSwitchSymbolsUninitialized() {
+            broker.Dispose();
+            switchSettingsMock.Object.KnownReadonlySwitchSymbols = new List<string> { "RememberedGauge" };
+            switchSettingsMock.Object.KnownWritableSwitchSymbols = new List<string> { "RememberedSwitch" };
+            broker = new SymbolBroker(profileServiceMock.Object, switchMediatorMock.Object, weatherDataMediatorMock.Object, cameraMediatorMock.Object, domeMediatorMock.Object,
+                flatDeviceMediatorMock.Object, filterWheelMediatorMock.Object, rotatorMediatorMock.Object, safetyMonitorMediatorMock.Object, focuserMediatorMock.Object,
+                telescopeMediatorMock.Object, guiderMediatorMock.Object, imagingMediatorMock.Object);
+
+            ValidateUninitializedSymbol("Gauge_RememberedGauge");
+            ValidateUninitializedSymbol("Switch_RememberedSwitch");
+
+            switchSettingsMock.Object.KnownReadonlySwitchSymbols = new List<string> { "NewGauge" };
+            switchSettingsMock.Object.KnownWritableSwitchSymbols = new List<string> { "NewSwitch" };
+            profileServiceMock.Raise(x => x.ProfileChanged += null, EventArgs.Empty);
+
+            ValidateSymbol("Gauge_RememberedGauge", expectedSuccess: false);
+            ValidateSymbol("Switch_RememberedSwitch", expectedSuccess: false);
+            ValidateUninitializedSymbol("Gauge_NewGauge");
+            ValidateUninitializedSymbol("Switch_NewSwitch");
         }
 
         [Test]
@@ -391,10 +451,10 @@ namespace NINA.Test.Sequencer.Logic {
 
             // Assert
             ValidateSymbol(key: "Switch_Connected", expectedSuccess: true, expectedValue: false);
-            ValidateSymbol(key: "Gauge_TestSwitch1", expectedSuccess: false);
-            ValidateSymbol(key: "Gauge_TestSwitch2", expectedSuccess: false);
-            ValidateSymbol(key: "Switch_TestSwitch3", expectedSuccess: false);
-            ValidateSymbol(key: "Switch_TestSwitch4", expectedSuccess: false);
+            ValidateUninitializedSymbol("Gauge_TestSwitch1");
+            ValidateUninitializedSymbol("Gauge_TestSwitch2");
+            ValidateUninitializedSymbol("Switch_TestSwitch3");
+            ValidateUninitializedSymbol("Switch_TestSwitch4");
         }
 
 
@@ -436,12 +496,12 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Mount_Altitude", expectedSuccess: false);
-            ValidateSymbol(key: "Mount_Azimuth", expectedSuccess: false);
-            ValidateSymbol(key: "Mount_RightAscensionJ2000", expectedSuccess: false);
-            ValidateSymbol(key: "Mount_DeclinationJ2000", expectedSuccess: false);
-            ValidateSymbol(key: "Mount_SideOfPier", expectedSuccess: false);
-            ValidateSymbol(key: "Mount_AtPark", expectedSuccess: false);
+            ValidateUninitializedSymbol("Mount_Altitude");
+            ValidateUninitializedSymbol("Mount_Azimuth");
+            ValidateUninitializedSymbol("Mount_RightAscensionJ2000");
+            ValidateUninitializedSymbol("Mount_DeclinationJ2000");
+            ValidateUninitializedSymbol("Mount_SideOfPier");
+            ValidateUninitializedSymbol("Mount_AtPark");
         }
 
         [Test]
@@ -475,9 +535,9 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "FlatPanel_LightOn", expectedSuccess: false);
-            ValidateSymbol(key: "FlatPanel_Brightness", expectedSuccess: false);
-            ValidateSymbol(key: "FlatPanel_CoverState", expectedSuccess: false);
+            ValidateUninitializedSymbol("FlatPanel_LightOn");
+            ValidateUninitializedSymbol("FlatPanel_Brightness");
+            ValidateUninitializedSymbol("FlatPanel_CoverState");
         }
 
         [Test]
@@ -542,14 +602,14 @@ namespace NINA.Test.Sequencer.Logic {
             ValidateSymbol(key: "Weather_DewPoint", expectedSuccess: true, expectedValue: info.DewPoint);
             ValidateSymbol(key: "Weather_Humidity", expectedSuccess: true, expectedValue: info.Humidity);
             ValidateSymbol(key: "Weather_Pressure", expectedSuccess: true, expectedValue: info.Pressure);
-            ValidateSymbol(key: "Weather_RainRate", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyBrightness", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyQuality", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyTemperature", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_StarFWHM", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindDirection", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindGust", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindSpeed", expectedSuccess: false);
+            ValidateUninitializedSymbol("Weather_RainRate");
+            ValidateUninitializedSymbol("Weather_SkyBrightness");
+            ValidateUninitializedSymbol("Weather_SkyQuality");
+            ValidateUninitializedSymbol("Weather_SkyTemperature");
+            ValidateUninitializedSymbol("Weather_StarFWHM");
+            ValidateUninitializedSymbol("Weather_WindDirection");
+            ValidateUninitializedSymbol("Weather_WindGust");
+            ValidateUninitializedSymbol("Weather_WindSpeed");
         }
 
         [Test]
@@ -565,20 +625,20 @@ namespace NINA.Test.Sequencer.Logic {
 
             // Assert
             ValidateSymbol(key: "Weather_Connected", expectedSuccess: true, expectedValue: false);
-            ValidateSymbol(key: "Weather_Temperature", expectedSuccess: false);
+            ValidateUninitializedSymbol("Weather_Temperature");
             ValidateSymbol(key: "Weather_AveragePeriod", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_CloudCover", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_DewPoint", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_Humidity", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_Pressure", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_RainRate", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyBrightness", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyQuality", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_SkyTemperature", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_StarFWHM", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindDirection", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindGust", expectedSuccess: false);
-            ValidateSymbol(key: "Weather_WindSpeed", expectedSuccess: false);
+            ValidateUninitializedSymbol("Weather_CloudCover");
+            ValidateUninitializedSymbol("Weather_DewPoint");
+            ValidateUninitializedSymbol("Weather_Humidity");
+            ValidateUninitializedSymbol("Weather_Pressure");
+            ValidateUninitializedSymbol("Weather_RainRate");
+            ValidateUninitializedSymbol("Weather_SkyBrightness");
+            ValidateUninitializedSymbol("Weather_SkyQuality");
+            ValidateUninitializedSymbol("Weather_SkyTemperature");
+            ValidateUninitializedSymbol("Weather_StarFWHM");
+            ValidateUninitializedSymbol("Weather_WindDirection");
+            ValidateUninitializedSymbol("Weather_WindGust");
+            ValidateUninitializedSymbol("Weather_WindSpeed");
         }
 
         [Test]
@@ -615,11 +675,11 @@ namespace NINA.Test.Sequencer.Logic {
 
             // Assert
             ValidateSymbol(key: "Dome_Connected", expectedSuccess: true, expectedValue: false);
-            ValidateSymbol(key: "Dome_ShutterStatus", expectedSuccess: false);
-            ValidateSymbol(key: "Dome_Altitude", expectedSuccess: false);
-            ValidateSymbol(key: "Dome_Azimuth", expectedSuccess: false);
-            ValidateSymbol(key: "Dome_DomeAltitude", expectedSuccess: false);
-            ValidateSymbol(key: "Dome_DomeAzimuth", expectedSuccess: false);
+            ValidateUninitializedSymbol("Dome_ShutterStatus");
+            ValidateUninitializedSymbol("Dome_Altitude");
+            ValidateUninitializedSymbol("Dome_Azimuth");
+            ValidateUninitializedSymbol("Dome_DomeAltitude", isHidden: true);
+            ValidateUninitializedSymbol("Dome_DomeAzimuth", isHidden: true);
         }
 
         [Test]
@@ -657,10 +717,11 @@ namespace NINA.Test.Sequencer.Logic {
 
             // Assert
             ValidateSymbol(key: "Guider_Connected", expectedSuccess: true, expectedValue: false);
-            ValidateSymbol(key: "Guider_PeakRA", expectedSuccess: false);
-            ValidateSymbol(key: "Guider_PeakDec", expectedSuccess: false);
-            ValidateSymbol(key: "Guider_RMSRA", expectedSuccess: false);
-            ValidateSymbol(key: "Guider_RMSDec", expectedSuccess: false);
+            ValidateUninitializedSymbol("Guider_PeakRA");
+            ValidateUninitializedSymbol("Guider_PeakDec");
+            ValidateUninitializedSymbol("Guider_RMSTotal");
+            ValidateUninitializedSymbol("Guider_RMSRA");
+            ValidateUninitializedSymbol("Guider_RMSDec");
         }
 
         [Test]
@@ -691,7 +752,7 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Safety_IsSafe", expectedSuccess: true, expectedValue: false);
+            ValidateUninitializedSymbol("Safety_IsSafe");
         }
 
         [Test]
@@ -708,7 +769,7 @@ namespace NINA.Test.Sequencer.Logic {
             broker.UpdateDeviceInfo(info);
 
             // Assert
-            ValidateSymbol(key: "Safety_IsSafe", expectedSuccess: false);
+            ValidateUninitializedSymbol("Safety_IsSafe");
         }
 
         [Test]
@@ -741,7 +802,7 @@ namespace NINA.Test.Sequencer.Logic {
             ValidateSymbol(key: "Camera_PixelSize", expectedSuccess: true, expectedValue: cameraInfo.PixelSize, isHidden: true);
             ValidateSymbol(key: "Camera_XSize", expectedSuccess: true, expectedValue: cameraInfo.XSize, isHidden: true);
             ValidateSymbol(key: "Camera_YSize", expectedSuccess: true, expectedValue: cameraInfo.YSize, isHidden: true);
-            ValidateSymbol(key: "Weather_CloudCover", expectedSuccess: false);
+            ValidateUninitializedSymbol("Weather_CloudCover");
         }
 
         [Test]
@@ -951,7 +1012,7 @@ namespace NINA.Test.Sequencer.Logic {
             await broker.SetImageStatisticsSymbolsAsync(imageDataMock.Object, -1);
 
             // Assert
-            ValidateSymbol(key: "Image_Mean", expectedSuccess: false);
+            ValidateUninitializedSymbol("Image_Mean");
         }
 
         [Test]
@@ -997,12 +1058,14 @@ namespace NINA.Test.Sequencer.Logic {
                 // Assert
                 setImageSymbolsTask.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("image statistics must not hold up ImagePrepared handling");
                 ValidateSymbol(key: "Image_ImageId", expectedSuccess: true, expectedValue: 10);
-                ValidateSymbol(key: "Image_Mean", expectedSuccess: false);
+                ValidateUninitializedSymbol("Image_Mean");
             } finally {
                 statisticsCompletion.TrySetResult(imageStatisticsMock.Object);
             }
 
-            SpinWait.SpinUntil(() => broker.TryGetValue("Image_Mean", out _), TimeSpan.FromSeconds(5)).Should().BeTrue();
+            SpinWait.SpinUntil(
+                () => broker.TryGetValue("Image_Mean", out object value) && value != null,
+                TimeSpan.FromSeconds(5)).Should().BeTrue();
         }
 
         private class LegacyStarDetectionAnalysis : IStarDetectionAnalysis {
@@ -1042,13 +1105,17 @@ namespace NINA.Test.Sequencer.Logic {
 
             broker.UpdateDeviceInfo(info);
             ValidateSymbol("Camera_Connected", true, true);
-            ValidateSymbol("FilterWheel_Connected", false, false);
-            ValidateSymbol("Connected", true, true);
+            ValidateUninitializedSymbol("FilterWheel_Connected");
+            broker.TryGetSymbol("Connected", out var ambiguousSymbol).Should().BeFalse();
+            ambiguousSymbol.Should().BeOfType<AmbiguousSymbol>();
+            broker.TryGetValue("Connected", out var ambiguousValue).Should().BeFalse();
+            ambiguousValue.Should().BeOfType<AmbiguousSymbol>();
 
             broker.UpdateDeviceInfo(new CameraInfo { Connected = false });
             ValidateSymbol("Camera_Connected", true, false);
-            ValidateSymbol("FilterWheel_Connected", false, false);
-            ValidateSymbol("Connected", true, false);
+            ValidateUninitializedSymbol("FilterWheel_Connected");
+            broker.TryGetSymbol("Connected", out ambiguousSymbol).Should().BeFalse();
+            ambiguousSymbol.Should().BeOfType<AmbiguousSymbol>();
         }
 
         [Test]
@@ -1181,6 +1248,25 @@ namespace NINA.Test.Sequencer.Logic {
             removed[0].ChangeKind.Should().Be(SymbolChangeKind.Removed);
             removed[0].OldValue.Should().Be(2);
             removed[0].NewValue.Should().BeNull();
+        }
+
+        [Test]
+        public void SymbolBroker_Disconnect_UpdatesCoreSymbolsToNullWithoutRemovingThem() {
+            broker.UpdateDeviceInfo(new CameraInfo {
+                Connected = true,
+                Temperature = -10.5,
+                TemperatureSetPoint = -15
+            });
+            List<SymbolChangedEventArgs> updated = new List<SymbolChangedEventArgs>();
+            List<SymbolChangedEventArgs> removed = new List<SymbolChangedEventArgs>();
+            broker.SymbolUpdated += (sender, args) => updated.Add(args);
+            broker.SymbolRemoved += (sender, args) => removed.Add(args);
+
+            broker.UpdateDeviceInfo(new CameraInfo { Connected = false });
+
+            updated.Should().Contain(x => x.QualifiedKey == "Camera_Temperature" && Equals(x.OldValue, -10.5) && x.NewValue == null);
+            removed.Should().NotContain(x => x.ProviderName == "Camera");
+            ValidateUninitializedSymbol("Camera_Temperature");
         }
 
         [Test]

--- a/NINA.Test/Sequencer/logic/SymbolProviderTest.cs
+++ b/NINA.Test/Sequencer/logic/SymbolProviderTest.cs
@@ -166,12 +166,12 @@ namespace NINA.Test.Sequencer.Logic {
             broker.TryGetSymbol("PierStatus", out sym).Should().BeTrue();
             //sym.Value.Should().Be(1);
 
-            broker.TryGetSymbol("PierUnknown", out sym).Should().BeTrue();
+            broker.TryGetSymbol("PierUnknown", out sym).Should().BeFalse();
+            sym.Should().BeOfType<AmbiguousSymbol>();
+            broker.TryGetSymbol("Mount_PierUnknown", out sym).Should().BeTrue();
             sym.Value.Should().Be(-1);
-            broker.TryGetSymbol("PierEast", out sym).Should().BeTrue();
+            broker.TryGetSymbol("Plugin1_PierEast", out sym).Should().BeTrue();
             sym.Value.Should().Be(0);
-            broker.TryGetSymbol("PierWest", out sym).Should().BeTrue();
-            sym.Value.Should().Be(1);
             broker.TryGetSymbol("Plugin1_PierWest", out sym).Should().BeTrue();
             sym.Value.Should().Be(1);
         }


### PR DESCRIPTION


<!--
🎯 Thank you for contributing to N.I.N.A.! Please fill out the template below to help us review your PR effectively.
-->

## 🚀 Purpose

<!-- Briefly describe the goal of this pull request. What feature, fix, or improvement does it bring? -->
Core Symbols are no longer removed when not available, instead they are always shown but initialized with null values, so it is easier to see what's available.

## 🧪 How Was It Tested?

<!-- Describe how you tested your changes. Include manual tests, automated tests, and testing across themes or configurations. -->
Manual testing via UI testing

## 🤖 AI / Tooling Disclosure

<!-- If meaningful AI- or tool-generated content was used, list the tool or model used.
If not, write "None". -->
Codex 5.6 was used to assist

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [ ] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->
No Issues, but requested a bunch of times via Discord.

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
