### PR TITLE
Fix camera abort cancellation for active captures

### DIFF
--- a/NINA.Test/Mediator/CameraMediatorTest.cs
+++ b/NINA.Test/Mediator/CameraMediatorTest.cs
@@ -1,7 +1,11 @@
 using FluentAssertions;
 using Moq;
+using NINA.Core.Model;
 using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Equipment.Model;
 using NINA.WPF.Base.Mediator;
+using System.Threading;
 
 namespace NINA.Test.Mediator {
 
@@ -72,6 +76,137 @@ namespace NINA.Test.Mediator {
 
             mediator.ReleaseCaptureBlock(owner);
             mediator.IsFreeToCapture(other).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Verifies that aborting an exposure also cancels the active mediator capture while still forwarding the hardware abort.
+        /// This protects plugin callers that abort independently of the token supplied when capture started.
+        /// </summary>
+        [Test]
+        public async Task AbortExposure_WhenCaptureIsActive_CancelsCaptureAndForwardsAbort() {
+            TaskCompletionSource<bool> captureStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<ICameraVM> handler = new Mock<ICameraVM>();
+            handler.Setup(x => x.Capture(It.IsAny<CaptureSequence>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .Returns<CaptureSequence, CancellationToken, IProgress<ApplicationStatus>>(async (_, token, _) => {
+                    captureStarted.TrySetResult(true);
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                });
+            CameraMediator mediator = CreateMediator(handler);
+
+            Task captureTask = Capture(mediator, CancellationToken.None);
+            await captureStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            mediator.AbortExposure();
+
+            Func<Task> waitForCapture = async () => await captureTask.WaitAsync(TimeSpan.FromSeconds(1));
+            await waitForCapture.Should().ThrowAsync<OperationCanceledException>();
+            handler.Verify(x => x.AbortExposure(), Times.Once);
+        }
+
+        /// <summary>
+        /// Verifies that the caller-provided cancellation token retains its normal cancellation behavior.
+        /// This protects built-in capture flows that own and cancel their operation token directly.
+        /// </summary>
+        [Test]
+        public async Task Capture_WhenCallerTokenIsCancelled_CancelsCapture() {
+            TaskCompletionSource<bool> captureStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            Mock<ICameraVM> handler = new Mock<ICameraVM>();
+            handler.Setup(x => x.Capture(It.IsAny<CaptureSequence>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .Returns<CaptureSequence, CancellationToken, IProgress<ApplicationStatus>>(async (_, token, _) => {
+                    captureStarted.TrySetResult(true);
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                });
+            CameraMediator mediator = CreateMediator(handler);
+            using CancellationTokenSource callerCts = new CancellationTokenSource();
+            Task captureTask = Capture(mediator, callerCts.Token);
+            await captureStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            callerCts.Cancel();
+
+            Func<Task> waitForCapture = async () => await captureTask.WaitAsync(TimeSpan.FromSeconds(1));
+            await waitForCapture.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        /// <summary>
+        /// Verifies that an abort only cancels captures that were already in flight.
+        /// This protects the supported workflow of starting a new exposure immediately after an abort.
+        /// </summary>
+        [Test]
+        public async Task Capture_WhenStartedAfterAbort_UsesFreshCancellationToken() {
+            TaskCompletionSource<bool> firstCaptureStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> secondCaptureStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> releaseSecondCapture = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationToken secondCaptureToken = default;
+            int captureCount = 0;
+            Mock<ICameraVM> handler = new Mock<ICameraVM>();
+            handler.Setup(x => x.Capture(It.IsAny<CaptureSequence>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .Returns<CaptureSequence, CancellationToken, IProgress<ApplicationStatus>>(async (_, token, _) => {
+                    if (Interlocked.Increment(ref captureCount) == 1) {
+                        firstCaptureStarted.TrySetResult(true);
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    } else {
+                        secondCaptureToken = token;
+                        secondCaptureStarted.TrySetResult(true);
+                        await releaseSecondCapture.Task.WaitAsync(token);
+                    }
+                });
+            CameraMediator mediator = CreateMediator(handler);
+
+            Task firstCaptureTask = Capture(mediator, CancellationToken.None);
+            await firstCaptureStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            mediator.AbortExposure();
+            Func<Task> waitForFirstCapture = async () => await firstCaptureTask.WaitAsync(TimeSpan.FromSeconds(1));
+            await waitForFirstCapture.Should().ThrowAsync<OperationCanceledException>();
+
+            Task secondCaptureTask = Capture(mediator, CancellationToken.None);
+            await secondCaptureStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            secondCaptureToken.IsCancellationRequested.Should().BeFalse();
+            releaseSecondCapture.TrySetResult(true);
+            await secondCaptureTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+
+        /// <summary>
+        /// Verifies that aborting after one capture has completed does not poison the next capture.
+        /// This protects idle abort calls and cleanup races between successive captures.
+        /// </summary>
+        [Test]
+        public async Task AbortExposure_AfterCaptureCompleted_DoesNotCancelLaterCapture() {
+            TaskCompletionSource<bool> secondCaptureStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> releaseSecondCapture = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationToken secondCaptureToken = default;
+            int captureCount = 0;
+            Mock<ICameraVM> handler = new Mock<ICameraVM>();
+            handler.Setup(x => x.Capture(It.IsAny<CaptureSequence>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<ApplicationStatus>>()))
+                .Returns<CaptureSequence, CancellationToken, IProgress<ApplicationStatus>>(async (_, token, _) => {
+                    if (Interlocked.Increment(ref captureCount) == 1) {
+                        return;
+                    }
+
+                    secondCaptureToken = token;
+                    secondCaptureStarted.TrySetResult(true);
+                    await releaseSecondCapture.Task.WaitAsync(token);
+                });
+            CameraMediator mediator = CreateMediator(handler);
+
+            await Capture(mediator, CancellationToken.None);
+            mediator.AbortExposure();
+            Task secondCaptureTask = Capture(mediator, CancellationToken.None);
+            await secondCaptureStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            secondCaptureToken.IsCancellationRequested.Should().BeFalse();
+            releaseSecondCapture.TrySetResult(true);
+            await secondCaptureTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+
+        private static Task Capture(CameraMediator mediator, CancellationToken token) {
+            return mediator.Capture(new CaptureSequence(), token, Mock.Of<IProgress<ApplicationStatus>>());
+        }
+
+        private static CameraMediator CreateMediator(Mock<ICameraVM> handler) {
+            CameraMediator mediator = new CameraMediator();
+            mediator.RegisterHandler(handler.Object);
+            return mediator;
         }
     }
 }

--- a/NINA.WPF.Base/Mediator/CameraMediator.cs
+++ b/NINA.WPF.Base/Mediator/CameraMediator.cs
@@ -28,15 +28,24 @@ namespace NINA.WPF.Base.Mediator {
 
     public class CameraMediator : DeviceMediator<ICameraVM, ICameraConsumer, CameraInfo>, ICameraMediator {
         private object blockingConsumer;
+        private readonly object captureCancellationLock = new();
+        private CancellationTokenSource captureAbortTokenSource = new();
 
         public event Func<object, EventArgs, Task> DownloadTimeout {
             add { this.handler.DownloadTimeout += value; }
             remove { this.handler.DownloadTimeout -= value; }
         }
 
-        public Task Capture(CaptureSequence sequence, CancellationToken token,
+        public async Task Capture(CaptureSequence sequence, CancellationToken token,
             IProgress<ApplicationStatus> progress) {
-            return handler.Capture(sequence, token, progress);
+            CancellationTokenSource linkedTokenSource;
+            lock (captureCancellationLock) {
+                linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, captureAbortTokenSource.Token);
+            }
+
+            using (linkedTokenSource) {
+                await handler.Capture(sequence, linkedTokenSource.Token, progress);
+            }
         }
 
         public IAsyncEnumerable<IExposureData> LiveView(CancellationToken token) {
@@ -60,6 +69,18 @@ namespace NINA.WPF.Base.Mediator {
         }
 
         public void AbortExposure() {
+            CancellationTokenSource tokenSourceToCancel;
+            lock (captureCancellationLock) {
+                tokenSourceToCancel = captureAbortTokenSource;
+                captureAbortTokenSource = new CancellationTokenSource();
+            }
+
+            try {
+                tokenSourceToCancel.Cancel();
+            } finally {
+                tokenSourceToCancel.Dispose();
+            }
+
             handler.AbortExposure();
         }
 


### PR DESCRIPTION
## 🚀 Purpose

Cancel the active capture workflow when `ICameraMediator.AbortExposure()` is called.

## 🧪 How Was It Tested?

- Added four `CameraMediator` regression tests.
- Broader camera and sequencer tests: 176 passed.
- Full suite: 5,457 passed, 16 skipped.
- Application build: 0 warnings and 0 errors.
- Manual hardware testing was not available.

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to implement the code, tests and release note.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (not applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated (not applicable)

## 🔗 Related Issues

Closes #65.

## 📸 Screenshots

Not applicable.

## 📝 Additional Notes

The fix is contained within `CameraMediator`. Captures now use a linked mediator abort token while preserving caller cancellation behavior.