### PR TITLE
Fix Center After Drift leaking across sequence containers

### DIFF
--- a/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
+++ b/NINA.Sequencer/Trigger/Platesolving/CenterAfterDriftTrigger.cs
@@ -162,6 +162,10 @@ namespace NINA.Sequencer.Trigger.Platesolving {
         public partial int AfterExposures { get; set; }
 
         private void PlatesolvingImageFollower_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e) {
+            if (!ReferenceEquals(sender, platesolvingImageFollower) || !IsActiveForImageFollower()) {
+                return;
+            }
+
             var follower = (PlatesolvingImageFollower)sender;
             if (e.PropertyName == nameof(follower.LastCoordinates)) {
                 var lastCoordinates = follower?.LastCoordinates;
@@ -211,10 +215,16 @@ namespace NINA.Sequencer.Trigger.Platesolving {
 
         public override void SequenceBlockInitialize() {
             EnsureFollowerClosed();
-            platesolvingImageFollower = new PlatesolvingImageFollower(this.profileService, this.telescopeMediator, this.imageSaveMediator, this.applicationStatusMediator) {
+            platesolvingImageFollower = new PlatesolvingImageFollower(this.profileService, this.telescopeMediator, this.imageSaveMediator, this.applicationStatusMediator, IsActiveForImageFollower) {
                 AfterExposures = AfterExposures
             };
             platesolvingImageFollower.PropertyChanged += PlatesolvingImageFollower_PropertyChanged;
+        }
+
+        private bool IsActiveForImageFollower() {
+            return ItemUtility.IsInRootContainer(Parent)
+                && Parent.Status == SequenceEntityStatus.RUNNING
+                && Status != SequenceEntityStatus.DISABLED;
         }
 
         public override void SequenceBlockTeardown() {

--- a/NINA.Sequencer/Trigger/Platesolving/PlatesolvingImageFollower.cs
+++ b/NINA.Sequencer/Trigger/Platesolving/PlatesolvingImageFollower.cs
@@ -38,16 +38,22 @@ namespace NINA.Sequencer.Trigger.Platesolving {
         private readonly ITelescopeMediator telescopeMediator;
         private readonly IProfileService profileService;
         private readonly IApplicationStatusMediator applicationStatusMediator;
+        private readonly Func<bool> isActive;
         private readonly IProgress<ApplicationStatus> progress;
         private object lockObj = new object();
         private bool closed = false;
         private Task solverBackgroundTask;
         private CancellationTokenSource solverBackgroundTaskCancellationSource = new CancellationTokenSource();
 
-        public PlatesolvingImageFollower(IProfileService profileService, ITelescopeMediator telescopeMediator, IImageSaveMediator imageSaveMediator, IApplicationStatusMediator applicationStatusMediator) {
+        public PlatesolvingImageFollower(IProfileService profileService, ITelescopeMediator telescopeMediator, IImageSaveMediator imageSaveMediator, IApplicationStatusMediator applicationStatusMediator)
+            : this(profileService, telescopeMediator, imageSaveMediator, applicationStatusMediator, () => true) {
+        }
+
+        internal PlatesolvingImageFollower(IProfileService profileService, ITelescopeMediator telescopeMediator, IImageSaveMediator imageSaveMediator, IApplicationStatusMediator applicationStatusMediator, Func<bool> isActive) {
             this.profileService = profileService;
             this.imageSaveMediator = imageSaveMediator;
             this.telescopeMediator = telescopeMediator;
+            this.isActive = isActive;
             this.imageSaveMediator.BeforeImageSaved += ImageSaveMediator_BeforeImageSaved;
             this.applicationStatusMediator = applicationStatusMediator;
             this.progress = new Progress<ApplicationStatus>(ProgressStatusUpdate);
@@ -62,6 +68,10 @@ namespace NINA.Sequencer.Trigger.Platesolving {
 
         private async Task ImageSaveMediator_BeforeImageSaved(object sender, BeforeImageSavedEventArgs e) {
             lock (lockObj) {
+                if (closed || !isActive()) {
+                    return;
+                }
+
                 if(e.Image.MetaData.Image.ImageType != "LIGHT") {
                     return;
                 }
@@ -152,8 +162,14 @@ namespace NINA.Sequencer.Trigger.Platesolving {
                 return;
             }
 
-            LastCoordinates = solveResult.Coordinates;
-            ProgressExposures = 0;
+            lock (lockObj) {
+                if (closed || !isActive()) {
+                    return;
+                }
+
+                LastCoordinates = solveResult.Coordinates;
+                ProgressExposures = 0;
+            }
         }
     }
 }

--- a/NINA.Test/Sequencer/Trigger/Platesolving/CenterAfterDriftTriggerTest.cs
+++ b/NINA.Test/Sequencer/Trigger/Platesolving/CenterAfterDriftTriggerTest.cs
@@ -14,11 +14,17 @@
 
 using FluentAssertions;
 using Moq;
+using NINA.Astrometry;
+using NINA.Core.Enum;
+using NINA.Core.Model.Equipment;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyTelescope;
 using NINA.Equipment.Interfaces;
 using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageData;
 using NINA.Image.Interfaces;
-using NINA.Core.Model.Equipment;
 using NINA.Profile.Interfaces;
+using NINA.Sequencer.Container;
 using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.Trigger.Platesolving;
 using NINA.WPF.Base.Interfaces.Mediator;
@@ -46,9 +52,11 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
         private Mock<IDomeMediator> domeMediatorMock;
         private Mock<IDomeFollower> domeFollowerMock;
         private Mock<ISafetyMonitorMediator> safetyMonitorMediatorMock;
+        private Func<object, BeforeImageSavedEventArgs, Task> imageSavedHandlers;
 
         [SetUp]
         public void Setup() {
+            imageSavedHandlers = null;
             profileServiceMock = new Mock<IProfileService>();
             telescopeMediatorMock = new Mock<ITelescopeMediator>();
             guiderMediatorMock = new Mock<IGuiderMediator>();
@@ -60,6 +68,14 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
             domeMediatorMock = new Mock<IDomeMediator>();
             domeFollowerMock = new Mock<IDomeFollower>();
             safetyMonitorMediatorMock = new Mock<ISafetyMonitorMediator>();
+            cameraMediatorMock.Setup(x => x.GetInfo()).Returns(new CameraInfo());
+            telescopeMediatorMock.Setup(x => x.GetInfo()).Returns(new TelescopeInfo());
+            imageSaveMediatorMock
+                .SetupAdd(x => x.BeforeImageSaved += It.IsAny<Func<object, BeforeImageSavedEventArgs, Task>>())
+                .Callback<Func<object, BeforeImageSavedEventArgs, Task>>(handler => imageSavedHandlers += handler);
+            imageSaveMediatorMock
+                .SetupRemove(x => x.BeforeImageSaved -= It.IsAny<Func<object, BeforeImageSavedEventArgs, Task>>())
+                .Callback<Func<object, BeforeImageSavedEventArgs, Task>>(handler => imageSavedHandlers -= handler);
         }
 
         [Test]
@@ -119,6 +135,165 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
             sut.ShouldTrigger(null, itemMock.Object).Should().BeTrue();
         }
 
+        /// <summary>
+        /// Verifies that a stale Center After Drift follower from a completed target cannot consume images from the next target.
+        /// </summary>
+        [Test]
+        public async Task ImageSaveEvent_InactiveTriggerDoesNotConsumeImageFromNextContainer() {
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer firstTarget = new SequentialContainer();
+            SequentialContainer secondTarget = new SequentialContainer();
+            CenterAfterDriftTrigger firstTrigger = CreateSut();
+            CenterAfterDriftTrigger secondTrigger = CreateSut();
+            firstTrigger.AfterExposures = 3;
+            secondTrigger.AfterExposures = 3;
+            root.Add(firstTarget);
+            root.Add(secondTarget);
+            firstTarget.Add(firstTrigger);
+            secondTarget.Add(secondTrigger);
+
+            try {
+                root.Status = SequenceEntityStatus.RUNNING;
+                firstTarget.Status = SequenceEntityStatus.RUNNING;
+                firstTrigger.SequenceBlockInitialize();
+
+                firstTarget.Status = SequenceEntityStatus.FINISHED;
+                secondTarget.Status = SequenceEntityStatus.RUNNING;
+                secondTrigger.SequenceBlockInitialize();
+
+                imageSavedHandlers.Should().NotBeNull();
+                await imageSavedHandlers.Invoke(this, CreateImageSavedArgs("LIGHT"));
+
+                firstTrigger.ProgressExposures.Should().Be(0);
+                secondTrigger.ProgressExposures.Should().Be(1);
+            } finally {
+                firstTrigger.SequenceBlockTeardown();
+                secondTrigger.SequenceBlockTeardown();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a late plate-solve result from a completed target cannot change that target's drift state.
+        /// </summary>
+        [Test]
+        public void PlateSolveResult_InactiveTriggerDoesNotPublishDrift() {
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer target = new SequentialContainer();
+            CenterAfterDriftTrigger sut = CreateSut();
+            root.Add(target);
+            target.Add(sut);
+            sut.Coordinates.Coordinates = new Coordinates(Angle.ByHours(10), Angle.ByDegree(20), Epoch.J2000);
+
+            try {
+                root.Status = SequenceEntityStatus.RUNNING;
+                target.Status = SequenceEntityStatus.RUNNING;
+                sut.SequenceBlockInitialize();
+                PlatesolvingImageFollower follower = GetImageFollower(sut);
+
+                target.Status = SequenceEntityStatus.FINISHED;
+                follower.LastCoordinates = new Coordinates(Angle.ByHours(11), Angle.ByDegree(20), Epoch.J2000);
+
+                sut.LastDistanceArcMinutes.Should().Be(0);
+            } finally {
+                sut.SequenceBlockTeardown();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that each Center After Drift trigger in a sequence owns exactly one subscription and releases it at teardown.
+        /// </summary>
+        [Test]
+        public void SequenceBlockLifecycle_MultipleContainersReleaseTheirFollowers() {
+            SequenceRootContainer root = new SequenceRootContainer();
+            CenterAfterDriftTrigger[] triggers = Enumerable.Range(0, 3)
+                .Select(_ => CreateSut())
+                .ToArray();
+            SequentialContainer[] targets = triggers
+                .Select(trigger => {
+                    SequentialContainer target = new SequentialContainer();
+                    root.Add(target);
+                    target.Add(trigger);
+                    return target;
+                })
+                .ToArray();
+            root.Status = SequenceEntityStatus.RUNNING;
+
+            for (int i = 0; i < triggers.Length; i++) {
+                targets[i].Status = SequenceEntityStatus.RUNNING;
+                triggers[i].SequenceBlockInitialize();
+                imageSavedHandlers.GetInvocationList().Should().HaveCount(1);
+
+                triggers[i].SequenceBlockInitialize();
+                imageSavedHandlers.GetInvocationList().Should().HaveCount(1);
+
+                triggers[i].SequenceBlockTeardown();
+                imageSavedHandlers.Should().BeNull();
+                targets[i].Status = SequenceEntityStatus.FINISHED;
+            }
+
+            imageSaveMediatorMock.VerifyAdd(
+                x => x.BeforeImageSaved += It.IsAny<Func<object, BeforeImageSavedEventArgs, Task>>(),
+                Times.Exactly(6));
+            imageSaveMediatorMock.VerifyRemove(
+                x => x.BeforeImageSaved -= It.IsAny<Func<object, BeforeImageSavedEventArgs, Task>>(),
+                Times.Exactly(6));
+        }
+
+        /// <summary>
+        /// Verifies that followers reject images for every non-running parent state.
+        /// </summary>
+        [TestCase(SequenceEntityStatus.CREATED)]
+        [TestCase(SequenceEntityStatus.FINISHED)]
+        [TestCase(SequenceEntityStatus.FAILED)]
+        [TestCase(SequenceEntityStatus.SKIPPED)]
+        [TestCase(SequenceEntityStatus.DISABLED)]
+        public async Task ImageSaveEvent_ParentNotRunningDoesNotConsumeImage(SequenceEntityStatus parentStatus) {
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer target = new SequentialContainer();
+            CenterAfterDriftTrigger sut = CreateSut();
+            sut.AfterExposures = 3;
+            root.Add(target);
+            target.Add(sut);
+
+            try {
+                root.Status = SequenceEntityStatus.RUNNING;
+                target.Status = parentStatus;
+                sut.SequenceBlockInitialize();
+
+                await imageSavedHandlers.Invoke(this, CreateImageSavedArgs("LIGHT"));
+
+                sut.ProgressExposures.Should().Be(0);
+            } finally {
+                sut.SequenceBlockTeardown();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a disabled trigger rejects images even while its parent is running.
+        /// </summary>
+        [Test]
+        public async Task ImageSaveEvent_DisabledTriggerDoesNotConsumeImage() {
+            SequenceRootContainer root = new SequenceRootContainer();
+            SequentialContainer target = new SequentialContainer();
+            CenterAfterDriftTrigger sut = CreateSut();
+            sut.AfterExposures = 3;
+            root.Add(target);
+            target.Add(sut);
+
+            try {
+                root.Status = SequenceEntityStatus.RUNNING;
+                target.Status = SequenceEntityStatus.RUNNING;
+                sut.Status = SequenceEntityStatus.DISABLED;
+                sut.SequenceBlockInitialize();
+
+                await imageSavedHandlers.Invoke(this, CreateImageSavedArgs("LIGHT"));
+
+                sut.ProgressExposures.Should().Be(0);
+            } finally {
+                sut.SequenceBlockTeardown();
+            }
+        }
+
         private CenterAfterDriftTrigger CreateSut() {
             return new CenterAfterDriftTrigger(
                 profileServiceMock.Object,
@@ -138,6 +313,20 @@ namespace NINA.Test.Sequencer.Trigger.Platesolving {
             typeof(CenterAfterDriftTrigger)
                 .GetField("lastDistanceArcMinutes", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(sut, distanceArcMinutes);
+        }
+
+        private static PlatesolvingImageFollower GetImageFollower(CenterAfterDriftTrigger sut) {
+            return (PlatesolvingImageFollower)typeof(CenterAfterDriftTrigger)
+                .GetField("platesolvingImageFollower", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(sut);
+        }
+
+        private static BeforeImageSavedEventArgs CreateImageSavedArgs(string imageType) {
+            Mock<IImageData> imageMock = new Mock<IImageData>();
+            imageMock.SetupGet(x => x.MetaData).Returns(new ImageMetaData {
+                Image = new ImageParameter { ImageType = imageType }
+            });
+            return new BeforeImageSavedEventArgs(imageMock.Object, Task.FromResult<IRenderedImage>(null));
         }
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- Center After Drift triggers in completed or otherwise inactive sequence containers no longer consume images or publish drift results while a later container is running.
 - Sun and Moon altitude calculations no longer return transient incorrect values when plugins calculate solar-system body positions concurrently.
 - Installer upgrades and repairs now restore missing, locally changed and higher-version application files instead of potentially leaving skipped files absent.
 - Autofocus after HFR Increase HFRTrendPercentage is now calculated correctly and will no longer underestimate the change on large HFR drift


### PR DESCRIPTION
## 🚀 Purpose

Center After Drift triggers in inactive sequence containers no longer consume images or publish late plate-solve results while another container is running.

The existing public API remains unchanged.

## 🧪 How Was It Tested?

- Added regression tests for multiple triggers in sequential containers.
- Verified inactive and disabled triggers ignore images.
- Verified late solve results are ignored.
- Verified reinitialization does not duplicate subscriptions.
- Verified teardown removes subscriptions.
- Targeted tests: 16 passed.
- Broader sequencer tests: 349 passed, 3 skipped.
- Full suite: 5,416 passed, 16 skipped. One clipboard test failed transiently and passed when rerun.

## 🤖 AI / Tooling Disclosure

OpenAI Codex using GPT-5 was used to help analyze and implement this change.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (not applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No existing public signatures changed
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated (not applicable)

## 🔗 Related Issues

Closes #49

## 📸 Screenshots

Not applicable.

## 📝 Additional Notes

The fix is limited to `CenterAfterDriftTrigger` and `PlatesolvingImageFollower`. The shared sequencer execution strategy was not changed.