### PR TITLE
Prevent connect-all and disconnect-all operations from overlapping

### DIFF
--- a/NINA.Test/ViewModel/ApplicationDeviceConnectionVMTest.cs
+++ b/NINA.Test/ViewModel/ApplicationDeviceConnectionVMTest.cs
@@ -1,0 +1,265 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.MyMessageBox;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Equipment.MyDome;
+using NINA.Equipment.Equipment.MyFilterWheel;
+using NINA.Equipment.Equipment.MyFlatDevice;
+using NINA.Equipment.Equipment.MyFocuser;
+using NINA.Equipment.Equipment.MyGuider;
+using NINA.Equipment.Equipment.MyRotator;
+using NINA.Equipment.Equipment.MySafetyMonitor;
+using NINA.Equipment.Equipment.MySwitch;
+using NINA.Equipment.Equipment.MyTelescope;
+using NINA.Equipment.Equipment.MyWeatherData;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Plugin.Interfaces;
+using NINA.Profile.Interfaces;
+using NINA.ViewModel;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace NINA.Test.ViewModel {
+
+#pragma warning disable CS0618 // ApplicationDeviceConnectionVM intentionally exposes the legacy AsyncCommand implementation.
+
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [NonParallelizable]
+    public class ApplicationDeviceConnectionVMTest {
+        private Mock<ICameraMediator> cameraMediator;
+        private Mock<ITelescopeMediator> telescopeMediator;
+        private Mock<IDomeMediator> domeMediator;
+        private Mock<IFilterWheelMediator> filterWheelMediator;
+        private Mock<IFocuserMediator> focuserMediator;
+        private Mock<IRotatorMediator> rotatorMediator;
+        private Mock<IFlatDeviceMediator> flatDeviceMediator;
+        private Mock<IGuiderMediator> guiderMediator;
+        private Mock<IWeatherDataMediator> weatherDataMediator;
+        private Mock<ISwitchMediator> switchMediator;
+        private Mock<ISafetyMonitorMediator> safetyMonitorMediator;
+        private Mock<IPluginLoader> pluginLoader;
+        private Mock<IUsbDeviceWatcher> usbDeviceWatcher;
+        private Window previousMainWindow;
+        private Window ownerWindow;
+
+        [SetUp]
+        public void SetUp() {
+            EnsureApplicationResources();
+            previousMainWindow = Application.Current.MainWindow;
+            ownerWindow = new Window {
+                ShowActivated = false,
+                ShowInTaskbar = false,
+                WindowStyle = WindowStyle.None,
+                Width = 1,
+                Height = 1,
+                Left = -10000,
+                Top = -10000
+            };
+            ownerWindow.Show();
+            Application.Current.MainWindow = ownerWindow;
+
+            cameraMediator = new Mock<ICameraMediator>();
+            telescopeMediator = new Mock<ITelescopeMediator>();
+            domeMediator = new Mock<IDomeMediator>();
+            filterWheelMediator = new Mock<IFilterWheelMediator>();
+            focuserMediator = new Mock<IFocuserMediator>();
+            rotatorMediator = new Mock<IRotatorMediator>();
+            flatDeviceMediator = new Mock<IFlatDeviceMediator>();
+            guiderMediator = new Mock<IGuiderMediator>();
+            weatherDataMediator = new Mock<IWeatherDataMediator>();
+            switchMediator = new Mock<ISwitchMediator>();
+            safetyMonitorMediator = new Mock<ISafetyMonitorMediator>();
+            pluginLoader = new Mock<IPluginLoader>();
+            usbDeviceWatcher = new Mock<IUsbDeviceWatcher>();
+
+            cameraMediator.Setup(x => x.GetInfo()).Returns(new CameraInfo());
+            telescopeMediator.Setup(x => x.GetInfo()).Returns(new TelescopeInfo());
+            domeMediator.Setup(x => x.GetInfo()).Returns(new DomeInfo());
+            filterWheelMediator.Setup(x => x.GetInfo()).Returns(new FilterWheelInfo());
+            focuserMediator.Setup(x => x.GetInfo()).Returns(new FocuserInfo());
+            rotatorMediator.Setup(x => x.GetInfo()).Returns(new RotatorInfo());
+            flatDeviceMediator.Setup(x => x.GetInfo()).Returns(new FlatDeviceInfo());
+            guiderMediator.Setup(x => x.GetInfo()).Returns(new GuiderInfo());
+            weatherDataMediator.Setup(x => x.GetInfo()).Returns(new WeatherDataInfo());
+            switchMediator.Setup(x => x.GetInfo()).Returns(new SwitchInfo());
+            safetyMonitorMediator.Setup(x => x.GetInfo()).Returns(new SafetyMonitorInfo());
+
+            cameraMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            telescopeMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            domeMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            filterWheelMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            focuserMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            rotatorMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            flatDeviceMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            guiderMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            weatherDataMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            switchMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+            safetyMonitorMediator.Setup(x => x.Connect()).ReturnsAsync(true);
+
+            cameraMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            telescopeMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            domeMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            filterWheelMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            focuserMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            rotatorMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            flatDeviceMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            guiderMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            weatherDataMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            switchMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+            safetyMonitorMediator.Setup(x => x.Disconnect()).Returns(Task.CompletedTask);
+
+            pluginLoader.Setup(x => x.Load()).Returns(Task.CompletedTask);
+        }
+
+        [TearDown]
+        public void TearDown() {
+            foreach (MyMessageBoxView dialog in Application.Current.Windows.OfType<MyMessageBoxView>().ToArray()) {
+                dialog.Close();
+            }
+            Application.Current.MainWindow = previousMainWindow;
+            ownerWindow.Close();
+        }
+
+        [Test]
+        public async Task ConnectAllDevicesCommand_DisablesDisconnectWhileConnectionIsRunning() {
+            TaskCompletionSource<bool> connection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource connectionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            cameraMediator.Setup(x => x.Connect()).Returns(() => {
+                connectionStarted.TrySetResult();
+                return connection.Task;
+            });
+            ApplicationDeviceConnectionVM sut = CreateInitializedSut();
+
+            Task execution = ExecuteConfirmed(sut.ConnectAllDevicesCommand);
+            await connectionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            AsyncCommand<bool> connectCommand = (AsyncCommand<bool>)sut.ConnectAllDevicesCommand;
+            connectCommand.Execution.InnerException.Should().BeNull();
+            connectCommand.IsRunning.Should().BeTrue();
+            sut.ConnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+            sut.DisconnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+
+            connection.SetResult(true);
+            await execution;
+
+            sut.DisconnectAllDevicesCommand.CanExecute(null).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task DisconnectAllDevicesCommand_DisablesConnectWhileDisconnectionIsRunning() {
+            TaskCompletionSource disconnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource disconnectionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            guiderMediator.Setup(x => x.Disconnect()).Returns(() => {
+                disconnectionStarted.TrySetResult();
+                return disconnection.Task;
+            });
+            ApplicationDeviceConnectionVM sut = CreateInitializedSut();
+
+            Task execution = ExecuteConfirmed(sut.DisconnectAllDevicesCommand);
+            await disconnectionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            AsyncCommand<bool> disconnectCommand = (AsyncCommand<bool>)sut.DisconnectAllDevicesCommand;
+            disconnectCommand.Execution.InnerException.Should().BeNull();
+            disconnectCommand.IsRunning.Should().BeTrue();
+            sut.DisconnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+            sut.ConnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+
+            disconnection.SetResult();
+            await execution;
+
+            sut.ConnectAllDevicesCommand.CanExecute(null).Should().BeTrue();
+        }
+
+        [Test]
+        public void DeviceConnectionCommands_RemainDisabledUntilInitializationCompletes() {
+            TaskCompletionSource initialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            pluginLoader.Setup(x => x.Load()).Returns(initialization.Task);
+            ApplicationDeviceConnectionVM sut = CreateSut();
+
+            sut.ConnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+            sut.DisconnectAllDevicesCommand.CanExecute(null).Should().BeFalse();
+
+            initialization.SetResult();
+            SpinWait.SpinUntil(() => sut.Initialized, TimeSpan.FromSeconds(2)).Should().BeTrue();
+
+            sut.ConnectAllDevicesCommand.CanExecute(null).Should().BeTrue();
+            sut.DisconnectAllDevicesCommand.CanExecute(null).Should().BeTrue();
+        }
+
+        private ApplicationDeviceConnectionVM CreateInitializedSut() {
+            ApplicationDeviceConnectionVM sut = CreateSut();
+
+            SpinWait.SpinUntil(() => sut.Initialized, TimeSpan.FromSeconds(2)).Should().BeTrue();
+            return sut;
+        }
+
+        private ApplicationDeviceConnectionVM CreateSut() {
+            return new ApplicationDeviceConnectionVM(
+                new Mock<IProfileService>().Object,
+                cameraMediator.Object,
+                telescopeMediator.Object,
+                focuserMediator.Object,
+                filterWheelMediator.Object,
+                rotatorMediator.Object,
+                flatDeviceMediator.Object,
+                guiderMediator.Object,
+                switchMediator.Object,
+                weatherDataMediator.Object,
+                domeMediator.Object,
+                safetyMonitorMediator.Object,
+                pluginLoader.Object,
+                usbDeviceWatcher.Object);
+        }
+
+        private static Task ExecuteConfirmed(ICommand command) {
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() => {
+                MyMessageBoxView dialog = Application.Current.Windows.OfType<MyMessageBoxView>().Single();
+                dialog.DialogResult = true;
+            }));
+            return ((AsyncCommand<bool>)command).ExecuteAsync(null);
+        }
+
+        private static void EnsureApplicationResources() {
+            Application application = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            string[] resourceSources = [
+                "/NINA.WPF.Base;component/Resources/StaticResources/ProfileService.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/SVGDictionary.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Brushes.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Converters.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Button.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Path.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBlock.xaml",
+                "/NINA;component/Resources/Styles/Window.xaml"
+            ];
+
+            foreach (string resourceSource in resourceSources) {
+                if (!application.Resources.MergedDictionaries.Any(x => x.Source?.OriginalString == resourceSource)) {
+                    application.Resources.MergedDictionaries.Add(new ResourceDictionary {
+                        Source = new Uri(resourceSource, UriKind.Relative)
+                    });
+                }
+            }
+
+        }
+    }
+
+#pragma warning restore CS0618
+}

