### PR TITLE
Add configurable minimum movement for Mount Dither

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -1177,6 +1177,12 @@ when the lines are not aligned there is some Polar Alignment error</value>
   <data name="LblDitherPixelsMountDitherTooltip" xml:space="preserve">
     <value>Typical number of pixels to dither by. Dithering follows a normal distribution centered at the target, which this value as the standard deviation. 67% of dithers will be within this distance</value>
   </data>
+  <data name="LblMountDitherMinimumPixels" xml:space="preserve">
+    <value>Minimum dither movement</value>
+  </data>
+  <data name="LblMountDitherMinimumPixelsTooltip" xml:space="preserve">
+    <value>Minimum number of main camera pixels moved between successive Mount Dither positions. Set to 0 to preserve the existing random behavior. The value cannot exceed Dither Pixels.</value>
+  </data>
   <data name="LblDitherRAOnly" xml:space="preserve">
     <value>Dither RA Only</value>
   </data>

--- a/NINA.Equipment/Equipment/MyGuider/DirectGuider.cs
+++ b/NINA.Equipment/Equipment/MyGuider/DirectGuider.cs
@@ -19,7 +19,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NINA.Astrometry;
-using Accord.Statistics.Distributions.Univariate;
 using NINA.Core.Enum;
 using NINA.Equipment.Interfaces.Mediator;
 using NINA.Core.Locale;
