### PR TITLE
Fix fatal Nikon automatic exposure cancellation

### DIFF
--- a/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
+++ b/NINA.Equipment/Equipment/MyCamera/NikonCamera.cs
@@ -241,8 +241,46 @@ namespace NINA.Equipment.Equipment.MyCamera {
             }
         }
 
+        private readonly object exposureSync = new object();
         private TaskCompletionSource<object> _downloadExposure;
         private TaskCompletionSource<bool> _cameraConnected;
+        private Action activeExposureStopAction;
+        private bool activeExposureStopRequested;
+
+        private void SetActiveExposureStopAction(Action stopAction) {
+            lock (exposureSync) {
+                activeExposureStopAction = stopAction;
+                activeExposureStopRequested = false;
+            }
+        }
+
+        private void StopActiveExposure() {
+            Action stopAction;
+            CancellationTokenSource completionCancellationTokenSource;
+            lock (exposureSync) {
+                if (activeExposureStopAction == null || activeExposureStopRequested) {
+                    return;
+                }
+
+                activeExposureStopRequested = true;
+                stopAction = activeExposureStopAction;
+                activeExposureStopAction = null;
+                completionCancellationTokenSource = bulbCompletionCTS;
+                bulbCompletionCTS = null;
+            }
+
+            try {
+                completionCancellationTokenSource?.Cancel();
+            } catch (Exception ex) {
+                Logger.Error("Failed to cancel Nikon Bulb exposure timer.", ex);
+            }
+
+            try {
+                stopAction();
+            } catch (Exception ex) {
+                Logger.Error("Failed to stop Nikon exposure.", ex);
+            }
+        }
 
         private void _camera_CaptureComplete(NikonDevice sender, int data) {
             Logger.Debug("Capture complete");
@@ -612,12 +650,16 @@ namespace NINA.Equipment.Equipment.MyCamera {
         public bool HasBattery => true;
 
         public void AbortExposure() {
-            if (Connected) {
-                _camera.StopBulbCapture();
-            }
+            StopActiveExposure();
         }
 
         public void Disconnect() {
+            StopActiveExposure();
+            lock (exposureSync) {
+                _downloadExposure?.TrySetCanceled();
+                activeExposureStopAction = null;
+                activeExposureStopRequested = false;
+            }
             Connected = false;
             _camera = null;
             _activeNikonManager?.Shutdown();
@@ -631,8 +673,20 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
         public async Task WaitUntilExposureIsReady(CancellationToken token) {
-            using (token.Register(() => AbortExposure())) {
-                await _downloadExposure.Task;
+            Task downloadExposureTask;
+            lock (exposureSync) {
+                downloadExposureTask = _downloadExposure.Task;
+            }
+
+            try {
+                await downloadExposureTask.WaitAsync(token);
+            } catch (OperationCanceledException) when (token.IsCancellationRequested) {
+                try {
+                    AbortExposure();
+                } catch (Exception ex) {
+                    Logger.Error("Failed to abort Nikon exposure after cancellation.", ex);
+                }
+                throw;
             }
         }
 
@@ -667,21 +721,34 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
         private Dictionary<int, double> _shutterSpeeds = new Dictionary<int, double>();
         private int _bulbShutterSpeedIndex;
+        private const double MaximumAutomaticShutterExposureTime = 30.0;
+
+        private static bool UsesAutomaticShutter(double exposureTime) {
+            return exposureTime <= MaximumAutomaticShutterExposureTime;
+        }
 
         public void StartExposure(CaptureSequence sequence) {
             if (Connected) {
-                if (_downloadExposure != null && _downloadExposure.Task.Status <= TaskStatus.Running) {
+                bool exposureInProgress;
+                lock (exposureSync) {
+                    exposureInProgress = _downloadExposure != null && !_downloadExposure.Task.IsCompleted;
+                }
+                if (exposureInProgress) {
                     Notification.ShowWarning(Loc.Instance["LblExposureInProgress"]);
                     Logger.Warning("An exposure was still in progress. Cancelling it to start another.");
-                    try { bulbCompletionCTS?.Cancel(); } catch { }
+                    StopActiveExposure();
                     _downloadExposure.TrySetCanceled();
                 }
 
                 double exposureTime = sequence.ExposureTime;
                 Logger.Debug("Prepare start of exposure: " + sequence);
-                _downloadExposure = new TaskCompletionSource<object>();
+                lock (exposureSync) {
+                    activeExposureStopAction = null;
+                    activeExposureStopRequested = false;
+                    _downloadExposure = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
 
-                if (exposureTime <= 30.0) {
+                if (UsesAutomaticShutter(exposureTime)) {
                     Logger.Debug("Exposuretime <= 30. Setting automatic shutter speed.");
                     var speed = _shutterSpeeds.Aggregate((x, y) => Math.Abs(x.Value - exposureTime) < Math.Abs(y.Value - exposureTime) ? x : y);
                     SetCameraShutterSpeed(speed.Key);
@@ -778,27 +845,48 @@ namespace NINA.Equipment.Equipment.MyCamera {
 
             SetCameraShutterSpeed(_bulbShutterSpeedIndex);
 
+            SetActiveExposureStopAction(() => {
+                try {
+                    stopCapture();
+                } finally {
+                    Logger.Debug("Restore previous shutter speed");
+                    SetCameraShutterSpeed(_prevShutterSpeed);
+                }
+            });
+
             try {
                 Logger.Debug("Starting bulb capture");
                 capture();
             } catch (NikonException ex) {
                 if (ex.ErrorCode != eNkMAIDResult.kNkMAIDResult_BulbReleaseBusy) {
+                    StopActiveExposure();
                     throw;
                 }
+            } catch {
+                StopActiveExposure();
+                throw;
             }
 
             /*Stop Exposure after exposure time or upon cancellation*/
-            try { bulbCompletionCTS?.Cancel(); } catch { }
-            bulbCompletionCTS = new CancellationTokenSource();
-            bulbCompletionTask = Task.Run(async () => {
-                await CoreUtil.Wait(TimeSpan.FromSeconds(exposureTime), bulbCompletionCTS.Token);
-                if (!bulbCompletionCTS.IsCancellationRequested) {
-                    stopCapture();
-                    Logger.Debug("Restore previous shutter speed");
-                    // Restore original shutter speed
-                    SetCameraShutterSpeed(_prevShutterSpeed);
+            var completionCancellationTokenSource = new CancellationTokenSource();
+            lock (exposureSync) {
+                if (activeExposureStopRequested) {
+                    completionCancellationTokenSource.Dispose();
+                    return;
                 }
-            }, bulbCompletionCTS.Token);
+                bulbCompletionCTS = completionCancellationTokenSource;
+            }
+            bulbCompletionTask = Task.Run(async () => {
+                try {
+                    await CoreUtil.Wait(TimeSpan.FromSeconds(exposureTime), completionCancellationTokenSource.Token);
+                    StopActiveExposure();
+                } catch (OperationCanceledException) {
+                } catch (Exception ex) {
+                    Logger.Error("Failed while waiting to stop Nikon Bulb exposure.", ex);
+                } finally {
+                    completionCancellationTokenSource.Dispose();
+                }
+            });
         }
 
         private void StartBulbCapture() {
@@ -853,9 +941,7 @@ namespace NINA.Equipment.Equipment.MyCamera {
         }
 
         public void StopExposure() {
-            if (Connected) {
-                _camera.StopBulbCapture();
-            }
+            StopActiveExposure();
         }
 
         public async Task<bool> Connect(CancellationToken token) {

--- a/NINA.Test/Equipment/Camera/NikonCameraTest.cs
+++ b/NINA.Test/Equipment/Camera/NikonCameraTest.cs
@@ -1,0 +1,244 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using Nikon;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.Interfaces;
+using NINA.Profile.Interfaces;
+using System.Reflection;
+
+namespace NINA.Test.Equipment.Camera;
+
+[TestFixture]
+public class NikonCameraTest {
+
+    [TestCase(29.9, true)]
+    [TestCase(30.0, true)]
+    [TestCase(30.1, false)]
+    public void UsesAutomaticShutter_AtThirtySecondBoundary_SelectsExpectedMode(double exposureTime, bool expected) {
+        bool actual = (bool)typeof(NikonCamera)
+            .GetMethod("UsesAutomaticShutter", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { exposureTime })!;
+
+        actual.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenImageArrivesBeforeCaptureCompletes_CompletesFromImageReady() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+
+        Task waitTask = sut.WaitUntilExposureIsReady(CancellationToken.None);
+        RaiseImageReady(sut);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenCaptureCompletesBeforeImageArrives_WaitsForImageReady() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+
+        Task waitTask = sut.WaitUntilExposureIsReady(CancellationToken.None);
+        RaiseCaptureComplete(sut);
+
+        Task firstCompletion = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        firstCompletion.Should().NotBeSameAs(waitTask);
+
+        RaiseImageReady(sut);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenCanceled_ThrowsOperationCanceledException() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        Task waitTask = sut.WaitUntilExposureIsReady(cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        Func<Task> wait = async () => await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Test]
+    public void AbortAndStopExposure_WhenLongExposureHasStopAction_InvokesItExactlyOnce() {
+        var sut = CreateCamera();
+        int stopCount = 0;
+        Action stopAction = () => stopCount++;
+        Invoke(sut, "SetActiveExposureStopAction", stopAction);
+
+        sut.AbortExposure();
+        sut.StopExposure();
+
+        stopCount.Should().Be(1);
+    }
+
+    [Test]
+    public void AbortAndStopExposure_WhenNoStopActionExists_DoesNotCallNikonBulbTermination() {
+        var sut = CreateCamera();
+        sut.Connected = true;
+
+        Action abortAndStop = () => {
+            sut.AbortExposure();
+            sut.StopExposure();
+        };
+
+        abortAndStop.Should().NotThrow();
+    }
+
+    [Test]
+    public void AbortAndStopExposure_WhenStopActionThrows_ContainsExceptionAndInvokesItExactlyOnce() {
+        var sut = CreateCamera();
+        int stopCount = 0;
+        Action stopAction = () => {
+            stopCount++;
+            throw new InvalidOperationException("Vendor stop failed");
+        };
+        Invoke(sut, "SetActiveExposureStopAction", stopAction);
+
+        Action abortAndStop = () => {
+            sut.AbortExposure();
+            sut.StopExposure();
+        };
+
+        abortAndStop.Should().NotThrow();
+        stopCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenCanceled_AllowsLateEventsToSettleExposure() {
+        var sut = CreateCamera();
+        TaskCompletionSource<object> pendingExposure = SetDownloadExposure(sut);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Task waitTask = sut.WaitUntilExposureIsReady(cancellationTokenSource.Token);
+
+        cancellationTokenSource.Cancel();
+
+        Func<Task> wait = async () => await waitTask;
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+        pendingExposure.Task.IsCompleted.Should().BeFalse();
+
+        RaiseImageReady(sut);
+
+        await pendingExposure.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenLongExposureIsCanceled_InvokesStopActionOnce() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+        int stopCount = 0;
+        Action stopAction = () => stopCount++;
+        Invoke(sut, "SetActiveExposureStopAction", stopAction);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Task waitTask = sut.WaitUntilExposureIsReady(cancellationTokenSource.Token);
+
+        cancellationTokenSource.Cancel();
+
+        Func<Task> wait = async () => await waitTask;
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+        stopCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenVendorStopThrows_ContainsVendorException() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+        Action stopAction = () => throw new NikonException("Vendor stop failed");
+        Invoke(sut, "SetActiveExposureStopAction", stopAction);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        Task waitTask = sut.WaitUntilExposureIsReady(cancellationTokenSource.Token);
+
+        cancellationTokenSource.Cancel();
+
+        Func<Task> wait = async () => await waitTask;
+        await wait.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Test]
+    public void AbortAndStopExposure_WhenCalledConcurrently_InvokesStopActionOnce() {
+        var sut = CreateCamera();
+        int stopCount = 0;
+        Action stopAction = () => Interlocked.Increment(ref stopCount);
+        Invoke(sut, "SetActiveExposureStopAction", stopAction);
+
+        Parallel.For(0, 100, iteration => {
+            if (iteration % 2 == 0) {
+                sut.AbortExposure();
+            } else {
+                sut.StopExposure();
+            }
+        });
+
+        stopCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task WaitUntilExposureIsReady_WhenSdkEventsAreDuplicated_RemainsCompleted() {
+        var sut = CreateCamera();
+        SetDownloadExposure(sut);
+        Task waitTask = sut.WaitUntilExposureIsReady(CancellationToken.None);
+
+        RaiseImageReady(sut);
+        RaiseImageReady(sut);
+        RaiseCaptureComplete(sut);
+        RaiseCaptureComplete(sut);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private static NikonCamera CreateCamera() {
+        return new NikonCamera(
+            Mock.Of<IProfileService>(),
+            Mock.Of<ITelescopeMediator>(),
+            Mock.Of<IExposureDataFactory>());
+    }
+
+    private static TaskCompletionSource<object> SetDownloadExposure(NikonCamera camera) {
+        var downloadExposure = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetField(camera, "_downloadExposure", downloadExposure);
+        return downloadExposure;
+    }
+
+    private static void RaiseImageReady(NikonCamera camera) {
+        var image = (NikonImage)Activator.CreateInstance(
+            typeof(NikonImage),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { 1, NikonImageType.Raw, 1, false },
+            culture: null)!;
+
+        Invoke(camera, "Camera_ImageReady", null, image);
+    }
+
+    private static void RaiseCaptureComplete(NikonCamera camera) {
+        Invoke(camera, "_camera_CaptureComplete", null, 0);
+    }
+
+    private static void SetField(NikonCamera camera, string fieldName, object value) {
+        typeof(NikonCamera).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(camera, value);
+    }
+
+    private static void Invoke(NikonCamera camera, string methodName, params object?[] arguments) {
+        typeof(NikonCamera).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(camera, arguments);
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,7 @@ This allows you to safely return to a stable release if needed.
 - QHY cameras now really have their cooler turned off when they are disconnected. The cooler shutdown was skipped on every disconnect, so a camera that was cooling kept regulating to its old set point after being disconnected or after N.I.N.A. was closed, while the next session reported the cooler as off.
 - Captures now switch to the exposure's readout mode before applying gain and offset, so the first frame after a mode change is digitized and logged with the settings for that mode.
 - ASCOM cameras that report extremely large binning ranges no longer take minutes to connect while N.I.N.A. builds the selectable binning modes.
+- Canceling a native Nikon automatic shutter exposure no longer sends an unsupported Bulb termination command that could terminate N.I.N.A.
 
 ## Improvements
 - URLs throughout the application can now be copied from their right-click context menu.


### PR DESCRIPTION
## 🚀 Purpose

Prevent native Nikon automatic exposure cancellation from sending an unsupported Bulb termination command that can terminate N.I.N.A.

## 🧪 How Was It Tested?

- 14 Nikon tests passed
- Full suite: 5,474 passed, 16 skipped
- NINA build: 0 warnings and 0 errors
- No Nikon hardware was available

## 🤖 AI / Tooling Disclosure

OpenAI Codex assisted with diagnosis, implementation and tests.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI theme testing not applicable
- [x] Plugin API compatibility reviewed
  - [x] No breaking interface changes
  - [x] No method/class signature changes
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation changes not applicable

## 🔗 Related Issues

Closes #308

## 📸 Screenshots

Not applicable.

## 📝 Additional Notes

The failure was traced to Nikon `TerminateCapture` returning `NotSupported` from a cancellation callback.