### PR TITLE
Apply the exposure readout mode before gain and offset

### DIFF
--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -662,6 +662,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
             return new AsyncEnumerable<IExposureData>(async yield => {
                 if (CameraInfo.Connected) {
                     try {
+                        ApplyReadoutModeForSequence(sequence);
                         SetGain(sequence.Gain);
                         SetOffset(sequence.Offset);
                         if (sequence.Binning == null) {
@@ -718,6 +719,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
 
         public async Task Capture(CaptureSequence sequence, CancellationToken token, IProgress<ApplicationStatus> progress) {
             if (CameraInfo.Connected == true) {
+                ApplyReadoutModeForSequence(sequence);
                 SetGain(sequence.Gain);
                 SetOffset(sequence.Offset);
                 if (sequence.Binning == null) {
@@ -802,6 +804,13 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                 Cam.ReadoutMode = CameraInfo.ReadoutMode = mode;
                 BroadcastCameraInfo();
             }
+        }
+
+        private void ApplyReadoutModeForSequence(CaptureSequence sequence) {
+            short mode = sequence.ImageType == CaptureSequence.ImageTypes.SNAPSHOT
+                ? Cam.ReadoutModeForSnapImages
+                : Cam.ReadoutModeForNormalImages;
+            SetReadoutMode(mode);
         }
 
         public void SetUSBLimit(int usbLimit) {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,7 @@ This allows you to safely return to a stable release if needed.
 - QHY cameras now re-apply gain and offset after a read mode change. Previously a frame taken across a read mode switch was exposed with the new mode's power-on defaults while its metadata still recorded the requested values.
 - QHY cameras connected in a read mode that fixes the offset in hardware, such as Linearity HDR, no longer misreport their offset for the remainder of the session.
 - QHY cameras now really have their cooler turned off when they are disconnected. The cooler shutdown was skipped on every disconnect, so a camera that was cooling kept regulating to its old set point after being disconnected or after N.I.N.A. was closed, while the next session reported the cooler as off.
+- Captures now switch to the exposure's readout mode before applying gain and offset, so the first frame after a mode change is digitized and logged with the settings for that mode.
 
 ## Improvements
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
## 🚀 Purpose

`CameraVM.Capture` applied gain and offset, logged `CameraInfo`, then left `StartExposure` to switch readout mode. On cameras that reinitialize when the mode changes, the first frame after a switch is digitized with the previous mode's analog settings, and the capture log reports those leftover values.

Capture and LiveView now switch to the exposure's snap or normal readout mode before commanding gain and offset. `StartExposure` still applies the mode as well.

## 🧪 How Was It Tested?

QHYminiCam8M on the native QHY driver. Camera left in Linearity HDR (gain 9 / offset 100), with snap and normal readout modes set to Full Resolution.

- First SNAPSHOT after that switch: capture log, FITS key and pedestal were Full Resolution gain 80 / offset 50. A second SNAPSHOT in the same mode matched (mean 3315.0 vs 3314.9).
- First LIGHT after returning to Linearity HDR, requested at gain 137: Full Resolution gain 137 / offset 50, matching a second 137 frame (mean 3902 vs 3908) and distinct from gain 80 (mean 3306).
- LIGHT taken in Linearity HDR still records gain 9 / offset 100 (mean 409).

## 🤖 AI / Tooling Disclosure

The code change, the release notes entry and this description were drafted with the help of Cursor's agent. I reviewed all of it, and the hardware results above were taken on the camera described. I take responsibility for its correctness.

## ✅ PR Checklist

- [ ] All unit tests pass — not run; there are no CameraVM tests for this path. Verification is the hardware run above.
- [ ] UI changes tested across Light, Dark, and Night themes — not applicable, no UI changes
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated — not applicable

## 🔗 Related Issues

Follow-up to #331, which restores gain and offset inside the QHY read mode setter after `InitQHYCCD`. This change moves the mode switch earlier so those analog settings are commanded in the mode that will actually expose.

## 📸 Screenshots

Not applicable, no UI changes.

## 📝 Additional Notes

Private helper only; no public API change.