### PR TITLE
QHY: cooler is never turned off on disconnect

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/QHYCamera.cs
@@ -973,13 +973,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
                         Info.CoolerTargetTemp = 0;
                     }
 
-                    /*
-                     * Force any TEC cooler to off upon startup
-                     */
                     if (!internalReconnect) {
-                        CoolerOn = false;
-                        CancelCoolingSync();
-
                         /*
                          * Start the thread that operates the TEC
                          * This thread will operate the TEC in accordance with the user turning the cooler on or off
@@ -1088,9 +1082,16 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
             try {
                 if (!internalReconnect) {
-                    Connected = false;
+                    /*
+                     * CancelCoolingSync() returns immediately while Connected is false, so the
+                     * workers have to be shut down before the flag is cleared. Clearing it first
+                     * skipped the whole cooler teardown: the CoolerWorker task and its
+                     * CancellationTokenSource were left running and the TEC was never commanded
+                     * off, so the camera kept cooling after NINA released it.
+                     */
                     CancelCoolingSync();
                     CancelSensorStatsSync();
+                    Connected = false;
                     Logger.Info($"QHYCCD: Closing camera {Info.Id}");
                 }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@ This allows you to safely return to a stable release if needed.
 - Image save failures in the asynchronous save queue now raise a persistent notification and are forwarded into the active sequence failure event stream.
 - QHY cameras now re-apply gain and offset after a read mode change. Previously a frame taken across a read mode switch was exposed with the new mode's power-on defaults while its metadata still recorded the requested values.
 - QHY cameras connected in a read mode that fixes the offset in hardware, such as Linearity HDR, no longer misreport their offset for the remainder of the session.
+- QHY cameras now really have their cooler turned off when they are disconnected. The cooler shutdown was skipped on every disconnect, so a camera that was cooling kept regulating to its old set point after being disconnected or after N.I.N.A. was closed, while the next session reported the cooler as off.
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
## 🚀 Purpose

`QHYCamera.Disconnect()` clears `Connected` before calling `CancelCoolingSync()`. That method returns immediately when `Connected` is false, so the cooler teardown never runs: the TEC is never commanded off, and the `CoolerWorker` task and its `CancellationTokenSource` leak across every disconnect. A camera that was cooling therefore keeps regulating to its last set point after N.I.N.A. releases it, while the next session reports the cooler as off because `Info.CoolerOn` starts out false.

The workers are now shut down before the flag is cleared.

The same early-return also made the `CoolerOn = false; CancelCoolingSync();` pair in `ConnectSync()` a no-op (`Connected` is only set at the end of that method). Those two lines are removed rather than repaired: forcing a cooler that is already running to off on connect is not wanted (see #319), and leaving dead code that reads as if it does is worse.

## 🧪 How Was It Tested?

QHYminiCam8M on the native QHY driver, SDK `25-4-23-15`, USB driver `25.6.13.908`, firmware `9-4-8`. Built from this change against `Version-3.2` and driven through the Advanced API so `CoolerOn`, `CoolerPower` (`CONTROL_CURPWM`) and `Temperature` (`CONTROL_CURTEMP`) are the same values the UI binds to. Ambient 17.3 °C.

- **Before.** Cool to 0 °C, close N.I.N.A. normally, reconnect 5.5 minutes later: `CoolerOn=False`, `CoolerPower=0%`, temperature still exactly `0.00 °C`. Same result at −10 °C. An in-app disconnect/reconnect while cooling never stops the TEC either, and the reconnect comes back regulating to 0 °C because `ConnectSync()` resets `CoolerTargetTemp` while `CoolerOn` survives as true.
- **After.** Same graceful-shutdown path from −10 °C: on reconnect the sensor has drifted to 14.6 °C and continues toward ambient, with `CoolerOn=False` / `CoolerPower=0%`. An in-app disconnect while cooling at −10 °C leaves the sensor warming (9.7 °C after 60 s). Cooling again after reconnect, and a full warm-up to ambient, both behave normally.
- **Unit tests.** Debug `NINA.Test`: 5270 passed, 16 skipped, 3 failed. A pristine `develop` in the same environment produces the same three failures (`CustomHorizon_AboveHorizon_CheckFalse`, `StandardHorizon_AboveHorizon_CheckFalse`, `ExprConverter_HandlesSentinelsLiteralsExpressionsBooleansAndComboValues`), so this change introduces none of them. `NINA.Equipment` builds with 0 warnings and 0 errors.

## 🤖 AI / Tooling Disclosure

The code change, the release notes entry and this description were drafted with the help of Cursor's agent. I reviewed all of it, and every behavioural claim above was verified by me on the camera described. I take responsibility for its correctness.

## ✅ PR Checklist

- [x] All unit tests pass — the three failures above are pre-existing on `develop`
- [ ] UI changes tested across Light, Dark, and Night themes — not applicable, no UI changes
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated — not applicable

## 🔗 Related Issues

Supersedes the closed #319. No open tracker issue for this.

## 📸 Screenshots

Not applicable, no UI changes.

## 📝 Additional Notes

The `internalReconnect` path (live-view mode switch) is untouched and still preserves cooling across it. If N.I.N.A. is killed or the machine loses power while cooling, the camera stays cold and the next connect still shows the cooler as off: while the camera is autonomously holding a set point, `CONTROL_CURPWM` reads 0 on this model, and the SDK has no cooler-on or target-temperature query, so there is nothing to adopt from on connect.
