### PR TITLE
Fix missing and mismatched files during installer upgrades and repairs

### DIFF
--- a/NINA.Setup/ARCHITECTURE.md
+++ b/NINA.Setup/ARCHITECTURE.md
@@ -38,6 +38,12 @@ From the code, the MSI is responsible for:
 
 The file layout in the MSI mirrors the runtime layout expected by the executable and libraries.
 
+## Upgrade File Replacement
+
+`Product.wxs` schedules `REINSTALLMODE=amus` before `CostInitialize` in both MSI sequences. This must be a scheduled property assignment rather than a Property-table default because Burn supplies its own `REINSTALLMODE` value on the MSI command line. The scheduled assignment makes file costing replace every packaged file during upgrade and repair, including files that are missing, locally changed or report a higher version than the packaged file.
+
+`Tests/InstallerUpgradeFileBehavior.ps1` verifies this through two isolated full-payload Burn bundles. It covers missing, lower-version, equal-version mismatch, higher-version and modified unversioned files. It also covers `Newtonsoft.Json.dll` as a third-party dependency and verifies that an unrelated sentinel is preserved. The harness uses test-only product, bundle, component, registry and install-directory identities and confirms that existing N.I.N.A. registrations and selected file hashes are unchanged after cleanup.
+
 ## Project References And Harvesting
 
 `NINA.Setup.wixproj` references the built outputs of:
@@ -72,3 +78,4 @@ It should contain installer authoring and packaging rules, not application logic
 - If a runtime feature requires a new shipped file or directory, verify both the executable project output and this WiX authoring.
 - Keep the install layout aligned with the paths the runtime code expects, especially under `External`, `Database`, `Utility`, and `Sequencer`.
 - Package behavior such as shortcuts, registry entries, and custom actions belongs here, not in the main application project.
+- Keep the scheduled `REINSTALLMODE=amus` assignment before file costing. A Property-table default can be overwritten by the Burn command line and can cause a skipped higher-version file to be removed during a major upgrade.

--- a/NINA.Setup/Product.wxs
+++ b/NINA.Setup/Product.wxs
@@ -33,8 +33,23 @@
   <Package Name="N.I.N.A. - Nighttime Imaging 'N' Astronomy" Language="1033" Version="!(bind.fileVersion.NINA.exe)" Manufacturer="N.I.N.A." UpgradeCode="5DC025EA-3D24-4E6B-9F82-79718D70896A" InstallerVersion="200">
     
 
-    <!--https://learn.microsoft.com/en-us/windows/win32/msi/reinstallmode-->
-    <Property Id="REINSTALLMODE" Value="amus" />
+    <!-- A Property-table default is not sufficient here because Burn supplies
+         REINSTALLMODE=muso for upgrades and REINSTALLMODE=cmuse for repairs on the
+         MSI command line, which takes precedence over that default. Those modes let
+         MSI file-versioning rules skip a changed or higher-version file. During a
+         major upgrade the old product can then remove that skipped file, leaving it
+         missing instead of installing the packaged copy.
+
+         Reassert "amus" with a scheduled SetProperty action so "a" forces every
+         packaged file to be reinstalled regardless of checksum or version. It must
+         run before CostInitialize because file replacement decisions are made during
+         costing. Sequence="both" applies the override to the UI and execute sequences
+         (and is stated explicitly even though it is the WiX default), covering both
+         direct MSI UI and Burn/quiet execution paths.
+
+         https://learn.microsoft.com/en-us/windows/win32/msi/reinstallmode
+         https://learn.microsoft.com/en-us/windows/win32/msi/costinitialize-action -->
+    <SetProperty Id="REINSTALLMODE" Value="amus" Before="CostInitialize" Sequence="both" />
         
     <Icon Id="Logo_Nina.ico" SourceFile="Logo_Nina.ico" />
     <Property Id="ARPPRODUCTICON" Value="Logo_Nina.ico" />

--- a/NINA.SetupBundle/ARCHITECTURE.md
+++ b/NINA.SetupBundle/ARCHITECTURE.md
@@ -25,6 +25,8 @@ The bundle:
 
 The bundle is therefore a thin outer installer shell around the MSI, not a second independent package definition.
 
+Burn controls the MSI command line for install and repair, including `REINSTALLMODE`. The chained MSI deliberately reasserts its required file-replacement mode before file costing. Do not rely on an MSI Property-table default for a value that Burn passes on the command line.
+
 ## Build-Time Responsibilities
 
 `NINA.SetupBundle.wixproj` also performs build-pipeline work:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- Installer upgrades and repairs now restore missing, locally changed and higher-version application files instead of potentially leaving skipped files absent.
 - Autofocus after HFR Increase HFRTrendPercentage is now calculated correctly and will no longer underestimate the change on large HFR drift
 - ToupTek based filter wheels and focusers will no longer be listed in the camera connector.
 - When updating the application, the color schema upgrades now properly apply updated or added colors


### PR DESCRIPTION
## Purpose
Fix upgrades and repairs leaving packaged files missing or unchanged. The MSI now forces `REINSTALLMODE=amus` before file costing, overriding Burn's `muso` and `cmuse` values.

## How Was It Tested?
- Reproduced the bug with the unpatched installer.
- Tested upgrade and repair with missing, lower-version, equal-version mismatched, higher-version and modified unversioned files.
- Verified the patched installer restored every tested file to the packaged hash.
- Verified an unrelated sentinel file and the existing N.I.N.A. installation remained unchanged.
- Confirmed installer logs set `amus` before costing.

## AI / Tooling Disclosure
OpenAI Codex was used for diagnosis

## ✅ PR Checklist
- [ ] All unit tests pass
- [x] UI theme testing not applicable
- [x] Plugin API compatibility reviewed
  - [x] No breaking interface changes
  - [x] No method or class signature changes
- [x] `RELEASE_NOTES.md` updated
- [x] External documentation not applicable

## Related Issues
None.

## Screenshots
Not applicable.

## Additional Notes
No runtime, UI or plugin API behavior changed. The installer test harness was run locally and is not included in this PR.