@@ -35,10 +34,16 @@ namespace NINA.Equipment.Equipment.MyGuider {
     public class DirectGuider : BaseINPC, IGuider, ITelescopeConsumer {
         private readonly IProfileService profileService;
         private readonly ITelescopeMediator telescopeMediator;
+        private readonly DitherOffsetSelector ditherOffsetSelector;
 
-        public DirectGuider(IProfileService profileService, ITelescopeMediator telescopeMediator) {
+        public DirectGuider(IProfileService profileService, ITelescopeMediator telescopeMediator)
+            : this(profileService, telescopeMediator, new DitherOffsetSelector()) {
+        }
+
+        internal DirectGuider(IProfileService profileService, ITelescopeMediator telescopeMediator, DitherOffsetSelector ditherOffsetSelector) {
             this.profileService = profileService;
             this.telescopeMediator = telescopeMediator;
+            this.ditherOffsetSelector = ditherOffsetSelector;
             this.telescopeMediator.RegisterConsumer(this);
         }
 
@@ -216,13 +221,15 @@ namespace NINA.Equipment.Equipment.MyGuider {
             return Task.FromResult(true);
         }
 
-        private readonly Random random = new Random();
-        private double previousWestEastOffsetPixels = 0.0;
-        private double previousNorthSouthOffsetPixels = 0.0;
+        private DitherOffset previousOffset = new DitherOffset(0.0, 0.0);
 
         public event EventHandler<IGuideStep> GuideEvent { add { } remove { } }
 
-        public async Task<bool>Dither (double ditherPixels, TimeSpan settleTime, bool ditherRAOnly, IProgress<ApplicationStatus> progress, CancellationToken ct) {
+        public Task<bool> Dither(double ditherPixels, TimeSpan settleTime, bool ditherRAOnly, IProgress<ApplicationStatus> progress, CancellationToken ct) {
+            return Dither(ditherPixels, 0.0, settleTime, ditherRAOnly, progress, ct);
+        }
+
+        private async Task<bool> Dither(double ditherPixels, double minimumDitherPixels, TimeSpan settleTime, bool ditherRAOnly, IProgress<ApplicationStatus> progress, CancellationToken ct) {
             try {
                 State = "Dithering...";
 
@@ -230,7 +237,7 @@ namespace NINA.Equipment.Equipment.MyGuider {
                 if (!telescopeInfo.Connected) {
                     return false;
                 } else {
-                    var pulseInstructions = SelectDitherPulse(ditherPixels);
+                    var pulseInstructions = SelectDitherPulse(ditherPixels, minimumDitherPixels, ditherRAOnly);
 
                     // Note: According to the ASCOM specification, PulseGuide returns immediately (asynchronous) if the mount supports back to back axis moves, otherwise
                     // it waits until completion. To be strictly correct here we'd start a counter here instead to avoid a potential extra wait. However, DirectGuiding is
@@ -258,7 +265,14 @@ namespace NINA.Equipment.Equipment.MyGuider {
         }
 
         public Task<bool> Dither(IProgress<ApplicationStatus> progress, CancellationToken ct) {
-            return Dither(profileService.ActiveProfile.GuiderSettings.DitherPixels, TimeSpan.FromSeconds(profileService.ActiveProfile.GuiderSettings.SettleTime), profileService.ActiveProfile.GuiderSettings.DitherRAOnly, progress, ct);
+            IGuiderSettings settings = profileService.ActiveProfile.GuiderSettings;
+            return Dither(
+                settings.DitherPixels,
+                settings.MountDitherMinimumPixels,
+                TimeSpan.FromSeconds(settings.SettleTime),
+                settings.DitherRAOnly,
+                progress,
+                ct);
         }
 
         private struct GuidePulses {
@@ -271,34 +285,28 @@ namespace NINA.Equipment.Equipment.MyGuider {
         /// <summary>
         /// Determines what dither pulses to send in N/S and W/E directions so that deviations are normally distributed
         /// around the target, with standard deviation equal to the configured "DitherPixels", and distances clamped to +- 3 times that.
-        /// This is accomplished by computing a vector from the previous randomly chosen offset to the target and sending a pulse guide
-        /// accordingly. Durations are chosen by factoring in the mount-reported guiding rate (using 0.5x sidereal as a fallback) and the camera pixel scale,
-        /// which also factors in telescope focal length
+        /// Candidate offsets that do not move at least the configured minimum are rejected. This is accomplished by computing a vector
+        /// from the previous accepted offset to the target and sending a pulse guide accordingly. Durations are chosen by factoring in
+        /// the mount-reported guiding rate (using 0.5x sidereal as a fallback) and the camera pixel scale, which also factors in telescope focal length.
         /// </summary>
         /// <returns>Parameters for two guide pulses, one in N/S direction and one in E/W direction</returns>
 
-        private GuidePulses SelectDitherPulse(double ditherPixels) {
-            double ditherAngle = random.NextDouble() * Math.PI;
-            double cosAngle = Math.Cos(ditherAngle);
-            double sinAngle = Math.Sin(ditherAngle);
-            var expectedDitherPixels = ditherPixels;
+        private GuidePulses SelectDitherPulse(double ditherPixels, double minimumDitherPixels, bool ditherRAOnly) {
+            double effectiveMinimum = DitherOffsetSelector.NormalizeMinimum(ditherPixels, minimumDitherPixels);
+            if (effectiveMinimum != minimumDitherPixels) {
+                Logger.Warning($"Mount Dither minimum of {minimumDitherPixels} pixels is outside the valid range of 0 to {ditherPixels} pixels and will use {effectiveMinimum} pixels");
+            }
 
-            // Generate a normally distributed distance from 0 with standard deviation equal to the configured "Dither Pixels", and clamped to +- 3 standard deviations
-            double targetDistancePixels = NormalDistribution.Random(mean: 0.0, stdDev: expectedDitherPixels);
-            targetDistancePixels = Math.Min(3.0d * expectedDitherPixels, Math.Max(-3.0d * expectedDitherPixels, targetDistancePixels));
-
-            double targetWestEastOffsetPixels = targetDistancePixels * cosAngle;
-            double targetNorthSouthOffsetPixels = targetDistancePixels * sinAngle;
+            DitherOffset targetOffset = ditherOffsetSelector.SelectOffset(previousOffset, ditherPixels, effectiveMinimum, ditherRAOnly);
 
             // RA axis is East/West
             // Dec axis is North/South
             // pixels * (arcseconds per pixel) / (arcseconds per second) = seconds
-            double westEastDuration = (targetWestEastOffsetPixels - previousWestEastOffsetPixels) * PixelScale / WestEastGuideRate;
-            double northSouthDuration = (targetNorthSouthOffsetPixels - previousNorthSouthOffsetPixels) * PixelScale / NorthSouthGuideRate;
-            Logger.Info($"Dither target from ({previousWestEastOffsetPixels}, {previousNorthSouthOffsetPixels}) to ({targetWestEastOffsetPixels}, {targetNorthSouthOffsetPixels}) using guide durations of {westEastDuration} and {northSouthDuration} seconds");
+            double westEastDuration = (targetOffset.WestEastPixels - previousOffset.WestEastPixels) * PixelScale / WestEastGuideRate;
+            double northSouthDuration = (targetOffset.NorthSouthPixels - previousOffset.NorthSouthPixels) * PixelScale / NorthSouthGuideRate;
+            Logger.Info($"Dither target from ({previousOffset.WestEastPixels}, {previousOffset.NorthSouthPixels}) to ({targetOffset.WestEastPixels}, {targetOffset.NorthSouthPixels}) using guide durations of {westEastDuration} and {northSouthDuration} seconds");
 
-            previousWestEastOffsetPixels = targetWestEastOffsetPixels;
-            previousNorthSouthOffsetPixels = targetNorthSouthOffsetPixels;
+            previousOffset = targetOffset;
 
             GuidePulses resultPulses = new GuidePulses();
             if (westEastDuration >= 0) {

--- a/NINA.Equipment/Equipment/MyGuider/DitherOffsetSelector.cs
+++ b/NINA.Equipment/Equipment/MyGuider/DitherOffsetSelector.cs
@@ -1,0 +1,114 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using Accord.Statistics.Distributions.Univariate;
+using System;
+
+namespace NINA.Equipment.Equipment.MyGuider {
+
+    internal readonly struct DitherOffset {
+        internal DitherOffset(double westEastPixels, double northSouthPixels) {
+            WestEastPixels = westEastPixels;
+            NorthSouthPixels = northSouthPixels;
+        }
+
+        internal double WestEastPixels { get; }
+        internal double NorthSouthPixels { get; }
+    }
+
+    internal sealed class DitherOffsetSelector {
+        internal const int MaxSelectionAttempts = 100;
+
+        private readonly Func<double, DitherOffset> candidateFactory;
+
+        internal DitherOffsetSelector() {
+            Random random = new Random();
+            candidateFactory = ditherPixels => GenerateCandidate(ditherPixels, random);
+        }
+
+        internal DitherOffsetSelector(Func<double, DitherOffset> candidateFactory) {
+            this.candidateFactory = candidateFactory ?? throw new ArgumentNullException(nameof(candidateFactory));
+        }
+
+        internal DitherOffset SelectOffset(DitherOffset previousOffset, double ditherPixels, double minimumDitherPixels, bool ditherRAOnly) {
+            double effectiveMinimum = NormalizeMinimum(ditherPixels, minimumDitherPixels);
+            for (int attempt = 0; attempt < MaxSelectionAttempts; attempt++) {
+                DitherOffset candidate = candidateFactory(ditherPixels);
+                if (ditherRAOnly) {
+                    candidate = new DitherOffset(candidate.WestEastPixels, previousOffset.NorthSouthPixels);
+                }
+
+                if (MeetsMinimum(previousOffset, candidate, effectiveMinimum, ditherRAOnly)) {
+                    return candidate;
+                }
+            }
+
+            return GenerateFallback(previousOffset, effectiveMinimum, ditherRAOnly);
+        }
+
+        internal static double NormalizeMinimum(double ditherPixels, double minimumDitherPixels) {
+            double maximum = double.IsFinite(ditherPixels) && ditherPixels > 0.0 ? ditherPixels : 0.0;
+            if (double.IsNaN(minimumDitherPixels) || minimumDitherPixels <= 0.0) {
+                return 0.0;
+            }
+            if (double.IsPositiveInfinity(minimumDitherPixels) || minimumDitherPixels > maximum) {
+                return maximum;
+            }
+            return minimumDitherPixels;
+        }
+
+        private static DitherOffset GenerateCandidate(double ditherPixels, Random random) {
+            double ditherAngle = random.NextDouble() * Math.PI;
+            double targetDistancePixels = NormalDistribution.Random(mean: 0.0, stdDev: ditherPixels);
+            targetDistancePixels = Math.Min(3.0d * ditherPixels, Math.Max(-3.0d * ditherPixels, targetDistancePixels));
+            return new DitherOffset(
+                targetDistancePixels * Math.Cos(ditherAngle),
+                targetDistancePixels * Math.Sin(ditherAngle));
+        }
+
+        private static bool MeetsMinimum(DitherOffset previousOffset, DitherOffset candidate, double minimumDitherPixels, bool ditherRAOnly) {
+            double westEastMovement = candidate.WestEastPixels - previousOffset.WestEastPixels;
+            if (ditherRAOnly) {
+                return Math.Abs(westEastMovement) >= minimumDitherPixels;
+            }
+
+            double northSouthMovement = candidate.NorthSouthPixels - previousOffset.NorthSouthPixels;
+            return Math.Sqrt(westEastMovement * westEastMovement + northSouthMovement * northSouthMovement) >= minimumDitherPixels;
+        }
+
+        private static DitherOffset GenerateFallback(DitherOffset previousOffset, double minimumDitherPixels, bool ditherRAOnly) {
+            if (minimumDitherPixels <= 0.0) {
+                return previousOffset;
+            }
+
+            if (ditherRAOnly) {
+                double direction = previousOffset.WestEastPixels > 0.0 ? -1.0 : 1.0;
+                return new DitherOffset(
+                    previousOffset.WestEastPixels + direction * minimumDitherPixels,
+                    previousOffset.NorthSouthPixels);
+            }
+
+            double distanceFromOrigin = Math.Sqrt(
+                previousOffset.WestEastPixels * previousOffset.WestEastPixels
+                + previousOffset.NorthSouthPixels * previousOffset.NorthSouthPixels);
+            if (distanceFromOrigin == 0.0) {
+                return new DitherOffset(minimumDitherPixels, 0.0);
+            }
+
+            return new DitherOffset(
+                previousOffset.WestEastPixels - minimumDitherPixels * previousOffset.WestEastPixels / distanceFromOrigin,
+                previousOffset.NorthSouthPixels - minimumDitherPixels * previousOffset.NorthSouthPixels / distanceFromOrigin);
+        }
+    }
+}

--- a/NINA.Profile/GuiderSettings.cs
+++ b/NINA.Profile/GuiderSettings.cs
@@ -33,6 +33,7 @@ namespace NINA.Profile {
         protected override void SetDefaultValues() {
             lastDeviceName = string.Empty;
             ditherPixels = 5;
+            mountDitherMinimumPixels = 0;
             ditherRAOnly = false;
             settleTime = 10;
             pHD2ServerUrl = "localhost";
@@ -103,6 +104,19 @@ namespace NINA.Profile {
             set {
                 if (ditherPixels != value) {
                     ditherPixels = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private double mountDitherMinimumPixels;
+
+        [DataMember]
+        public double MountDitherMinimumPixels {
+            get => mountDitherMinimumPixels;
+            set {
+                if (mountDitherMinimumPixels != value) {
+                    mountDitherMinimumPixels = value;
                     RaisePropertyChanged();
                 }
             }

--- a/NINA.Profile/Interfaces/IGuiderSettings.cs
+++ b/NINA.Profile/Interfaces/IGuiderSettings.cs
@@ -21,6 +21,7 @@ namespace NINA.Profile.Interfaces {
         string GuiderName { get; set; }
         string LastDeviceName { get; set; }
         double DitherPixels { get; set; }
+        double MountDitherMinimumPixels { get; set; }
         bool DitherRAOnly { get; set; }
         GuiderScaleEnum PHD2GuiderScale { get; set; }
         bool PHD2GuideChartShowStarMass { get; set; }

--- a/NINA.Test/Equipment/DirectGuiderTest.cs
+++ b/NINA.Test/Equipment/DirectGuiderTest.cs
@@ -1,0 +1,162 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.Enum;
+using NINA.Equipment.Equipment.MyGuider;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Profile.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NINA.Test.Equipment {
+
+    [TestFixture]
+    public class DirectGuiderTest {
+
+        [Test]
+        public void SelectOffset_WhenCandidateMovementIsBelowMinimum_RejectsCandidate() {
+            Queue<DitherOffset> candidates = new Queue<DitherOffset>(new[] {
+                new DitherOffset(4.8, 0.5),
+                new DitherOffset(-2.0, 1.0)
+            });
+            DitherOffsetSelector sut = new DitherOffsetSelector(_ => candidates.Dequeue());
+
+            DitherOffset result = sut.SelectOffset(new DitherOffset(5.0, 0.5), 5.0, 1.0, false);
+
+            result.WestEastPixels.Should().Be(-2.0);
+            result.NorthSouthPixels.Should().Be(1.0);
+            candidates.Should().BeEmpty();
+        }
+
+        [Test]
+        public void SelectOffset_WhenMovementEqualsMinimum_AcceptsCandidate() {
+            Queue<DitherOffset> candidates = new Queue<DitherOffset>(new[] {
+                new DitherOffset(3.0, 4.0)
+            });
+            DitherOffsetSelector sut = new DitherOffsetSelector(_ => candidates.Dequeue());
+
+            DitherOffset result = sut.SelectOffset(new DitherOffset(0.0, 0.0), 5.0, 5.0, false);
+
+            result.WestEastPixels.Should().Be(3.0);
+            result.NorthSouthPixels.Should().Be(4.0);
+            candidates.Should().BeEmpty();
+        }
+
+        [Test]
+        public void SelectOffset_WhenMinimumIsZero_AcceptsFirstCandidate() {
+            Queue<DitherOffset> candidates = new Queue<DitherOffset>(new[] {
+                new DitherOffset(0.0, 0.0),
+                new DitherOffset(5.0, 0.0)
+            });
+            DitherOffsetSelector sut = new DitherOffsetSelector(_ => candidates.Dequeue());
+
+            DitherOffset result = sut.SelectOffset(new DitherOffset(0.0, 0.0), 5.0, 0.0, false);
+
+            result.WestEastPixels.Should().Be(0.0);
+            result.NorthSouthPixels.Should().Be(0.0);
+            candidates.Should().ContainSingle();
+        }
+
+        [Test]
+        public void SelectOffset_WhenDitheringRAOnly_RequiresRAMovementAndPreservesDeclinationOffset() {
+            Queue<DitherOffset> candidates = new Queue<DitherOffset>(new[] {
+                new DitherOffset(0.5, 10.0),
+                new DitherOffset(-2.0, -10.0)
+            });
+            DitherOffsetSelector sut = new DitherOffsetSelector(_ => candidates.Dequeue());
+
+            DitherOffset result = sut.SelectOffset(new DitherOffset(0.0, 3.0), 5.0, 1.0, true);
+
+            result.WestEastPixels.Should().Be(-2.0);
+            result.NorthSouthPixels.Should().Be(3.0);
+            candidates.Should().BeEmpty();
+        }
+
+        [TestCase(-1.0, 0.0)]
+        [TestCase(0.0, 0.0)]
+        [TestCase(2.0, 2.0)]
+        [TestCase(5.0, 5.0)]
+        [TestCase(6.0, 5.0)]
+        public void NormalizeMinimum_ConstrainsValueToConfiguredDitherPixels(double minimum, double expected) {
+            DitherOffsetSelector.NormalizeMinimum(5.0, minimum).Should().Be(expected);
+        }
+
+        [TestCase(false, 3.0, 4.0)]
+        [TestCase(false, -3.0, -4.0)]
+        [TestCase(true, 5.0, 7.0)]
+        [TestCase(true, -5.0, 7.0)]
+        public void SelectOffset_WhenCandidatesAreExhausted_FallsBackToExactMinimum(bool raOnly, double previousWestEast, double previousNorthSouth) {
+            DitherOffsetSelector sut = new DitherOffsetSelector(_ => new DitherOffset(previousWestEast, previousNorthSouth));
+            DitherOffset previous = new DitherOffset(previousWestEast, previousNorthSouth);
+
+            DitherOffset result = sut.SelectOffset(previous, 5.0, 2.0, raOnly);
+
+            double westEastMovement = result.WestEastPixels - previous.WestEastPixels;
+            double northSouthMovement = result.NorthSouthPixels - previous.NorthSouthPixels;
+            double movement = raOnly
+                ? Math.Abs(westEastMovement)
+                : Math.Sqrt(westEastMovement * westEastMovement + northSouthMovement * northSouthMovement);
+            movement.Should().BeApproximately(2.0, 1e-10);
+            if (raOnly) {
+                result.NorthSouthPixels.Should().Be(previousNorthSouth);
+            }
+        }
+
+        [Test]
+        public async Task Dither_WithConfiguredMinimum_UsesQualifyingMovementForPulseGuide() {
+            Mock<IProfileService> profileService = new Mock<IProfileService>();
+            Mock<IProfile> profile = new Mock<IProfile>();
+            Mock<IGuiderSettings> guiderSettings = new Mock<IGuiderSettings>();
+            Mock<ICameraSettings> cameraSettings = new Mock<ICameraSettings>();
+            Mock<ITelescopeSettings> telescopeSettings = new Mock<ITelescopeSettings>();
+            Mock<ITelescopeMediator> telescopeMediator = new Mock<ITelescopeMediator>();
+            Queue<DitherOffset> candidates = new Queue<DitherOffset>(new[] {
+                new DitherOffset(0.25, 0.25),
+                new DitherOffset(2.0, -3.0)
+            });
+            DitherOffsetSelector selector = new DitherOffsetSelector(_ => candidates.Dequeue());
+            guiderSettings.SetupGet(x => x.DitherPixels).Returns(5.0);
+            guiderSettings.SetupGet(x => x.MountDitherMinimumPixels).Returns(1.0);
+            guiderSettings.SetupGet(x => x.SettleTime).Returns(0);
+            guiderSettings.SetupGet(x => x.DitherRAOnly).Returns(false);
+            cameraSettings.SetupGet(x => x.PixelSize).Returns(3.76);
+            telescopeSettings.SetupGet(x => x.FocalLength).Returns(600.0);
+            profile.SetupGet(x => x.GuiderSettings).Returns(guiderSettings.Object);
+            profile.SetupGet(x => x.CameraSettings).Returns(cameraSettings.Object);
+            profile.SetupGet(x => x.TelescopeSettings).Returns(telescopeSettings.Object);
+            profileService.SetupGet(x => x.ActiveProfile).Returns(profile.Object);
+            DirectGuider sut = new DirectGuider(profileService.Object, telescopeMediator.Object, selector);
+            sut.UpdateDeviceInfo(new TelescopeInfo {
+                Connected = true,
+                GuideRateRightAscensionArcsecPerSec = 1.0,
+                GuideRateDeclinationArcsecPerSec = 1.0
+            });
+            sut.PixelScale = 0.001;
+            sut.WestEastGuideRate = 1.0;
+            sut.NorthSouthGuideRate = 1.0;
+
+            bool result = await sut.Dither(null, CancellationToken.None);
+
+            result.Should().BeTrue();
+            telescopeMediator.Verify(x => x.PulseGuide(GuideDirections.guideEast, 2), Times.Once);
+            telescopeMediator.Verify(x => x.PulseGuide(GuideDirections.guideSouth, 3), Times.Once);
+            candidates.Should().BeEmpty();
+        }
+    }
+}

--- a/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
+++ b/NINA.Test/ProfileTest/ProfileSettingsBehaviorTest.cs
@@ -8,8 +8,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Media;
+using System.Xml.Linq;
 
 namespace NINA.Test.ProfileTest {
 
@@ -335,6 +337,42 @@ namespace NINA.Test.ProfileTest {
             defaults.PHD2GuideChartShowSNR.Should().BeFalse();
             roundTripped.PHD2GuideChartShowStarMass.Should().BeTrue();
             roundTripped.PHD2GuideChartShowSNR.Should().BeTrue();
+        }
+
+        [Test]
+        public void GuiderSettings_MountDitherMinimumPixels_RoundTripsWithCompatibleDefault() {
+            GuiderSettings defaults = new GuiderSettings();
+            GuiderSettings settings = new GuiderSettings {
+                MountDitherMinimumPixels = 2.5
+            };
+
+            GuiderSettings roundTripped = RoundTrip(settings);
+
+            defaults.MountDitherMinimumPixels.Should().Be(0.0);
+            roundTripped.MountDitherMinimumPixels.Should().Be(2.5);
+        }
+
+        [Test]
+        public void GuiderSettings_MissingMountDitherMinimumPixels_UsesCompatibleDefault() {
+            GuiderSettings settings = new GuiderSettings {
+                MountDitherMinimumPixels = 2.5
+            };
+            DataContractSerializer serializer = new DataContractSerializer(typeof(GuiderSettings));
+            using MemoryStream stream = new MemoryStream();
+            serializer.WriteObject(stream, settings);
+            stream.Position = 0;
+
+            XDocument document = XDocument.Load(stream);
+            document.Descendants()
+                .Single(element => element.Name.LocalName == nameof(GuiderSettings.MountDitherMinimumPixels))
+                .Remove();
+            stream.SetLength(0);
+            document.Save(stream);
+            stream.Position = 0;
+
+            GuiderSettings deserialized = (GuiderSettings)serializer.ReadObject(stream);
+
+            deserialized.MountDitherMinimumPixels.Should().Be(0.0);
         }
 
         private static List<string> CapturePropertyChanges(INotifyPropertyChanged source) {

--- a/NINA.Test/View/DirectGuiderDetailViewTest.cs
+++ b/NINA.Test/View/DirectGuiderDetailViewTest.cs
@@ -1,0 +1,82 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.View.Equipment.Guider;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace NINA.Test.View {
+
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [NonParallelizable]
+    [SingleThreaded]
+    public class DirectGuiderDetailViewTest {
+
+        [Test]
+        public void Constructor_LoadsMinimumDitherBindingAndValidation() {
+            EnsureApplicationResources();
+
+            DirectGuiderDetailView view = new DirectGuiderDetailView();
+            Window host = new Window { Width = 800, Height = 450, Content = view };
+            host.Measure(new Size(host.Width, host.Height));
+            host.Arrange(new Rect(0, 0, host.Width, host.Height));
+            host.UpdateLayout();
+
+            TextBox minimumTextBox = FindLogicalDescendants<TextBox>(view)
+                .Single(textBox => BindingOperations.GetBinding(textBox, TextBox.TextProperty)?.Path?.Path
+                    == "ActiveProfile.GuiderSettings.MountDitherMinimumPixels");
+            Binding minimumBinding = BindingOperations.GetBinding(minimumTextBox, TextBox.TextProperty);
+
+            minimumBinding.ValidationRules.Should().ContainSingle(rule => rule is NINA.Core.Utility.ValidationRules.DoubleRangeRule);
+            host.Close();
+        }
+
+        private static void EnsureApplicationResources() {
+            const string resourcesLoadedMarker = "DirectGuiderDetailViewTest.ResourcesLoaded";
+            Application app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            if (app.Resources.Contains(resourcesLoadedMarker)) {
+                return;
+            }
+
+            string[] resourceSources = [
+                "/NINA.WPF.Base;component/Resources/StaticResources/ProfileService.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Brushes.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBlock.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/CheckBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Tooltip.xaml"
+            ];
+
+            foreach (string resourceSource in resourceSources) {
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary {
+                    Source = new Uri(resourceSource, UriKind.Relative)
+                });
+            }
+            app.Resources[resourcesLoadedMarker] = true;
+        }
+
+        private static T[] FindLogicalDescendants<T>(DependencyObject root) where T : DependencyObject {
+            return LogicalTreeHelper.GetChildren(root)
+                .OfType<DependencyObject>()
+                .SelectMany(child => (child is T match ? new[] { match } : Array.Empty<T>()).Concat(FindLogicalDescendants<T>(child)))
+                .ToArray();
+        }
+    }
+}

--- a/NINA/View/Equipment/Guider/DirectGuiderDetailView.xaml
+++ b/NINA/View/Equipment/Guider/DirectGuiderDetailView.xaml
@@ -105,6 +105,38 @@
                         </ninactrl:UnitTextBox>
                     </Grid>
                 </UniformGrid>
+                <UniformGrid
+                    Margin="5,5,0,0"
+                    VerticalAlignment="Center"
+                    Columns="2">
+                    <TextBlock
+                        MinWidth="200"
+                        VerticalAlignment="Center"
+                        Text="{ns:Loc LblMountDitherMinimumPixels}"
+                        ToolTip="{ns:Loc LblMountDitherMinimumPixelsTooltip}" />
+                    <ninactrl:UnitTextBox
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Unit="px">
+                        <TextBox.Text>
+                            <Binding
+                                Path="ActiveProfile.GuiderSettings.MountDitherMinimumPixels"
+                                Source="{StaticResource ProfileService}"
+                                UpdateSourceTrigger="LostFocus">
+                                <Binding.ValidationRules>
+                                    <rules:DoubleRangeRule>
+                                        <rules:DoubleRangeRule.ValidRange>
+                                            <rules:DoubleRangeChecker
+                                                Maximum="{Binding Source={StaticResource ProfileService}, Path=ActiveProfile.GuiderSettings.DitherPixels}"
+                                                Minimum="0" />
+                                        </rules:DoubleRangeRule.ValidRange>
+                                    </rules:DoubleRangeRule>
+                                </Binding.ValidationRules>
+                            </Binding>
+                        </TextBox.Text>
+                    </ninactrl:UnitTextBox>
+                </UniformGrid>
                 <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="0">
                     <UniformGrid
                         Margin="5,5,0,0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,7 @@ This allows you to safely return to a stable release if needed.
 
 ## Improvements
 - URLs throughout the application can now be copied from their right-click context menu.
+- Mount Dither can now enforce a configurable minimum movement between exposures, preventing randomly selected offsets that are too small to be useful.
 - PHD2 users can optionally show guide-star mass and SNR in the guide graphs, using PHD2-style independent scaling in the upper half of the chart.
 - **Autofocus after HFR Increase Trigger**
     - new Trend per Filter checkbox to consider HFR Trend per filter (default) or across all filters to earlier trigger autofocus runs when imaging with continues filter loops 


### PR DESCRIPTION
## 🚀 Purpose

Adds a configurable minimum movement for Mount Dither so randomly selected positions cannot produce ineffective, very small dithers.

The setting defaults to `0`, preserving existing behavior.

## 🧪 How Was It Tested?

- Added tests for two-axis and RA-only dithering, boundary values and profile compatibility
- Runtime-tested the updated XAML view
- Full test suite: 5,441 passed, 16 skipped
- Application build passed

## 🤖 AI / Tooling Disclosure

OpenAI Codex assisted with the implementation, tests and documentation.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes
- [x] Plugin API compatibility reviewed
  - [ ] No breaking changes to interfaces
  - [x] No changes to public method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated

## 🔗 Related Issues

Closes #254

## 📸 Screenshots

Not included.

## 📝 Additional Notes

-