### PR TITLE
Fix cached sky image orientation across zoom levels

### DIFF
--- a/NINA.Test/SkySurvey/CacheSkySurveyTest.cs
+++ b/NINA.Test/SkySurvey/CacheSkySurveyTest.cs
@@ -359,6 +359,84 @@ namespace NINA.Test.SkySurvey {
             AstroUtil.EuclidianModulus(placement.Rotation, 360).Should().BeApproximately(expectedRotation, 0.05);
         }
 
+        [TestCase(45.153436349090754, 0)]
+        [TestCase(45.153436349090754, 180)]
+        [TestCase(-45.153436349090754, 0)]
+        [TestCase(-45.153436349090754, 180)]
+        public async Task SkyMapImageCache_WhenZoomChanges_PreservesIssue71TileOrientation(
+            double declination,
+            double viewportRotation) {
+            Coordinates tileCoordinates = new Coordinates(
+                21.073240111482587,
+                declination,
+                Epoch.J2000,
+                Coordinates.RAType.Hours);
+            const double imageRotation = 179.44002835323062;
+            CacheSkySurvey cache = new CacheSkySurvey(cachePath);
+            cache.SaveImageToCache(CreateSkySurveyImage(
+                "Issue 71 tile",
+                tileCoordinates.RA,
+                tileCoordinates.Dec,
+                imageRotation,
+                210.89612594552327,
+                210.89612594552327,
+                nameof(FileSkySurvey)));
+            SkyMapImageCache sut = new SkyMapImageCache(cache);
+
+            (double FieldOfView, int ExpectedPixelWidth)[] zoomSequence = [
+                (40, 75),
+                (20, 150),
+                (6, 500),
+                (4, 4),
+                (6, 500),
+                (20, 150),
+                (40, 75)
+            ];
+            foreach ((double fieldOfView, int expectedPixelWidth) in zoomSequence) {
+                ViewportFoV viewport = new ViewportFoV(tileCoordinates, fieldOfView, 1644, 1513, viewportRotation);
+                SkyMapViewportProjection projection = new SkyMapViewportProjection(viewport);
+
+                await sut.LoadAsync(viewport, CancellationToken.None);
+                SkyMapImagePlacement placement = sut.GetPlacements(projection).Single();
+                System.Windows.Point top = projection.Project(OffsetCoordinates(tileCoordinates, -imageRotation));
+                double expectedRotation = AstroUtil.EuclidianModulus(AstroUtil.ToDegree(Math.Atan2(
+                    top.Y - placement.Center.Y,
+                    top.X - placement.Center.X)) + 90, 360);
+
+                placement.FlipHorizontally.Should().BeFalse();
+                placement.Image.PixelWidth.Should().Be(expectedPixelWidth);
+                AstroUtil.EuclidianModulus(placement.Rotation, 360).Should().BeApproximately(expectedRotation, 0.05);
+            }
+        }
+
+        [Test]
+        public void CacheSkySurveyImageFactory_WhenFieldOfViewChanges_PreservesCenteredTileOrientation() {
+            Coordinates tileCoordinates = new Coordinates(
+                21.073240111482587,
+                45.153436349090754,
+                Epoch.J2000,
+                Coordinates.RAType.Hours);
+            CacheSkySurvey cache = new CacheSkySurvey(cachePath);
+            cache.SaveImageToCache(new SkySurveyImage {
+                Name = "Issue 71 directional tile",
+                Source = nameof(FileSkySurvey),
+                Coordinates = tileCoordinates,
+                Rotation = 179.44002835323062,
+                FoVWidth = 210.89612594552327,
+                FoVHeight = 210.89612594552327,
+                Image = CreateDirectionalBitmapSource()
+            });
+            CacheSkySurveyImageFactory sut = new CacheSkySurveyImageFactory(400, 190, cache);
+
+            System.Windows.Point tenDegreeMarker = FindRedMarkerCentroid(sut.Render(tileCoordinates, 10, 0));
+            System.Windows.Point twelveDegreeMarker = FindRedMarkerCentroid(sut.Render(tileCoordinates, 12, 0));
+
+            tenDegreeMarker.X.Should().BeGreaterThan(200);
+            tenDegreeMarker.Y.Should().BeGreaterThan(95);
+            twelveDegreeMarker.X.Should().BeGreaterThan(200);
+            twelveDegreeMarker.Y.Should().BeGreaterThan(95);
+        }
+
         [TestCase(50, 45, 180, 38, 205, 11)]
         [TestCase(50, 45, 180, 38, 155, 11)]
         [TestCase(50, 70, 350, 60, 10, 0)]
