### PR TITLE
Limit ASCOM binning mode enumeration during camera connection

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/AscomCamera.cs
@@ -37,6 +37,8 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
     public class AscomCamera : AscomDevice<ICameraV4>, ICamera, IDisposable {
 
+        private const int MaximumSelectableBinFactor = 16;
+
         public AscomCamera(string cameraId, string name, IProfileService profileService, IExposureDataFactory exposureDataFactory) : base(cameraId, name) {
             this.profileService = profileService;
             this.exposureDataFactory = exposureDataFactory;
@@ -54,16 +56,27 @@ namespace NINA.Equipment.Equipment.MyCamera {
             CanSetGain = true;
             CanGetGain = true;
             _canGetGainMinMax = true;
-            BinningModes = new AsyncObservableCollection<BinningMode>();
-            for (short i = 1; i <= MaxBinX; i++) {
-                if (CanAsymmetricBin) {
-                    for (short j = 1; j <= MaxBinY; j++) {
-                        BinningModes.Add(new BinningMode(i, j));
+            var maxBinX = MaxBinX;
+            var maxBinY = MaxBinY;
+            var canAsymmetricBin = CanAsymmetricBin;
+            var selectableMaxBinX = Math.Clamp((int)maxBinX, 1, MaximumSelectableBinFactor);
+            var selectableMaxBinY = Math.Clamp((int)maxBinY, 1, MaximumSelectableBinFactor);
+
+            if (selectableMaxBinX != maxBinX || selectableMaxBinY != maxBinY) {
+                Logger.Warning($"{Name} reported maximum binning {maxBinX}x{maxBinY}. Selectable binning factors will be limited to {selectableMaxBinX}x{selectableMaxBinY}.");
+            }
+
+            var binningModes = new List<BinningMode>(canAsymmetricBin ? selectableMaxBinX * selectableMaxBinY : selectableMaxBinX);
+            for (var i = 1; i <= selectableMaxBinX; i++) {
+                if (canAsymmetricBin) {
+                    for (var j = 1; j <= selectableMaxBinY; j++) {
+                        binningModes.Add(new BinningMode((short)i, (short)j));
                     }
                 } else {
-                    BinningModes.Add(new BinningMode(i, i));
+                    binningModes.Add(new BinningMode((short)i, (short)i));
                 }
             }
+            BinningModes = new AsyncObservableCollection<BinningMode>(binningModes);
 
             Gains.Clear();
             try {

--- a/NINA.Test/Equipment/Camera/AscomCameraTest.cs
+++ b/NINA.Test/Equipment/Camera/AscomCameraTest.cs
@@ -1,0 +1,149 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using ASCOM.Common.DeviceInterfaces;
+using FluentAssertions;
+using Moq;
+using NINA.Core.Model.Equipment;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Image.Interfaces;
+using NINA.Profile.Interfaces;
+using System.Threading;
+
+namespace NINA.Test.Equipment.Camera {
+
+    [TestFixture]
+    public class AscomCameraTest {
+
+        [Test]
+        public async Task Connect_WhenAsymmetricBinningIsWithinLimit_ProvidesEveryCombination() {
+            var (camera, _) = CreateCamera(2, 3, true);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().Equal(
+                new BinningMode(1, 1),
+                new BinningMode(1, 2),
+                new BinningMode(1, 3),
+                new BinningMode(2, 1),
+                new BinningMode(2, 2),
+                new BinningMode(2, 3));
+        }
+
+        [Test]
+        public async Task Connect_WhenAsymmetricBinningExceedsLimit_ClampsSelectableModes() {
+            var (camera, _) = CreateCamera(17, 17, true);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().HaveCount(256);
+            camera.BinningModes.Should().Contain(new BinningMode(16, 16));
+            camera.BinningModes.Should().NotContain(new BinningMode(17, 1));
+            camera.BinningModes.Should().NotContain(new BinningMode(1, 17));
+        }
+
+        [TestCase(16, 16, 16, 16)]
+        [TestCase(17, 2, 16, 2)]
+        [TestCase(2, 17, 2, 16)]
+        public async Task Connect_WhenAsymmetricBinningReachesLimit_ClampsAxesIndependently(
+            short maxBinX,
+            short maxBinY,
+            short expectedMaxBinX,
+            short expectedMaxBinY) {
+            var (camera, _) = CreateCamera(maxBinX, maxBinY, true);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().HaveCount(expectedMaxBinX * expectedMaxBinY);
+            camera.BinningModes.Should().Contain(new BinningMode(expectedMaxBinX, expectedMaxBinY));
+            camera.BinningModes.Should().OnlyContain(mode => mode.X <= expectedMaxBinX && mode.Y <= expectedMaxBinY);
+        }
+
+        [TestCase(0, 2)]
+        [TestCase(2, 0)]
+        [TestCase(-1, 2)]
+        [TestCase(2, -1)]
+        public async Task Connect_WhenAsymmetricBinningLimitIsNotPositive_FallsBackToOne(short maxBinX, short maxBinY) {
+            var (camera, _) = CreateCamera(maxBinX, maxBinY, true);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().HaveCount(2);
+            camera.BinningModes.Should().Contain(new BinningMode(1, 1));
+            camera.BinningModes.Should().Contain(new BinningMode(Math.Max(maxBinX, (short)1), Math.Max(maxBinY, (short)1)));
+        }
+
+        [TestCase(2048)]
+        [TestCase(short.MaxValue)]
+        public async Task Connect_WhenAsymmetricBinningLimitIsExtreme_BoundsModesAndPreservesReportedCapabilities(short reportedMaximum) {
+            var (camera, driver) = CreateCamera(reportedMaximum, reportedMaximum, true);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().HaveCount(256);
+            camera.BinningModes.Should().Contain(new BinningMode(1, 1));
+            camera.BinningModes.Should().Contain(new BinningMode(16, 16));
+            driver.VerifyGet(x => x.MaxBinX, Times.Once);
+            driver.VerifyGet(x => x.MaxBinY, Times.Once);
+            driver.VerifyGet(x => x.CanAsymmetricBin, Times.Once);
+            camera.MaxBinX.Should().Be(reportedMaximum);
+            camera.MaxBinY.Should().Be(reportedMaximum);
+        }
+
+        [Test]
+        public async Task Connect_WhenSymmetricBinningExceedsLimit_ProvidesBoundedSquareModes() {
+            var (camera, _) = CreateCamera(17, 17, false);
+
+            var connected = await camera.Connect(CancellationToken.None);
+
+            connected.Should().BeTrue();
+            camera.BinningModes.Should().HaveCount(16);
+            camera.BinningModes.Should().ContainInOrder(Enumerable.Range(1, 16).Select(bin => new BinningMode((short)bin, (short)bin)));
+            camera.BinningModes.Should().OnlyContain(mode => mode.X == mode.Y);
+        }
+
+        private static (AscomCamera Camera, Mock<ICameraV4> Driver) CreateCamera(short maxBinX, short maxBinY, bool canAsymmetricBin) {
+            var driver = new Mock<ICameraV4>();
+            driver.SetupProperty(x => x.Connected, false);
+            driver.SetupGet(x => x.SensorType).Returns(SensorType.Monochrome);
+            driver.SetupGet(x => x.MaxBinX).Returns(maxBinX);
+            driver.SetupGet(x => x.MaxBinY).Returns(maxBinY);
+            driver.SetupGet(x => x.CanAsymmetricBin).Returns(canAsymmetricBin);
+            driver.SetupGet(x => x.Name).Returns("Test ASCOM Camera");
+
+            var profileService = new Mock<IProfileService>();
+            var exposureDataFactory = new Mock<IExposureDataFactory>();
+            var camera = new TestAscomCamera(driver.Object, profileService.Object, exposureDataFactory.Object);
+            return (camera, driver);
+        }
+
+        private sealed class TestAscomCamera : AscomCamera {
+            private readonly ICameraV4 driver;
+
+            public TestAscomCamera(ICameraV4 driver, IProfileService profileService, IExposureDataFactory exposureDataFactory)
+                : base("Test.Camera", "Test ASCOM Camera", profileService, exposureDataFactory) {
+                this.driver = driver;
+            }
+
+            protected override ICameraV4 GetInstance() {
+                return driver;
+            }
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,7 @@ This allows you to safely return to a stable release if needed.
 - QHY cameras connected in a read mode that fixes the offset in hardware, such as Linearity HDR, no longer misreport their offset for the remainder of the session.
 - QHY cameras now really have their cooler turned off when they are disconnected. The cooler shutdown was skipped on every disconnect, so a camera that was cooling kept regulating to its old set point after being disconnected or after N.I.N.A. was closed, while the next session reported the cooler as off.
 - Captures now switch to the exposure's readout mode before applying gain and offset, so the first frame after a mode change is digitized and logged with the settings for that mode.
+- ASCOM cameras that report extremely large binning ranges no longer take minutes to connect while N.I.N.A. builds the selectable binning modes.
 
 ## Improvements
 - URLs throughout the application can now be copied from their right-click context menu.


### PR DESCRIPTION
## 🚀 Purpose

Fixes long ASCOM camera connection times when a driver reports an extreme binning range.

A camera reporting 2048x2048 asymmetric binning previously caused N.I.N.A. to construct 4,194,304 selectable binning modes and synchronously dispatch each collection insertion to the UI.

This change:

- Limits selectable binning factors to 1 through 16 per axis
- Produces at most 256 asymmetric modes
- Reads the relevant ASCOM capabilities once during mode construction
- Builds the modes in a temporary list before creating the observable collection
- Logs one warning per connection when reported limits are normalized or clamped
- Preserves the driver-reported public `MaxBinX` and `MaxBinY` values

## 🧪 How Was It Tested?

The regression test was added before the production change. A 17x17 asymmetric camera initially returned 289 modes instead of the expected 256, confirming the failure.

Final verification:

- `AscomCameraTest`: 12 tests passed
- Equipment camera test suite: 61 tests passed
- `NINA.csproj` Debug build: succeeded with 0 warnings and 0 errors
- `NINA.Test.csproj` Debug build: succeeded with 0 warnings and 0 errors

Automated coverage includes:

- Normal 2x3 asymmetric limits
- The unchanged 16x16 boundary
- Independent X and Y clamping with 17x2 and 2x17 limits
- 2048x2048 and `short.MaxValue`
- Zero and negative limits
- Symmetric cameras
- Capability properties being read once
- The real `AscomCamera.Connect` path using a mocked `ICameraV4`

No physical affected camera was available for hardware testing.

## 🤖 AI / Tooling Disclosure

OpenAI Codex (GPT-5) was used to investigate, implement and test the change.

## ✅ PR Checklist

- [ ] All unit tests pass (the full solution test suite was not run; the relevant camera suites pass)
- [x] UI changes tested across Light, Dark, and Night themes (not applicable; no XAML or visual changes)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [x] [Documentation](https://github.com/isbeorn/nina.docs) updated (not applicable; no documentation changes required)

## 🔗 Related Issues

Closes #43

## 📸 Screenshots

Not applicable. This change does not alter the visual layout.

## 📝 Additional Notes

The limit applies only to modes offered by the binning dropdown. Public `MaxBinX` and `MaxBinY` values remain unchanged.

Existing saved sequences containing binning factors above 16 can still execute. The warning records both the driver-reported limits and the effective selectable limits.