### PR TITLE
Add PHD2 Star Mass and SNR guide graph overlays

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -8079,4 +8079,16 @@ This is useful when a built-in trigger has the timing you need, but you want cus
   <data name="Lbl_SequenceTrigger_TriggerOnUnsafe_AfterWaitingUntilSafe_HelpDescription" xml:space="preserve">
     <value>Instructions that run after conditions are safe again.</value>
   </data>
+  <data name="LblPHD2GuideChartShowStarMass" xml:space="preserve">
+    <value>Show Star Mass in Guide Graph</value>
+  </data>
+  <data name="LblPHD2GuideChartShowSNR" xml:space="preserve">
+    <value>Show Star SNR in Guide Graph</value>
+  </data>
+  <data name="LblStarMass" xml:space="preserve">
+    <value>Star Mass</value>
+  </data>
+  <data name="LblStarSNR" xml:space="preserve">
+    <value>Star SNR</value>
+  </data>
 </root>

--- a/NINA.Equipment/Equipment/GuideStepsHistory.cs
+++ b/NINA.Equipment/Equipment/GuideStepsHistory.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NINA.Core.Model;
 using NINA.Core.Interfaces;
+using NINA.Equipment.Equipment.MyGuider.PHD2.PhdEvents;
 
 namespace NINA.Equipment.Equipment {
 
@@ -225,10 +226,13 @@ namespace NINA.Equipment.Equipment {
             public double DECDistanceRaw { get; private set; }
             public double DECDistanceRawDisplay { get; private set; }
             public double DECDuration { get; private set; }
+            public double StarMass { get; private set; } = double.NaN;
+            public double SNR { get; private set; } = double.NaN;
             public double Dither { get; private set; } = double.NaN;
 
             public static HistoryStep FromGuideStep(IGuideStep guideStep, double pixelScale) {
                 var id = idProvider++;
+                var phd2GuideStep = guideStep as PhdEventGuideStep;
                 return new HistoryStep() {
                     Id = id,
                     RADistanceRaw = guideStep.RADistanceRaw,
@@ -236,7 +240,9 @@ namespace NINA.Equipment.Equipment {
                     RADuration = guideStep.RADuration,
                     DECDistanceRaw = guideStep.DECDistanceRaw,
                     DECDistanceRawDisplay = guideStep.DECDistanceRaw * pixelScale,
-                    DECDuration = guideStep.DECDuration
+                    DECDuration = guideStep.DECDuration,
+                    StarMass = phd2GuideStep?.StarMass ?? double.NaN,
+                    SNR = phd2GuideStep?.SNR ?? double.NaN
                 };
             }
 
@@ -263,6 +269,8 @@ namespace NINA.Equipment.Equipment {
                     DECDistanceRaw = this.DECDistanceRaw,
                     DECDistanceRawDisplay = this.DECDistanceRaw * pixelScale,
                     DECDuration = this.DECDuration,
+                    StarMass = this.StarMass,
+                    SNR = this.SNR,
                     Dither = this.Dither
                 };
             }

--- a/NINA.Profile/GuiderSettings.cs
+++ b/NINA.Profile/GuiderSettings.cs
@@ -40,6 +40,8 @@ namespace NINA.Profile {
             pHD2InstanceNumber = 1;
             pHD2LargeHistorySize = 100;
             pHD2GuiderScale = GuiderScaleEnum.PIXELS;
+            pHD2GuideChartShowStarMass = false;
+            pHD2GuideChartShowSNR = false;
             phd2ROIPct = 100;
             settlePixels = 1.5;
             settleTimeout = 40;
@@ -205,6 +207,32 @@ namespace NINA.Profile {
             set {
                 if (pHD2GuiderScale != value) {
                     pHD2GuiderScale = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool pHD2GuideChartShowStarMass;
+
+        [DataMember]
+        public bool PHD2GuideChartShowStarMass {
+            get => pHD2GuideChartShowStarMass;
+            set {
+                if (pHD2GuideChartShowStarMass != value) {
+                    pHD2GuideChartShowStarMass = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private bool pHD2GuideChartShowSNR;
+
+        [DataMember]
+        public bool PHD2GuideChartShowSNR {
+            get => pHD2GuideChartShowSNR;
+            set {
+                if (pHD2GuideChartShowSNR != value) {
+                    pHD2GuideChartShowSNR = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Profile/Interfaces/IGuiderSettings.cs
+++ b/NINA.Profile/Interfaces/IGuiderSettings.cs
@@ -23,6 +23,8 @@ namespace NINA.Profile.Interfaces {
         double DitherPixels { get; set; }
         bool DitherRAOnly { get; set; }
         GuiderScaleEnum PHD2GuiderScale { get; set; }
+        bool PHD2GuideChartShowStarMass { get; set; }
+        bool PHD2GuideChartShowSNR { get; set; }
         double MaxY { get; set; }
         int PHD2HistorySize { get; set; }
         int PHD2ServerPort { get; set; }

--- a/NINA.Test/GuideStepsHistoryTest.cs
+++ b/NINA.Test/GuideStepsHistoryTest.cs
@@ -22,6 +22,7 @@ using NINA.Core.Interfaces;
 using NINA.Equipment.Equipment;
 using NINA.Equipment.Equipment.MyGuider.PHD2.PhdEvents;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework.Legacy;
 
 namespace NINA.Test {
@@ -117,6 +118,40 @@ namespace NINA.Test {
             Assert.That(gsh.RMS.Dec, Is.EqualTo(630));
             var total = Math.Sqrt((Math.Pow(300, 2) + Math.Pow(630, 2)));
             Assert.That(gsh.RMS.Total, Is.EqualTo(total));
+        }
+
+        [Test]
+        public void GuideStepsHistory_PHD2GuideStep_PreservesStarMetricsThroughResizeAndScaleChanges() {
+            GuideStepsHistory history = new GuideStepsHistory(2, GuiderScaleEnum.PIXELS, 4);
+            history.AddGuideStep(new PhdEventGuideStep {
+                RADistanceRaw = 1,
+                DECDistanceRaw = 2,
+                StarMass = 1234.5,
+                SNR = 27.25
+            });
+            history.AddGuideStep(new PhdEventGuideStep { StarMass = 900, SNR = 20 });
+            history.AddGuideStep(new PhdEventGuideStep { StarMass = 800, SNR = 15 });
+
+            history.GuideSteps.Select(step => step.StarMass).Should().Equal(900, 800);
+            history.GuideSteps.Select(step => step.SNR).Should().Equal(20, 15);
+
+            history.HistorySize = 3;
+            history.PixelScale = 2;
+            history.Scale = GuiderScaleEnum.ARCSECONDS;
+
+            history.GuideSteps.Select(step => step.StarMass).Should().Equal(1234.5, 900, 800);
+            history.GuideSteps.Select(step => step.SNR).Should().Equal(27.25, 20, 15);
+        }
+
+        [Test]
+        public void GuideStepsHistory_NonPHD2AndDitherSteps_UseNaNForStarMetrics() {
+            GuideStepsHistory history = new GuideStepsHistory(3, GuiderScaleEnum.PIXELS, 4);
+            Mock<IGuideStep> genericStep = new Mock<IGuideStep>();
+
+            history.AddGuideStep(genericStep.Object);
+            history.AddDitherIndicator();
+
+            history.GuideSteps.Should().OnlyContain(step => double.IsNaN(step.StarMass) && double.IsNaN(step.SNR));
         }
 
         [Test]

--- a/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
+++ b/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
@@ -321,6 +321,22 @@ namespace NINA.Test.ProfileTest {
             roundTripped.ShowHorizon.Should().BeTrue();
         }
 
+        [Test]
+        public void GuiderSettings_PHD2StarMetricVisibility_RoundTripsWithCompatibleDefaults() {
+            GuiderSettings defaults = new GuiderSettings();
+            GuiderSettings settings = new GuiderSettings {
+                PHD2GuideChartShowStarMass = true,
+                PHD2GuideChartShowSNR = true
+            };
+
+            GuiderSettings roundTripped = RoundTrip(settings);
+
+            defaults.PHD2GuideChartShowStarMass.Should().BeFalse();
+            defaults.PHD2GuideChartShowSNR.Should().BeFalse();
+            roundTripped.PHD2GuideChartShowStarMass.Should().BeTrue();
+            roundTripped.PHD2GuideChartShowSNR.Should().BeTrue();
+        }
+
         private static List<string> CapturePropertyChanges(INotifyPropertyChanged source) {
             List<string> propertyNames = new List<string>();
             source.PropertyChanged += (object sender, PropertyChangedEventArgs args) => propertyNames.Add(args.PropertyName);

--- a/NINA.Test/View/GuiderChartViewTest.cs
+++ b/NINA.Test/View/GuiderChartViewTest.cs
@@ -1,0 +1,164 @@
+#region "copyright"
+
+/*
+    Copyright (c) 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.View;
+using NINA.View.Equipment;
+using NINA.View.Equipment.Guider;
+using NUnit.Framework;
+using OxyPlot.Wpf;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+
+namespace NINA.Test.View {
+
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [NonParallelizable]
+    public class GuiderChartViewTest {
+
+        [TestCase(typeof(GuiderGraph))]
+        [TestCase(typeof(AnchorableGuiderView))]
+        [TestCase(typeof(PHD2DetailView))]
+        [TestCase(typeof(PHD2SetupView))]
+        public void ChangedGuiderViews_ConstructAtRuntime(Type viewType) {
+            EnsureApplicationResources();
+
+            UserControl view = (UserControl)Activator.CreateInstance(viewType)!;
+            using TestWindow host = new TestWindow { Content = view };
+
+            host.Measure(new Size(1280, 800));
+            host.Arrange(new Rect(0, 0, 1280, 800));
+            host.UpdateLayout();
+        }
+
+        [TestCase(typeof(GuiderGraph))]
+        [TestCase(typeof(AnchorableGuiderView))]
+        public void GuideCharts_UseIndependentUpperHalfAxesForPHD2StarMetrics(Type viewType) {
+            EnsureApplicationResources();
+            UserControl view = (UserControl)Activator.CreateInstance(viewType)!;
+            Plot plot = FindDescendants<Plot>(view).Single();
+
+            AssertMetricSeries(plot, "StarMass", "StarMassAxis", "PHD2GuideChartShowStarMass");
+            AssertMetricSeries(plot, "SNR", "StarSNRAxis", "PHD2GuideChartShowSNR");
+        }
+
+        [TestCase(typeof(PHD2DetailView))]
+        [TestCase(typeof(PHD2SetupView))]
+        public void PHD2Options_ExposeBothStarMetricToggles(Type viewType) {
+            EnsureApplicationResources();
+            UserControl view = (UserControl)Activator.CreateInstance(viewType)!;
+            HashSet<string> paths = FindDescendants<CheckBox>(view)
+                .Select(checkBox => BindingOperations.GetBinding(checkBox, ToggleButton.IsCheckedProperty)?.Path?.Path)
+                .OfType<string>()
+                .ToHashSet();
+
+            paths.Should().Contain("PHD2GuideChartShowStarMass");
+            paths.Should().Contain("PHD2GuideChartShowSNR");
+        }
+
+        private static void AssertMetricSeries(Plot plot, string dataFieldY, string axisKey, string settingPath) {
+            LineSeries series = plot.Series.OfType<LineSeries>().Single(candidate => candidate.DataFieldY == dataFieldY);
+            LinearAxis axis = plot.Axes.OfType<LinearAxis>().Single(candidate => candidate.Key == axisKey);
+            Binding? visibilityBinding = BindingOperations.GetBinding(series, UIElement.VisibilityProperty);
+
+            series.YAxisKey.Should().Be(axisKey);
+            axis.Minimum.Should().Be(0);
+            axis.MinimumPadding.Should().Be(0);
+            axis.MaximumPadding.Should().Be(0);
+            axis.StartPosition.Should().Be(0.5);
+            axis.EndPosition.Should().Be(1);
+            visibilityBinding.Should().NotBeNull();
+            visibilityBinding!.Path.Path.Should().EndWith(settingPath);
+        }
+
+        private static IEnumerable<T> FindDescendants<T>(DependencyObject parent) where T : DependencyObject {
+            foreach (object item in LogicalTreeHelper.GetChildren(parent)) {
+                if (item is not DependencyObject child) {
+                    continue;
+                }
+                if (child is T result) {
+                    yield return result;
+                }
+                foreach (T descendant in FindDescendants<T>(child)) {
+                    yield return descendant;
+                }
+            }
+        }
+
+        private static void EnsureApplicationResources() {
+            const string resourcesLoadedMarker = "GuiderChartViewTest.ResourcesLoaded";
+            Application app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            if (app.Resources.Contains(resourcesLoadedMarker)) {
+                return;
+            }
+
+            string[] resourceSources = [
+                "/NINA.WPF.Base;component/Resources/StaticResources/ProfileService.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/SVGDictionary.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Brushes.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Converters.xaml",
+                "/NINA;component/Resources/StaticResources/DataTemplates.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Button.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Path.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBlock.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TabControl.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/CheckBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/DataGrid.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ListView.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/GroupBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/RepeatButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ToggleButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Slider.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Expander.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ScrollViewer.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ComboBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/GridSplitter.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ProgressBar.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Tooltip.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/CancellableButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/DatePicker.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/StepperControl.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ContextMenu.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/SplitButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ColorPicker.xaml",
+                "/NINA;component/Resources/Styles/Window.xaml",
+                "/NINA;component/Resources/Styles/AvalonDock.xaml",
+                "/NINA;component/Resources/Styles/Oxyplot.xaml",
+                "/NINA;component/Resources/Styles/Markdown.xaml"
+            ];
+
+            foreach (string resourceSource in resourceSources) {
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary {
+                    Source = new Uri(resourceSource, UriKind.Relative)
+                });
+            }
+            app.Resources[resourcesLoadedMarker] = true;
+        }
+
+        private sealed class TestWindow : Window, IDisposable {
+
+            public void Dispose() {
+                Close();
+            }
+        }
+    }
+}

--- a/NINA/View/Equipment/Guider/GuiderGraph.xaml
+++ b/NINA/View/Equipment/Guider/GuiderGraph.xaml
@@ -110,6 +110,30 @@
                     Minimum="{Binding MinDurationY}"
                     Position="Right" />
                 <oxy:LinearAxis
+                    Key="StarMassAxis"
+                    EndPosition="1"
+                    IsAxisVisible="False"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MaximumPadding="0"
+                    Minimum="0"
+                    MinimumPadding="0"
+                    Position="Right"
+                    StartPosition="0.5"
+                    Title="{ns:Loc LblStarMass}" />
+                <oxy:LinearAxis
+                    Key="StarSNRAxis"
+                    EndPosition="1"
+                    IsAxisVisible="False"
+                    IsPanEnabled="False"
+                    IsZoomEnabled="False"
+                    MaximumPadding="0"
+                    Minimum="0"
+                    MinimumPadding="0"
+                    Position="Right"
+                    StartPosition="0.5"
+                    Title="{ns:Loc LblStarSNR}" />
+                <oxy:LinearAxis
                     Key="TextAxisX"
                     IsAxisVisible="False"
                     Maximum="1"
@@ -171,6 +195,24 @@
                     XAxisKey="DataAxisX"
                     YAxisKey="DistanceAxis"
                     Color="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.GuiderSettings.GuideChartDeclinationColor}" />
+                <oxy:LineSeries
+                    Title="{ns:Loc LblStarMass}"
+                    DataFieldX="Id"
+                    DataFieldY="StarMass"
+                    ItemsSource="{Binding GuideSteps}"
+                    Visibility="{Binding Path=ActiveProfile.GuiderSettings.PHD2GuideChartShowStarMass, Source={StaticResource ProfileService}, Converter={StaticResource VisibilityConverter}}"
+                    XAxisKey="DataAxisX"
+                    YAxisKey="StarMassAxis"
+                    Color="Yellow" />
+                <oxy:LineSeries
+                    Title="{ns:Loc LblStarSNR}"
+                    DataFieldX="Id"
+                    DataFieldY="SNR"
+                    ItemsSource="{Binding GuideSteps}"
+                    Visibility="{Binding Path=ActiveProfile.GuiderSettings.PHD2GuideChartShowSNR, Source={StaticResource ProfileService}, Converter={StaticResource VisibilityConverter}}"
+                    XAxisKey="DataAxisX"
+                    YAxisKey="StarSNRAxis"
+                    Color="White" />
                 <oxy:LineSeries
                     Title="{ns:Loc LblDither}"
                     DataFieldX="Id"

--- a/NINA/View/Equipment/Guider/PHD2DetailView.xaml
+++ b/NINA/View/Equipment/Guider/PHD2DetailView.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     Copyright (c) 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
 
     This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
@@ -105,6 +105,28 @@
                         </Binding>
                     </TextBox.Text>
                 </ninactrl:UnitTextBox>
+            </UniformGrid>
+            <UniformGrid
+                Margin="0,5,0,0"
+                VerticalAlignment="Center"
+                Columns="2"
+                DataContext="{Binding DataContext.ActiveProfile.GuiderSettings, RelativeSource={RelativeSource AncestorType=local:GuiderView}}">
+                <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblPHD2GuideChartShowStarMass}" />
+                <CheckBox
+                    Height="25"
+                    HorizontalAlignment="Left"
+                    IsChecked="{Binding PHD2GuideChartShowStarMass}" />
+            </UniformGrid>
+            <UniformGrid
+                Margin="5,5,0,0"
+                VerticalAlignment="Center"
+                Columns="2"
+                DataContext="{Binding DataContext.ActiveProfile.GuiderSettings, RelativeSource={RelativeSource AncestorType=local:GuiderView}}">
+                <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblPHD2GuideChartShowSNR}" />
+                <CheckBox
+                    Height="25"
+                    HorizontalAlignment="Left"
+                    IsChecked="{Binding PHD2GuideChartShowSNR}" />
             </UniformGrid>
             <UniformGrid
                 Margin="0,5,0,0"

--- a/NINA/View/Equipment/Guider/PHD2SetupView.xaml
+++ b/NINA/View/Equipment/Guider/PHD2SetupView.xaml
@@ -285,6 +285,33 @@
                 </ninactrl:UnitTextBox>
             </UniformGrid>
 
+            <UniformGrid
+                Margin="0,5,0,0"
+                VerticalAlignment="Center"
+                Columns="2"
+                DataContext="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.GuiderSettings}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Text="{ns:Loc LblPHD2GuideChartShowStarMass}" />
+                <CheckBox
+                    Height="25"
+                    HorizontalAlignment="Left"
+                    IsChecked="{Binding PHD2GuideChartShowStarMass}" />
+            </UniformGrid>
+            <UniformGrid
+                Margin="0,5,0,0"
+                VerticalAlignment="Center"
+                Columns="2"
+                DataContext="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.GuiderSettings}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Text="{ns:Loc LblPHD2GuideChartShowSNR}" />
+                <CheckBox
+                    Height="25"
+                    HorizontalAlignment="Left"
+                    IsChecked="{Binding PHD2GuideChartShowSNR}" />
+            </UniformGrid>
+
             <Button
                 Grid.Row="1"
                 Grid.Column="0"

--- a/NINA/View/Imaging/AnchorableGuiderView.xaml
+++ b/NINA/View/Imaging/AnchorableGuiderView.xaml
@@ -152,6 +152,30 @@
                         Minimum="{Binding MinDurationY}"
                         Position="Right" />
                     <oxy:LinearAxis
+                        Key="StarMassAxis"
+                        EndPosition="1"
+                        IsAxisVisible="False"
+                        IsPanEnabled="False"
+                        IsZoomEnabled="False"
+                        MaximumPadding="0"
+                        Minimum="0"
+                        MinimumPadding="0"
+                        Position="Right"
+                        StartPosition="0.5"
+                        Title="{ns:Loc LblStarMass}" />
+                    <oxy:LinearAxis
+                        Key="StarSNRAxis"
+                        EndPosition="1"
+                        IsAxisVisible="False"
+                        IsPanEnabled="False"
+                        IsZoomEnabled="False"
+                        MaximumPadding="0"
+                        Minimum="0"
+                        MinimumPadding="0"
+                        Position="Right"
+                        StartPosition="0.5"
+                        Title="{ns:Loc LblStarSNR}" />
+                    <oxy:LinearAxis
                         Key="TextAxisX"
                         IsAxisVisible="False"
                         Maximum="1"
@@ -213,7 +237,24 @@
                         XAxisKey="DataAxisX"
                         YAxisKey="DistanceAxis"
                         Color="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.GuiderSettings.GuideChartDeclinationColor}" />
-
+                    <oxy:LineSeries
+                        Title="{ns:Loc LblStarMass}"
+                        DataFieldX="Id"
+                        DataFieldY="StarMass"
+                        ItemsSource="{Binding GuideSteps}"
+                        Visibility="{Binding Path=ActiveProfile.GuiderSettings.PHD2GuideChartShowStarMass, Source={StaticResource ProfileService}, Converter={StaticResource VisibilityConverter}}"
+                        XAxisKey="DataAxisX"
+                        YAxisKey="StarMassAxis"
+                        Color="Yellow" />
+                    <oxy:LineSeries
+                        Title="{ns:Loc LblStarSNR}"
+                        DataFieldX="Id"
+                        DataFieldY="SNR"
+                        ItemsSource="{Binding GuideSteps}"
+                        Visibility="{Binding Path=ActiveProfile.GuiderSettings.PHD2GuideChartShowSNR, Source={StaticResource ProfileService}, Converter={StaticResource VisibilityConverter}}"
+                        XAxisKey="DataAxisX"
+                        YAxisKey="StarSNRAxis"
+                        Color="White" />
                     <oxy:LineSeries
                         Title="{ns:Loc LblDither}"
                         DataFieldX="Id"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-﻿# N.I.N.A. - Nighttime Imaging 'N' Astronomy Changelog
+# N.I.N.A. - Nighttime Imaging 'N' Astronomy Changelog
 
 If N.I.N.A. helps you on your journey to capture amazing deep sky images, please consider a donation. Every contribution helps keep the project alive and active.  
 More details at <a href="https://nighttime-imaging.eu/donate/" target="_blank">nighttime-imaging.eu/donate/</a>
@@ -44,6 +44,7 @@ This allows you to safely return to a stable release if needed.
 - Captures now switch to the exposure's readout mode before applying gain and offset, so the first frame after a mode change is digitized and logged with the settings for that mode.
 
 ## Improvements
+- PHD2 users can optionally show guide-star mass and SNR in the guide graphs, using PHD2-style independent scaling in the upper half of the chart.
 - **Autofocus after HFR Increase Trigger**
     - new Trend per Filter checkbox to consider HFR Trend per filter (default) or across all filters to earlier trigger autofocus runs when imaging with continues filter loops 
 - When a safety monitor is connected and is reporting unsafe conditions, the imaging related core triggers will no longer fire as the conditions aren't safe anyways to execute them.


### PR DESCRIPTION
## 🚀 Purpose

Adds optional PHD2 Star Mass and Star SNR overlays to the Equipment and Imaging guide graphs.

- Uses the Star Mass and SNR telemetry already provided by PHD2 guide-step events.
- Displays Star Mass in yellow and Star SNR in white.
- Gives each metric an independent automatic scale occupying the upper half of the graph, matching PHD2's graph behavior.
- Adds persisted PHD2-only visibility options that are disabled by default.
- Preserves the metrics through guide-history trimming, resizing and pixel-scale changes.
- Uses `NaN` for non-PHD2 and dither history points so they are not plotted.
- Does not change `IGuideStep` or the PHD2 communication protocol.

## 🧪 How Was It Tested?

- Added focused tests covering PHD2 metric projection, history trimming, history resizing, scale changes and non-PHD2/dither points.
- Added profile serialization tests covering the disabled defaults and persisted enabled values.
- Added STA runtime WPF tests that construct both guide graphs and both PHD2 option views.
- Verified both graph definitions use independent upper-half axes and bind visibility directly to the PHD2 settings.
- Focused test run: 35 passed.
- Full `NINA.Test` suite: 5,384 passed and 16 pre-existing tests skipped.

Manual visual verification across Light, Dark and Night themes has not been performed.

## 🤖 AI / Tooling Disclosure

OpenAI Codex (GPT-5) was used to implement and test the feature and to draft code, tests, release notes and documentation.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark and Night themes (if applicable)
- [x] Plugin API compatibility reviewed
  - [ ] No breaking changes to interfaces
  - [x] No changes to existing method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [x] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

Closes #323

## 📸 Screenshots

<img width="2042" height="1072" alt="image" src="https://github.com/user-attachments/assets/94c33016-d041-4ac1-a702-408e3c01cd42" />


## 📝 Additional Notes

-