@@ -452,6 +530,48 @@ namespace NINA.Test.SkySurvey {
             BitmapSource source = BitmapSource.Create(width, height, 96, 96, PixelFormats.Bgra32, null, pixels, width * 4);
             source.Freeze();
             return source;
+        }
+
+        private static BitmapSource CreateDirectionalBitmapSource() {
+            const int width = 32;
+            const int height = 32;
+            byte[] pixels = new byte[width * height * 4];
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    int offset = (y * width + x) * 4;
+                    bool marker = x < 8 && y < 8;
+                    pixels[offset] = marker ? (byte)0 : (byte)255;
+                    pixels[offset + 1] = 0;
+                    pixels[offset + 2] = marker ? (byte)255 : (byte)0;
+                    pixels[offset + 3] = 255;
+                }
+            }
+
+            BitmapSource source = BitmapSource.Create(width, height, 96, 96, PixelFormats.Bgra32, null, pixels, width * 4);
+            source.Freeze();
+            return source;
+        }
+
+        private static System.Windows.Point FindRedMarkerCentroid(BitmapSource source) {
+            int stride = source.PixelWidth * 4;
+            byte[] pixels = new byte[stride * source.PixelHeight];
+            source.CopyPixels(pixels, stride, 0);
+            double totalX = 0;
+            double totalY = 0;
+            int count = 0;
+            for (int y = 0; y < source.PixelHeight; y++) {
+                for (int x = 0; x < source.PixelWidth; x++) {
+                    int offset = y * stride + x * 4;
+                    if (pixels[offset + 2] > 160 && pixels[offset] < 100 && pixels[offset + 1] < 100) {
+                        totalX += x;
+                        totalY += y;
+                        count++;
+                    }
+                }
+            }
+
+            count.Should().BeGreaterThan(0);
+            return new System.Windows.Point(totalX / count, totalY / count);
         }
 
         private static XElement CreateLegacyCacheImageElement(string fileName, string rotation) {

--- a/NINA.WPF.Base/SkySurvey/CacheSkySurveyImageFactory.cs
+++ b/NINA.WPF.Base/SkySurvey/CacheSkySurveyImageFactory.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 /*
     Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors 
 
@@ -57,6 +57,7 @@ namespace NINA.WPF.Base.SkySurvey {
 
         private void DrawBufferedDSOImages(Graphics dsoImageGraphics) {
             try {
+                var projection = new SkyMapViewportProjection(ViewportFoV);
                 var relevantImages = GetCacheImagesForViewport();
                 foreach (var cacheImage in relevantImages) {
                     if (File.Exists(cacheImage.ImagePath)) {
@@ -69,24 +70,14 @@ namespace NINA.WPF.Base.SkySurvey {
                         var conversionH = imageResH / ViewportFoV.ArcSecHeight;
                         var dest = new RectangleF(-(float)(image.Width * conversionW / 2f), -(float)(image.Height * conversionH / 2f), (float)(image.Width * conversionW), (float)(image.Height * conversionH));
 
-                        var center = cacheImage.Coordinates.XYProjection(ViewportFoV);
-
-                        var panelDeltaX = center.X - ViewportFoV.ViewPortCenterPoint.X;
-                        var panelDeltaY = center.Y - ViewportFoV.ViewPortCenterPoint.Y;
-                        var referenceCenter = ViewportFoV.CenterCoordinates.Shift(panelDeltaX < 1E-10 ? 1 : 0, panelDeltaY, ViewportFoV.Rotation, ViewportFoV.ArcSecWidth, ViewportFoV.ArcSecHeight);
-
-                        var rotation = -(90 - ((float)AstroUtil.CalculatePositionAngle(referenceCenter.RADegrees, cacheImage.Coordinates.RADegrees, referenceCenter.Dec, cacheImage.Coordinates.Dec)));
-                        if (panelDeltaX < 0) {
-                            rotation += 180;
-                        }
-                        if (cacheImage.Coordinates.Dec < 0 || (referenceCenter.Dec < 0 && cacheImage.Coordinates.Dec >= 0)) {
-                            rotation += 180;
-                        }
-
-                        rotation += (float)cacheImage.Rotation;
+                        var center = projection.Project(cacheImage.Coordinates);
+                        var (rotation, _) = projection.ImageTransformFromEquatorial(
+                            cacheImage.Coordinates,
+                            cacheImage.Rotation,
+                            center);
 
                         dsoImageGraphics.TranslateTransform((float)center.X, (float)center.Y);
-                        dsoImageGraphics.RotateTransform(rotation);
+                        dsoImageGraphics.RotateTransform((float)rotation);
                         dsoImageGraphics.DrawImage(image, dest, sourceR, GraphicsUnit.Pixel);
                         dsoImageGraphics.ResetTransform();
                     }

--- a/NINA.WPF.Base/SkySurvey/SkyMapImageCache.cs
+++ b/NINA.WPF.Base/SkySurvey/SkyMapImageCache.cs
@@ -117,7 +117,10 @@ namespace NINA.WPF.Base.SkySurvey {
                 double width = image.PixelWidth * imageResolutionWidth / viewport.ArcSecWidth;
                 double height = image.PixelHeight * imageResolutionHeight / viewport.ArcSecHeight;
                 System.Windows.Point center = projection.Project(tile.Coordinates);
-                (double rotation, bool flipHorizontally) = CalculateTransform(tile, viewport, projection, center);
+                (double rotation, bool flipHorizontally) = projection.ImageTransformFromEquatorial(
+                    tile.Coordinates,
+                    tile.Rotation,
+                    center);
                 result.Add(new SkyMapImagePlacement(image, center, width, height, rotation, flipHorizontally) {
                     RasterImage = loaded.RasterImage
                 });
@@ -267,37 +270,6 @@ namespace NINA.WPF.Base.SkySurvey {
                 + Math.Cos(firstDeclination) * Math.Cos(secondDeclination)
                 * Math.Cos(AstroUtil.ToRadians(first.RADegrees - second.RADegrees));
             return AstroUtil.ToDegree(Math.Acos(Math.Clamp(cosine, -1, 1)));
-        }
-
-        private static (double Rotation, bool FlipHorizontally) CalculateTransform(
-            ImageTile tile,
-            ViewportFoV viewport,
-            SkyMapViewportProjection projection,
-            System.Windows.Point center) {
-            if (projection.Mode == SkyMapProjectionMode.AltAz) {
-                return projection.ImageTransformFromEquatorial(tile.Coordinates, tile.Rotation, center);
-            }
-
-            double deltaX = center.X - viewport.ViewPortCenterPoint.X;
-            double deltaY = center.Y - viewport.ViewPortCenterPoint.Y;
-            Coordinates referenceCenter = viewport.CenterCoordinates.Shift(
-                deltaX < 1E-10 ? 1 : 0,
-                deltaY,
-                viewport.Rotation,
-                viewport.ArcSecWidth,
-                viewport.ArcSecHeight);
-            double equatorialRotation = -(90 - AstroUtil.CalculatePositionAngle(
-                referenceCenter.RADegrees,
-                tile.Coordinates.RADegrees,
-                referenceCenter.Dec,
-                tile.Coordinates.Dec));
-            if (deltaX < 0) {
-                equatorialRotation += 180;
-            }
-            if (tile.Coordinates.Dec < 0 || (referenceCenter.Dec < 0 && tile.Coordinates.Dec >= 0)) {
-                equatorialRotation += 180;
-            }
-            return (equatorialRotation + tile.Rotation, false);
         }
 
         private sealed record CacheEntry(

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- Cached Offline Sky Map and Sky Atlas image tiles now keep a stable orientation across zoom levels instead of occasionally rotating by 180 degrees.
 - Center After Drift triggers in completed or otherwise inactive sequence containers no longer consume images or publish drift results while a later container is running.
 - Launching N.I.N.A. with a nonexistent `--profileid` now writes an error log and returns a non-zero exit code instead of failing silently.
 - Sun and Moon altitude calculations no longer return transient incorrect values when plugins calculate solar-system body positions concurrently.


### PR DESCRIPTION
## 🚀 Purpose

Fixes cached Offline Sky Map and Sky Atlas image tiles occasionally rotating by exactly 180 degrees while zooming.

The previous rotation calculation used `atan(numerator / denominator)`, which loses quadrant information. Most views were unaffected, but coordinates near the quadrant boundary could change orientation because of small projection differences between zoom levels.

Both cached-image rendering paths now use the existing `SkyMapViewportProjection` orientation calculation, which uses `atan2` and preserves the correct quadrant.

## 🧪 How Was It Tested?

- Reproduced the reported problem using the coordinates and image rotation from issue #71.
- Confirmed the regression test failed before the fix with a rotation difference of approximately 180 degrees.
- Tested zooming through the 75 px, 150 px, 500 px and original-image cache tiers in both directions.
- Tested positive and negative declinations with 0-degree and 180-degree viewport rotations.
- Added a rendered-image regression test for the cached Sky Atlas image path.
- Focused regression tests: 5 passed, 0 failed.
- SkySurvey test suite: 143 passed, 0 failed.
- Complete test suite: 5,423 passed, 16 explicitly skipped and 0 failed.
- Debug application build: 0 warnings and 0 errors.
- Cached-image orientation benchmark: 6.929 microseconds average with no managed allocations.

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to diagnose the issue, implement the fix and create the regression tests. The generated changes were reviewed and verified with the repository's automated test suite.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark and Night themes (not applicable, no styling or theme changes)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated (not applicable, no user workflow or configuration changes)

## 🔗 Related Issues

Closes #71

## 📸 Screenshots

Not applicable. There are no UI layout or styling changes. The visual orientation behavior is covered by rendered-image regression tests.

## 📝 Additional Notes

The fix is intentionally scoped to the two cached-image rendering paths. It does not change the shared legacy `AstroUtil.CalculatePositionAngle` method or its other callers.