--- a/NINA/ViewModel/ApplicationDeviceConnectionVM.cs
+++ b/NINA/ViewModel/ApplicationDeviceConnectionVM.cs
@@ -207,7 +207,7 @@ namespace NINA.ViewModel {
                 } else {
                     return false;
                 }
-            }, (object o) => Initialized);
+            }, (object o) => Initialized && !((AsyncCommand<bool>)DisconnectAllDevicesCommand).IsRunning);
 
             DisconnectAllDevicesCommand = new AsyncCommand<bool>(async () => {
                 var diag = MyMessageBox.Show(Loc.Instance["LblDisconnectAll"], "", MessageBoxButton.OKCancel, MessageBoxResult.Cancel);
@@ -216,7 +216,7 @@ namespace NINA.ViewModel {
                     return true;
                 }
                 return false;
-            }, (object o) => Initialized);
+            }, (object o) => Initialized && !((AsyncCommand<bool>)ConnectAllDevicesCommand).IsRunning);
         }
 
         private async Task Device_Connected(object arg1, EventArgs arg2) {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- The Connect All and Disconnect All commands can no longer run at the same time, preventing conflicting device operations during slow connections.
 - Cached Offline Sky Map and Sky Atlas image tiles now keep a stable orientation across zoom levels instead of occasionally rotating by 180 degrees.
 - Center After Drift triggers in completed or otherwise inactive sequence containers no longer consume images or publish drift results while a later container is running.
 - Launching N.I.N.A. with a nonexistent `--profileid` now writes an error log and returns a non-zero exit code instead of failing silently.


### PR DESCRIPTION
## 🚀 Purpose

Prevent "Connect All" and "Disconnect All" from running at the same time.

Each command now checks the existing `IsRunning` state of its inverse command. This prevents conflicting operations against the same device mediators while preserving the existing serial connection order, exception handling and driver timeout behavior.

## 🧪 How Was It Tested?

Added an STA, non-parallelizable regression fixture covering the real command surface:

- Verified that "Disconnect All" is unavailable while "Connect All" is running and becomes available afterward.
- Verified the symmetric behavior for "Connect All" while "Disconnect All" is running.
- Verified initialization continues to gate both commands.
- Verified each command continues to prevent its own reentry.
- Confirmed the new overlap tests failed before the corresponding production fixes.

Final verification:

- Focused regression fixture: 3 passed
- `NINA.Test.ViewModel`: 137 passed
- Full `NINA.Test` suite: 5,456 passed, 16 skipped and 0 failed
- `NINA/NINA.csproj` build: 0 warnings and 0 errors
- `git diff --check`: clean

No manual theme testing was performed because this change does not modify XAML or visual styling.

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to help implement the command predicates, regression tests and release-note entry.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (not applicable; no visual or XAML changes)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated
- [x] [Documentation](https://github.com/isbeorn/nina.docs) updated (not applicable; no documentation changes required)

## 🔗 Related Issues

Closes #214

## 📸 Screenshots

Not applicable. This pull request does not include visual changes.

## 📝 Additional Notes

-