### PR TITLE
Fix silent startup failure for invalid profile IDs

### DIFF
--- a/NINA.Test/ProfileTest/ProfileServiceBehaviorTest.cs
+++ b/NINA.Test/ProfileTest/ProfileServiceBehaviorTest.cs
@@ -101,6 +101,23 @@ namespace NINA.Test.ProfileTest {
         }
 
         /// <summary>
+        /// Verifies that an existing requested profile remains discoverable when another instance has locked it.
+        /// </summary>
+        [Test]
+        public void TryLoad_WithLockedRequestedProfile_ReturnsFalseAndRetainsProfileMetadata() {
+            ProfileMeta profile = SaveProfile("Locked Requested Profile");
+            using IProfile lockedProfile = ProfileModel.Load(profile.Location);
+            ProfileService service = CreateService();
+
+            bool loaded = service.TryLoad(profile.Id.ToString());
+
+            loaded.Should().BeFalse();
+            service.ProfileWasSpecifiedFromCommandLineArgs.Should().BeTrue();
+            service.Profiles.Should().ContainSingle().Which.Id.Should().Be(profile.Id);
+            service.ActiveProfile.Should().BeNull();
+        }
+
+        /// <summary>
         /// Verifies that Add creates another persisted profile without disturbing the currently selected profile.
         /// </summary>
         [Test]

--- a/NINA/App.xaml.cs
+++ b/NINA/App.xaml.cs
@@ -49,6 +49,9 @@ namespace NINA {
         [DllImport("kernel32.dll")]
         static extern bool FreeConsole(uint dwProcessId);
         const uint ATTACH_PARENT_PROCESS = 0x0ffffffff;
+        // Microsoft recommends positive, non-zero process exit codes for errors to avoid negative exit codes.
+        // https://learn.microsoft.com/en-us/dotnet/api/system.environment.exitcode?view=net-10.0
+        const int STARTUP_ERROR_EXIT_CODE = 1;
 
         private CommandLineOptions _commandLineOptions;
         private ProfileService _profileService;
@@ -132,7 +135,7 @@ namespace NINA {
             FreeConsole(ATTACH_PARENT_PROCESS);
             if (_commandLineOptions.HasErrors) {
 
-                Shutdown(-1);
+                Shutdown(STARTUP_ERROR_EXIT_CODE);
                 return;
             }
 
@@ -157,8 +160,14 @@ namespace NINA {
 
             var startWithProfileId = _commandLineOptions.ProfileId;
             if (!_profileService.TryLoad(startWithProfileId)) {
-                ProfileService.ActivateInstanceOfNinaReferencingProfile(startWithProfileId);
-                Shutdown();
+                var profileExists = _profileService.Profiles.Any(x => x.Id.ToString() == startWithProfileId);
+                if (profileExists) {
+                    ProfileService.ActivateInstanceOfNinaReferencingProfile(startWithProfileId);
+                    Shutdown();
+                } else {
+                    Logger.Error($"Profile {startWithProfileId} was not found. Available profiles: {string.Join(", ", _profileService.Profiles.Select(x => x.Id))}");
+                    Shutdown(STARTUP_ERROR_EXIT_CODE);
+                }
                 return;
             }
             this.RefreshJumpList(_profileService);
@@ -231,7 +240,7 @@ namespace NINA {
         }
 
         protected override void OnExit(ExitEventArgs e) {
-            if (e?.ApplicationExitCode != -1) {
+            if (e?.ApplicationExitCode != STARTUP_ERROR_EXIT_CODE) {
                 this.RefreshJumpList(_profileService);
             }
         }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- Launching N.I.N.A. with a nonexistent `--profileid` now writes an error log and returns a non-zero exit code instead of failing silently.
 - Sun and Moon altitude calculations no longer return transient incorrect values when plugins calculate solar-system body positions concurrently.
 - Installer upgrades and repairs now restore missing, locally changed and higher-version application files instead of potentially leaving skipped files absent.
 - Autofocus after HFR Increase HFRTrendPercentage is now calculated correctly and will no longer underestimate the change on large HFR drift


### PR DESCRIPTION
## 🚀 Purpose

Fix startup with an invalid `--profileid` silently exiting with code 0 and producing no diagnostic output.

Missing profiles now:

- Write an error log containing the requested profile ID and available profile IDs.
- Exit with the positive error code 1.
- Avoid sending an activation signal when no matching profile exists.

Existing but unavailable profiles retain the current instance-handoff behavior, including activation signaling and exit code 0.

## 🧪 How Was It Tested?

Automated verification:

- Command-line and profile-service tests: 15 passed.
- Full NINA.Test suite: 5,387 passed with 16 expected skips.
- Added coverage confirming that a locked requested profile remains discoverable after `TryLoad` returns false.

Process-level verification against the built application:

- Nonexistent `--profileid`: exit code 1 with a diagnostic log.
- Mixed `-profileid` spelling: exit code 1 with the parsed invalid value logged.
- Unknown option: exit code 1, preserving the existing parser-error behavior.
- Existing locked profile: exit code 0 with the activation signal received.
- Valid unused profile selection remains covered by the existing profile-service test.

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to analyze the issue, implement the change and assist with regression testing.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (not applicable: no UI changes)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated (not applicable: no user documentation changes required)

## 🔗 Related Issues

Closes #357

## 📸 Screenshots

Not applicable. This change has no UI surface.

## 📝 Additional Notes

-