### PR TITLE
Add Load Imaging Layout sequencer instruction

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7210,6 +7210,18 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
     <value>Light</value>
     <comment>Light as in light bulb</comment>
   </data>
+  <data name="Lbl_SequenceItem_Utility_LoadImagingLayout_Description" xml:space="preserve">
+    <value>Loads an Imaging tab layout from a saved dock configuration file</value>
+  </data>
+  <data name="Lbl_SequenceItem_Utility_LoadImagingLayout_Name" xml:space="preserve">
+    <value>Load Imaging Layout</value>
+  </data>
+  <data name="Lbl_SequenceItem_Utility_LoadImagingLayout_Validation_InvalidLayout" xml:space="preserve">
+    <value>The selected file is not a valid Imaging layout backup</value>
+  </data>
+  <data name="Lbl_SequenceItem_Utility_LoadImagingLayout_Validation_InvalidPath" xml:space="preserve">
+    <value>Select an existing Imaging layout backup file</value>
+  </data>
   <data name="Lbl_SequenceItem_Utility_SaveSequence_Description" xml:space="preserve">
     <value>Saves the current sequence at the specified file path</value>
   </data>

--- a/NINA.Sequencer/SequenceItem/Utility/Datatemplates.xaml
+++ b/NINA.Sequencer/SequenceItem/Utility/Datatemplates.xaml
@@ -470,6 +470,45 @@
         </view:SequenceBlockView>
     </DataTemplate>
 
+    <DataTemplate DataType="{x:Type local:LoadImagingLayout}">
+        <view:SequenceBlockView>
+            <view:SequenceBlockView.SequenceItemContent>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock VerticalAlignment="Center" Text="{ns:Loc LblFile}" />
+                    <TextBox
+                        Grid.Column="1"
+                        MinWidth="40"
+                        Margin="5,0,0,0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Center"
+                        Text="{Binding FilePath, Mode=TwoWay}"
+                        TextAlignment="Left" />
+                    <Button
+                        Grid.Column="2"
+                        Width="20"
+                        Height="20"
+                        Margin="5,0,0,0"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Command="{Binding OpenDialogCommand}"
+                        Style="{StaticResource BackgroundButton}">
+                        <Path
+                            Margin="2,10,2,0"
+                            Data="{StaticResource DotsSVG}"
+                            Fill="{StaticResource ButtonForegroundBrush}"
+                            Stretch="Uniform"
+                            UseLayoutRounding="True" />
+                    </Button>
+                </Grid>
+            </view:SequenceBlockView.SequenceItemContent>
+        </view:SequenceBlockView>
+    </DataTemplate>
+
     <DataTemplate DataType="{x:Type local:SaveSequence}">
         <view:SequenceBlockView>
             <view:SequenceBlockView.SequenceItemContent>

--- a/NINA.Sequencer/SequenceItem/Utility/LoadImagingLayout.cs
+++ b/NINA.Sequencer/SequenceItem/Utility/LoadImagingLayout.cs
@@ -1,0 +1,116 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Newtonsoft.Json;
+using NINA.Core.Locale;
+using NINA.Core.Model;
+using NINA.Sequencer.Validations;
+using NINA.WPF.Base.Interfaces.Mediator;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace NINA.Sequencer.SequenceItem.Utility {
+
+    [ExportMetadata("Name", "Lbl_SequenceItem_Utility_LoadImagingLayout_Name")]
+    [ExportMetadata("Description", "Lbl_SequenceItem_Utility_LoadImagingLayout_Description")]
+    [ExportMetadata("Icon", "LoadSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_Utility")]
+    [Export(typeof(ISequenceItem))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public partial class LoadImagingLayout : SequenceItem, IValidatable {
+        private readonly IApplicationMediator applicationMediator;
+
+        [ImportingConstructor]
+        public LoadImagingLayout(IApplicationMediator applicationMediator) {
+            this.applicationMediator = applicationMediator;
+        }
+
+        private LoadImagingLayout(LoadImagingLayout copyMe) : this(copyMe.applicationMediator) {
+            CopyMetaData(copyMe);
+            filePath = copyMe.FilePath;
+        }
+
+        public override object Clone() {
+            return new LoadImagingLayout(this);
+        }
+
+        public override Task Execute(IProgress<ApplicationStatus> progress, CancellationToken token) {
+            return applicationMediator.LoadImagingLayout(FilePath, token);
+        }
+
+        [ObservableProperty]
+        [property: JsonProperty]
+        private string filePath = string.Empty;
+
+        partial void OnFilePathChanged(string value) {
+            Validate();
+        }
+
+        [ObservableProperty]
+        private IList<string> issues = ReadOnlyCollection<string>.Empty;
+
+        [RelayCommand]
+        private void OpenDialog() {
+            var dialog = new Microsoft.Win32.OpenFileDialog {
+                Title = Loc.Instance["Lbl_SequenceItem_Utility_LoadImagingLayout_Name"],
+                FileName = FilePath,
+                DefaultExt = ".dock.config",
+                Filter = "Dock Config|*.dock.config",
+                CheckFileExists = true
+            };
+
+            if (dialog.ShowDialog() == true) {
+                FilePath = dialog.FileName;
+            }
+        }
+
+        public bool Validate() {
+            var validationIssues = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(FilePath) || !Path.IsPathFullyQualified(FilePath) || !File.Exists(FilePath)) {
+                validationIssues.Add(Loc.Instance["Lbl_SequenceItem_Utility_LoadImagingLayout_Validation_InvalidPath"]);
+            } else {
+                try {
+                    using (var stream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                        var document = XDocument.Load(stream);
+                        if (document.Root?.Name.LocalName != "LayoutRoot") {
+                            validationIssues.Add(Loc.Instance["Lbl_SequenceItem_Utility_LoadImagingLayout_Validation_InvalidLayout"]);
+                        }
+                    }
+                } catch {
+                    validationIssues.Add(Loc.Instance["Lbl_SequenceItem_Utility_LoadImagingLayout_Validation_InvalidLayout"]);
+                }
+            }
+
+            Issues = validationIssues.Count == 0 ? ReadOnlyCollection<string>.Empty : validationIssues;
+            return validationIssues.Count == 0;
+        }
+
+        public override void AfterParentChanged() {
+            Validate();
+        }
+
+        public override string ToString() {
+            return $"Category: {Category}, Item: {nameof(LoadImagingLayout)}, Path: {FilePath}";
+        }
+    }
+}

--- a/NINA.Test/Mediator/ApplicationMediatorTest.cs
+++ b/NINA.Test/Mediator/ApplicationMediatorTest.cs
@@ -4,6 +4,8 @@ using NINA.Core.Enum;
 using NINA.Core.Model;
 using NINA.WPF.Base.Interfaces.ViewModel;
 using NINA.WPF.Base.Mediator;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NINA.Test.Mediator {
 
@@ -23,6 +25,31 @@ namespace NINA.Test.Mediator {
             mediator.ChangeTab(ApplicationTab.FRAMINGASSISTANT);
 
             applicationVM.Verify(x => x.ChangeTab(ApplicationTab.FRAMINGASSISTANT), Times.Once);
+        }
+
+        [Test]
+        public async Task LoadImagingLayout_ForwardsPathAndCancellationToken() {
+            Mock<IApplicationVM> applicationVM = new Mock<IApplicationVM>();
+            ApplicationMediator mediator = new ApplicationMediator();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            const string filePath = @"C:\Layouts\Imaging.dock.config";
+
+            mediator.RegisterHandler(applicationVM.Object);
+            await mediator.LoadImagingLayout(filePath, cancellationTokenSource.Token);
+
+            applicationVM.Verify(x => x.LoadImagingLayout(filePath, cancellationTokenSource.Token), Times.Once);
+        }
+
+        [Test]
+        public async Task LoadImagingLayout_WhenHandlerFails_PropagatesFailure() {
+            Mock<IApplicationVM> applicationVM = new Mock<IApplicationVM>();
+            applicationVM.Setup(x => x.LoadImagingLayout(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Load failed"));
+            ApplicationMediator mediator = new ApplicationMediator();
+            mediator.RegisterHandler(applicationVM.Object);
+
+            await mediator.Invoking(x => x.LoadImagingLayout(@"C:\Layouts\Invalid.dock.config", CancellationToken.None))
+                .Should().ThrowAsync<InvalidOperationException>();
         }
 
         /// <summary>

--- a/NINA.Test/Sequencer/SequenceItem/Utility/LoadImagingLayoutDataTemplateTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Utility/LoadImagingLayoutDataTemplateTest.cs
@@ -1,0 +1,89 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.View.Sequencer;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace NINA.Test.Sequencer.SequenceItem.Utility {
+
+    [TestFixture]
+    [NonParallelizable]
+    [Apartment(ApartmentState.STA)]
+    public class LoadImagingLayoutDataTemplateTest {
+        private static bool resourcesLoaded;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() {
+            EnsureApplicationResources();
+        }
+
+        [Test]
+        public void DataTemplate_LoadsWithFilePathAndBrowseCommandBindings() {
+            var resources = new NINA.Sequencer.SequenceItem.Utility.Datatemplates();
+            var template = (DataTemplate)resources[new DataTemplateKey(typeof(NINA.Sequencer.SequenceItem.Utility.LoadImagingLayout))];
+            var view = (SequenceBlockView)template.LoadContent();
+            var content = (Grid)view.SequenceItemContent;
+            var textBox = content.Children.OfType<TextBox>().Single();
+            var browseButton = content.Children.OfType<Button>().Single();
+            var item = new NINA.Sequencer.SequenceItem.Utility.LoadImagingLayout(Mock.Of<IApplicationMediator>());
+
+            view.DataContext = item;
+            content.DataContext = item;
+            textBox.DataContext = item;
+            browseButton.DataContext = item;
+            item.FilePath = @"C:\Layouts\Imaging.dock.config";
+            textBox.GetBindingExpression(TextBox.TextProperty).UpdateTarget();
+            browseButton.GetBindingExpression(Button.CommandProperty).UpdateTarget();
+
+            BindingOperations.GetBinding(textBox, TextBox.TextProperty).Path.Path.Should().Be(nameof(item.FilePath));
+            BindingOperations.GetBinding(browseButton, Button.CommandProperty).Path.Path.Should().Be(nameof(item.OpenDialogCommand));
+            item.OpenDialogCommand.Should().NotBeNull();
+        }
+
+        private static void EnsureApplicationResources() {
+            if (resourcesLoaded) {
+                return;
+            }
+
+            Application app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            if (app.MainWindow == null) {
+                var rootGrid = new Grid { Name = "RootGrid" };
+                var mainWindow = new Window { Content = rootGrid };
+                NameScope.SetNameScope(mainWindow, new NameScope());
+                mainWindow.RegisterName(rootGrid.Name, rootGrid);
+                app.MainWindow = mainWindow;
+            }
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/StaticResources/ProfileService.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/StaticResources/SVGDictionary.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/StaticResources/Brushes.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/StaticResources/Converters.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/Styles/Expander.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/Styles/Button.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/Styles/TabControl.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.WPF.Base;component/Resources/Styles/ListView.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.Sequencer;component/Resources/Styles/ProgressStyle.xaml", UriKind.Relative) });
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("/NINA.Sequencer;component/Resources/Styles/SequenceContainerStyles.xaml", UriKind.Relative) });
+            resourcesLoaded = true;
+        }
+    }
+}

--- a/NINA.Test/Sequencer/SequenceItem/Utility/LoadImagingLayoutTest.cs
+++ b/NINA.Test/Sequencer/SequenceItem/Utility/LoadImagingLayoutTest.cs
@@ -1,0 +1,181 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.Enum;
+using NINA.Core.Model;
+using NINA.Sequencer;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.Utility;
+using NINA.Sequencer.Serialization;
+using NINA.Sequencer.Trigger;
+using NINA.Sequencer.Utility.DateTimeProvider;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace NINA.Test.Sequencer.SequenceItem.Utility {
+
+    [TestFixture]
+    public class LoadImagingLayoutTest {
+        private string testDirectory;
+
+        [SetUp]
+        public void SetUp() {
+            testDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, nameof(LoadImagingLayoutTest), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(testDirectory);
+        }
+
+        [TearDown]
+        public void TearDown() {
+            if (Directory.Exists(testDirectory)) {
+                Directory.Delete(testDirectory, true);
+            }
+        }
+
+        [Test]
+        public void Clone_CopiesMetadataAndFilePath() {
+            var mediator = Mock.Of<IApplicationMediator>();
+            var sut = new LoadImagingLayout(mediator) {
+                Name = "Layout loader",
+                Description = "Loads a layout",
+                Icon = new GeometryGroup(),
+                FilePath = Path.Combine(testDirectory, "Imaging.dock.config")
+            };
+
+            var clone = (LoadImagingLayout)sut.Clone();
+
+            clone.Should().NotBeSameAs(sut);
+            clone.Name.Should().Be(sut.Name);
+            clone.Description.Should().Be(sut.Description);
+            clone.Icon.Should().BeSameAs(sut.Icon);
+            clone.FilePath.Should().Be(sut.FilePath);
+        }
+
+        [Test]
+        public void GetEstimatedDuration_ReturnsZero() {
+            var sut = new LoadImagingLayout(Mock.Of<IApplicationMediator>());
+
+            sut.GetEstimatedDuration().Should().Be(TimeSpan.Zero);
+        }
+
+        [TestCase("")]
+        [TestCase("missing.dock.config")]
+        public void Validate_WhenPathIsEmptyRelativeOrMissing_ReturnsFalse(string filePath) {
+            var sut = new LoadImagingLayout(Mock.Of<IApplicationMediator>()) {
+                FilePath = filePath
+            };
+
+            sut.Validate().Should().BeFalse();
+            sut.Issues.Should().ContainSingle();
+        }
+
+        [Test]
+        public void Validate_WhenFileIsMalformed_ReturnsFalse() {
+            string filePath = WriteLayout("malformed.dock.config", "<LayoutRoot>");
+            var sut = new LoadImagingLayout(Mock.Of<IApplicationMediator>()) {
+                FilePath = filePath
+            };
+
+            sut.Validate().Should().BeFalse();
+            sut.Issues.Should().ContainSingle();
+        }
+
+        [Test]
+        public void Validate_WhenRootIsNotLayoutRoot_ReturnsFalse() {
+            string filePath = WriteLayout("wrong-root.dock.config", "<NotALayout />");
+            var sut = new LoadImagingLayout(Mock.Of<IApplicationMediator>()) {
+                FilePath = filePath
+            };
+
+            sut.Validate().Should().BeFalse();
+            sut.Issues.Should().ContainSingle();
+        }
+
+        [Test]
+        public void Validate_WhenLayoutRootIsPresent_ReturnsTrue() {
+            string filePath = WriteLayout("valid.dock.config", "<LayoutRoot><RootPanel /></LayoutRoot>");
+            var sut = new LoadImagingLayout(Mock.Of<IApplicationMediator>()) {
+                FilePath = filePath
+            };
+
+            sut.Validate().Should().BeTrue();
+            sut.Issues.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Execute_ForwardsPathAndCancellationTokenWithoutChangingTabs() {
+            string filePath = WriteLayout("valid.dock.config", "<LayoutRoot><RootPanel /></LayoutRoot>");
+            var mediator = new Mock<IApplicationMediator>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var sut = new LoadImagingLayout(mediator.Object) {
+                FilePath = filePath
+            };
+
+            await sut.Execute(Mock.Of<IProgress<ApplicationStatus>>(), cancellationTokenSource.Token);
+
+            mediator.Verify(x => x.LoadImagingLayout(filePath, cancellationTokenSource.Token), Times.Once);
+            mediator.Verify(x => x.ChangeTab(It.IsAny<ApplicationTab>()), Times.Never);
+        }
+
+        [Test]
+        public async Task Execute_WhenMediatorFails_PropagatesFailure() {
+            string filePath = WriteLayout("valid.dock.config", "<LayoutRoot><RootPanel /></LayoutRoot>");
+            var mediator = new Mock<IApplicationMediator>();
+            mediator.Setup(x => x.LoadImagingLayout(filePath, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidDataException("Invalid layout"));
+            var sut = new LoadImagingLayout(mediator.Object) {
+                FilePath = filePath
+            };
+
+            await sut.Invoking(x => x.Execute(null, CancellationToken.None))
+                .Should().ThrowAsync<InvalidDataException>();
+        }
+
+        [Test]
+        public void SequenceJsonConverter_RoundTripsFilePath() {
+            string filePath = Path.Combine(testDirectory, "round-trip.dock.config");
+            var mediator = Mock.Of<IApplicationMediator>();
+            var itemPrototype = new LoadImagingLayout(mediator);
+            var factory = new Mock<ISequencerFactory>();
+            factory.SetupGet(x => x.Upgraders).Returns(new List<ISequenceEntityUpgrader>());
+            factory.Setup(x => x.GetContainer<SequentialContainer>()).Returns(() => new SequentialContainer());
+            factory.Setup(x => x.GetItem<LoadImagingLayout>()).Returns(() => (LoadImagingLayout)itemPrototype.Clone());
+            var converter = new SequenceJsonConverter(factory.Object);
+            var source = new SequentialContainer();
+            source.Add(new LoadImagingLayout(mediator) { FilePath = filePath });
+
+            string json = converter.Serialize(source);
+            ISequenceContainer result = converter.Deserialize(json);
+
+            var roundTripped = result.Items.Single().Should().BeOfType<LoadImagingLayout>().Subject;
+            roundTripped.FilePath.Should().Be(filePath);
+        }
+
+        private string WriteLayout(string fileName, string content) {
+            string filePath = Path.Combine(testDirectory, fileName);
+            File.WriteAllText(filePath, content);
+            return filePath;
+        }
+    }
+}

--- a/NINA.Test/ViewModel/DockManagerVMTest.cs
+++ b/NINA.Test/ViewModel/DockManagerVMTest.cs
@@ -1,0 +1,211 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using AvalonDock;
+using AvalonDock.Layout;
+using FluentAssertions;
+using Moq;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Plugin.Interfaces;
+using NINA.Profile;
+using NINA.Profile.Interfaces;
+using NINA.ViewModel;
+using NINA.ViewModel.ImageHistory;
+using NINA.ViewModel.Imaging;
+using NINA.ViewModel.Interfaces;
+using NINA.ViewModel.Sequencer;
+using NINA.WPF.Base.Interfaces.ViewModel;
+using NINA.WPF.Base.ViewModel.Equipment.Camera;
+using NINA.WPF.Base.ViewModel.Equipment.Dome;
+using NINA.WPF.Base.ViewModel.Equipment.FilterWheel;
+using NINA.WPF.Base.ViewModel.Equipment.FlatDevice;
+using NINA.WPF.Base.ViewModel.Equipment.Focuser;
+using NINA.WPF.Base.ViewModel.Equipment.Guider;
+using NINA.WPF.Base.ViewModel.Equipment.Rotator;
+using NINA.WPF.Base.ViewModel.Equipment.SafetyMonitor;
+using NINA.WPF.Base.ViewModel.Equipment.Switch;
+using NINA.WPF.Base.ViewModel.Equipment.Telescope;
+using NINA.WPF.Base.ViewModel.Equipment.WeatherData;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using System.Xml.Linq;
+
+namespace NINA.Test.ViewModel {
+
+    [TestFixture]
+    [NonParallelizable]
+    [Apartment(ApartmentState.STA)]
+    public class DockManagerVMTest {
+        private string originalProfileFolder;
+        private bool originalSingleDockLayout;
+        private string testDirectory;
+        private NINA.Profile.Profile profile;
+
+        [SetUp]
+        public void SetUp() {
+            _ = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            testDirectory = Path.Combine(TestContext.CurrentContext.WorkDirectory, nameof(DockManagerVMTest), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(testDirectory);
+            originalProfileFolder = ProfileService.PROFILEFOLDER;
+            originalSingleDockLayout = NINA.Properties.Settings.Default.SingleDockLayout;
+            ProfileService.PROFILEFOLDER = testDirectory;
+            NINA.Properties.Settings.Default.SingleDockLayout = false;
+            profile = new NINA.Profile.Profile();
+        }
+
+        [TearDown]
+        public void TearDown() {
+            profile.Dispose();
+            ProfileService.PROFILEFOLDER = originalProfileFolder;
+            NINA.Properties.Settings.Default.SingleDockLayout = originalSingleDockLayout;
+            if (Directory.Exists(testDirectory)) {
+                Directory.Delete(testDirectory, true);
+            }
+        }
+
+        [Test]
+        public void LoadImagingLayout_WhenDockIsInitialized_AppliesAndPersistsLayout() {
+            WriteProfileLayout(Orientation.Horizontal);
+            DockManagerVM sut = CreateSut();
+            var dockManager = new DockingManager();
+            WaitForTask(sut.InitializeAvalonDockLayout(dockManager));
+            string requestedLayout = WriteLayoutFile("requested.dock.config", Orientation.Vertical);
+
+            WaitForTask(sut.LoadImagingLayout(requestedLayout, CancellationToken.None));
+
+            dockManager.Layout.RootPanel.Orientation.Should().Be(Orientation.Vertical);
+            ReadLayoutOrientation(DockManagerVM.GetDockConfigPath(profile.Id)).Should().Be(Orientation.Vertical);
+        }
+
+        [Test]
+        public void LoadImagingLayout_WhenDockIsDeferred_AppliesLayoutOnFirstInitialization() {
+            WriteProfileLayout(Orientation.Horizontal);
+            DockManagerVM sut = CreateSut();
+            string requestedLayout = WriteLayoutFile("deferred.dock.config", Orientation.Vertical);
+
+            WaitForTask(sut.LoadImagingLayout(requestedLayout, CancellationToken.None));
+            var dockManager = new DockingManager();
+            WaitForTask(sut.InitializeAvalonDockLayout(dockManager));
+
+            dockManager.Layout.RootPanel.Orientation.Should().Be(Orientation.Vertical);
+            ReadLayoutOrientation(DockManagerVM.GetDockConfigPath(profile.Id)).Should().Be(Orientation.Vertical);
+        }
+
+        [Test]
+        public void LoadImagingLayout_WhenLiveDeserializationFails_RestoresPreviousLayout() {
+            WriteProfileLayout(Orientation.Horizontal);
+            DockManagerVM sut = CreateSut();
+            var dockManager = new DockingManager();
+            WaitForTask(sut.InitializeAvalonDockLayout(dockManager));
+            string invalidLayoutPath = Path.Combine(testDirectory, "invalid.dock.config");
+            File.WriteAllText(invalidLayoutPath, "<LayoutRoot><RootPanel Orientation=\"Diagonal\" /></LayoutRoot>");
+
+            Action act = () => WaitForTask(sut.LoadImagingLayout(invalidLayoutPath, CancellationToken.None));
+
+            act.Should().Throw<Exception>();
+
+            dockManager.Layout.RootPanel.Orientation.Should().Be(Orientation.Horizontal);
+            ReadLayoutOrientation(DockManagerVM.GetDockConfigPath(profile.Id)).Should().Be(Orientation.Horizontal);
+        }
+
+        private DockManagerVM CreateSut() {
+            var profileService = new Mock<IProfileService>();
+            profileService.SetupGet(x => x.ActiveProfile).Returns(profile);
+            var pluginLoader = new Mock<IPluginLoader>();
+            pluginLoader.Setup(x => x.Load()).Returns(Task.CompletedTask);
+            pluginLoader.SetupGet(x => x.DockableVMs).Returns(CreateLayoutDockables());
+
+            return new DockManagerVM(
+                profileService.Object,
+                Mock.Of<ICameraVM>(),
+                Mock.Of<ISequenceNavigationVM>(),
+                Mock.Of<IThumbnailVM>(),
+                Mock.Of<ISwitchVM>(),
+                Mock.Of<IFilterWheelVM>(),
+                Mock.Of<IFocuserVM>(),
+                Mock.Of<IRotatorVM>(),
+                Mock.Of<IWeatherDataVM>(),
+                Mock.Of<IDomeVM>(),
+                Mock.Of<IAnchorableSnapshotVM>(),
+                Mock.Of<IAnchorablePlateSolverVM>(),
+                Mock.Of<ITelescopeVM>(),
+                Mock.Of<IGuiderVM>(),
+                Mock.Of<IFocusTargetsVM>(),
+                Mock.Of<IAutoFocusToolVM>(),
+                Mock.Of<IImageHistoryVM>(),
+                Mock.Of<IImageControlVM>(),
+                Mock.Of<IImageStatisticsVM>(),
+                Mock.Of<IFlatDeviceVM>(),
+                Mock.Of<ISafetyMonitorVM>(),
+                pluginLoader.Object);
+        }
+
+        private void WriteProfileLayout(Orientation orientation) {
+            File.WriteAllText(DockManagerVM.GetDockConfigPath(profile.Id), CreateLayoutXml(orientation));
+        }
+
+        private string WriteLayoutFile(string fileName, Orientation orientation) {
+            string filePath = Path.Combine(testDirectory, fileName);
+            File.WriteAllText(filePath, CreateLayoutXml(orientation));
+            return filePath;
+        }
+
+        private static string CreateLayoutXml(Orientation orientation) {
+            var document = XDocument.Parse(NINA.Properties.Resources.avalondock);
+            document.Root.Element("RootPanel").SetAttributeValue("Orientation", orientation);
+            return document.ToString();
+        }
+
+        private static Orientation ReadLayoutOrientation(string filePath) {
+            var document = XDocument.Load(filePath);
+            return Enum.Parse<Orientation>(document.Root.Element("RootPanel").Attribute("Orientation").Value);
+        }
+
+        private static List<NINA.Equipment.Interfaces.ViewModel.IDockableVM> CreateLayoutDockables() {
+            return XDocument.Parse(NINA.Properties.Resources.avalondock)
+                .Descendants()
+                .Select(x => x.Attribute("ContentId")?.Value)
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct()
+                .Select(x => {
+                    var dockable = new Mock<NINA.Equipment.Interfaces.ViewModel.IDockableVM>();
+                    dockable.SetupGet(y => y.ContentId).Returns(x);
+                    dockable.SetupProperty(y => y.IsVisible);
+                    return dockable.Object;
+                })
+                .ToList();
+        }
+
+        private static void WaitForTask(Task task) {
+            if (!task.IsCompleted) {
+                var dispatcher = Dispatcher.CurrentDispatcher;
+                var frame = new DispatcherFrame();
+                _ = task.ContinueWith(
+                    _ => dispatcher.BeginInvoke(new Action(() => frame.Continue = false)),
+                    TaskScheduler.Default);
+                Dispatcher.PushFrame(frame);
+            }
+
+            task.GetAwaiter().GetResult();
+        }
+    }
+}

--- a/NINA.WPF.Base/Interfaces/Mediator/IApplicationMediator.cs
+++ b/NINA.WPF.Base/Interfaces/Mediator/IApplicationMediator.cs
@@ -15,11 +15,15 @@
 using NINA.Core.Enum;
 using NINA.Core.Interfaces;
 using NINA.WPF.Base.Interfaces.ViewModel;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NINA.WPF.Base.Interfaces.Mediator {
 
     public interface IApplicationMediator : IMediator<IApplicationVM> {
 
         void ChangeTab(ApplicationTab tab);
+
+        Task LoadImagingLayout(string filePath, CancellationToken token);
     }
 }

--- a/NINA.WPF.Base/Interfaces/ViewModel/IApplicationVM.cs
+++ b/NINA.WPF.Base/Interfaces/ViewModel/IApplicationVM.cs
@@ -14,6 +14,8 @@
 
 using CommunityToolkit.Mvvm.Input;
 using NINA.Core.Enum;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace NINA.WPF.Base.Interfaces.ViewModel {
@@ -30,5 +32,7 @@ namespace NINA.WPF.Base.Interfaces.ViewModel {
         string Version { get; }
 
         void ChangeTab(ApplicationTab tab);
+
+        Task LoadImagingLayout(string filePath, CancellationToken token);
     }
 }

--- a/NINA.WPF.Base/Interfaces/ViewModel/IDockManagerVM.cs
+++ b/NINA.WPF.Base/Interfaces/ViewModel/IDockManagerVM.cs
@@ -15,6 +15,7 @@
 using NINA.Core.Utility;
 using NINA.Equipment.Interfaces.ViewModel;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -28,6 +29,8 @@ namespace NINA.WPF.Base.Interfaces.ViewModel {
         ICommand ResetDockLayoutCommand { get; }
 
         Task<bool> InitializeAvalonDockLayout(object o);
+
+        Task LoadImagingLayout(string filePath, CancellationToken token);
 
         void SaveAvalonDockLayout();
     }

--- a/NINA.WPF.Base/Mediator/ApplicationMediator.cs
+++ b/NINA.WPF.Base/Mediator/ApplicationMediator.cs
@@ -16,6 +16,8 @@ using NINA.Core.Enum;
 using NINA.WPF.Base.Interfaces.Mediator;
 using NINA.WPF.Base.Interfaces.ViewModel;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NINA.WPF.Base.Mediator {
 
@@ -31,6 +33,10 @@ namespace NINA.WPF.Base.Mediator {
 
         public void ChangeTab(ApplicationTab tab) {
             handler.ChangeTab(tab);
+        }
+
+        public Task LoadImagingLayout(string filePath, CancellationToken token) {
+            return handler.LoadImagingLayout(filePath, token);
         }
     }
 }

--- a/NINA/ViewModel/ApplicationVM.cs
+++ b/NINA/ViewModel/ApplicationVM.cs
@@ -39,6 +39,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 using System.Globalization;
+using System.Threading;
 using NINA.WPF.Base.View;
 using System.Threading.Tasks;
 using NINA.Sequencer;
@@ -195,6 +196,11 @@ namespace NINA.ViewModel {
         public void ChangeTab(ApplicationTab tab) {
             TabIndex = (int)tab;
         }
+
+        public Task LoadImagingLayout(string filePath, CancellationToken token) {
+            return dockManager.LoadImagingLayout(filePath, token);
+        }
+
         public string Version => CoreUtil.VersionFriendlyName;
 
         public string Title => CoreUtil.Title;

--- a/NINA/ViewModel/DockManagerVM.cs
+++ b/NINA/ViewModel/DockManagerVM.cs
@@ -47,6 +47,7 @@ using System.Diagnostics;
 using System.Threading;
 using NINA.Core.Utility.Notification;
 using CommunityToolkit.Mvvm.ComponentModel;
+using System.Xml.Linq;
 
 namespace NINA.ViewModel {
 
@@ -219,6 +220,7 @@ namespace NINA.ViewModel {
         private void ProfileService_ProfileChanged(object sender, EventArgs e) {
             lock (lockObj) {
                 _dockloaded = false;
+                pendingDockLayout = null;
             }
         }
 
@@ -231,15 +233,7 @@ namespace NINA.ViewModel {
                         item.IsVisible = false;
                     }
 
-                    var serializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
-                    serializer.LayoutSerializationCallback += (s, args) => {
-                        if (args.Content is IDockableVM d) {
-                            d.IsVisible = true;
-                            args.Content = d;
-                        }
-                    };
-
-                    LoadDefaultLayout(serializer);
+                    LoadDefaultLayout();
                     SaveAvalonDockLayout();
                     Notification.ShowInformation(Loc.Instance["LblDockLayoutReset"]);
                 }
@@ -300,6 +294,7 @@ namespace NINA.ViewModel {
 
         private AvalonDock.DockingManager _dockmanager;
         private bool _dockloaded = false;
+        private string pendingDockLayout;
         private object lockObj = new object();
         private Dispatcher _dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
 
@@ -326,95 +321,37 @@ namespace NINA.ViewModel {
                     if (!_dockloaded) {
                         _dockmanager = (AvalonDock.DockingManager)o;
 
-                        foreach (var item in Anchorables) {
-                            item.IsVisible = false;
-                        }
-
-                        var serializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
-                        var success = true;
-                        var dupeCheck = new HashSet<string>();
-                        serializer.LayoutSerializationCallback += (s, args) => {
-                            if (args?.Model != null) {
-                                if (dupeCheck.Contains(args.Model.ContentId)) {
-                                    Logger.Trace($"Duplicate entry detected for content id: {args.Model.ContentId}");
-                                    args.Cancel = true;
-                                } else {
-                                    dupeCheck.Add(args.Model.ContentId);
-                                    if (args.Content == null) {
-                                        var context = Anchorables.FirstOrDefault(x => x.ContentId == args.Model.ContentId);
-                                        if (context == null) {
-                                            Logger.Debug($"Content not found for content id: {args.Model.ContentId}");
-                                            args.Cancel = true;
-                                        } else {
-                                            Logger.Trace($"Manually setting content for id: {args.Model.ContentId}");
-                                            args.Content = context;
-                                            success = false;
-                                        }
-                                    } else {
-                                        args.Content = args.Content;
-                                    }
-                                }
-                            } else {
-                                args.Cancel = true;
-                            }
-                        };
-
                         var profileId = profileService.ActiveProfile.Id;
                         var profilePath = GetDockConfigPath(profileId);
-                        if (File.Exists(profilePath)) {
+                        if (pendingDockLayout != null) {
+                            var layout = pendingDockLayout;
+                            pendingDockLayout = null;
+                            try {
+                                Logger.Info("Initializing imaging tab layout from a deferred sequencer instruction");
+                                DeserializeAvalonDockLayout(layout);
+                                SaveAvalonDockLayout();
+                            } catch (Exception ex) {
+                                Logger.Error("Failed to load deferred imaging tab layout. Loading default Layout!", ex);
+                                LoadDefaultLayout();
+                            }
+                        } else if (File.Exists(profilePath)) {
                             try {
                                 Logger.Info($"Initializing imaging tab layout from {profilePath}");
-                                using (var sw = new FileStream(profilePath, FileMode.Open, FileAccess.Read)) {
-                                    serializer.Deserialize(sw);
-                                    if (success) {
-                                        _dockloaded = true;
-                                    } else {
-                                        // Retry
-                                        Logger.Debug("The dock did not succeed to load. Trying again");
-                                        _dockloaded = false;
-
-                                        foreach (var item in Anchorables) {
-                                            item.IsVisible = false;
-                                        }
-                                        dupeCheck.Clear();
-                                        var serializer2 = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
-                                        serializer2.LayoutSerializationCallback += (s, args) => {
-                                            if (args?.Model != null) {
-                                                if (dupeCheck.Contains(args.Model.ContentId)) {
-                                                    Logger.Trace($"Duplicate entry detected for content id: {args.Model.ContentId}");
-                                                    args.Cancel = true;
-                                                } else {
-                                                    dupeCheck.Add(args.Model.ContentId);
-                                                    var d = (IDockableVM)args.Content;
-                                                    if (d != null) {
-                                                        d.IsVisible = true;
-                                                        args.Content = d;
-                                                    }
-                                                }
-                                            } else {
-                                                args.Cancel = true;
-                                            }
-                                        };
-                                        sw.Seek(0, SeekOrigin.Begin);
-                                        serializer2.Deserialize(sw);
-                                        _dockloaded = true;
-                                    }
-                                }
+                                DeserializeAvalonDockLayout(File.ReadAllText(profilePath));
                             } catch (Exception ex) {
                                 Logger.Error("Failed to load imaging tab layout. Loading default Layout!", ex);
-                                LoadDefaultLayout(serializer);
+                                LoadDefaultLayout();
                             }
                         } else if (!Properties.Settings.Default.SingleDockLayout && File.Exists(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "avalondock.config"))) {
                             try {
                                 Logger.Info("Migrating imaging tab layout from old path");
-                                serializer.Deserialize(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "avalondock.config"));
-                                _dockloaded = true;
+                                DeserializeAvalonDockLayout(File.ReadAllText(Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "avalondock.config")));
                             } catch (Exception ex) {
                                 Logger.Error("Failed to load imaging tab layout. Loading default Layout!", ex);
-                                LoadDefaultLayout(serializer);
+                                LoadDefaultLayout();
                             }
                         } else {
-                            LoadDefaultLayout(serializer);
+                            LoadDefaultLayout();
                         }
                     }
                 }
@@ -422,11 +359,124 @@ namespace NINA.ViewModel {
             return true;
         }
 
-        private void LoadDefaultLayout(AvalonDock.Layout.Serialization.XmlLayoutSerializer serializer) {
-            using (var stream = new StringReader(Properties.Resources.avalondock)) {
-                serializer.Deserialize(stream);
-                _dockloaded = true;
+        public async Task LoadImagingLayout(string filePath, CancellationToken token) {
+            var layout = await File.ReadAllTextAsync(filePath, token);
+            ValidateAvalonDockLayout(layout);
+            token.ThrowIfCancellationRequested();
+
+            await _dispatcher.InvokeAsync(() => {
+                lock (lockObj) {
+                    if (_dockmanager == null) {
+                        pendingDockLayout = layout;
+                        return;
+                    }
+
+                    var currentLayout = SerializeAvalonDockLayout();
+                    try {
+                        DeserializeAvalonDockLayout(layout);
+                        SaveAvalonDockLayout();
+                    } catch {
+                        try {
+                            DeserializeAvalonDockLayout(currentLayout);
+                            SaveAvalonDockLayout();
+                        } catch (Exception rollbackException) {
+                            _dockloaded = false;
+                            Logger.Error("Failed to restore the previous imaging tab layout after a load failure", rollbackException);
+                        }
+                        throw;
+                    }
+                }
+            }, DispatcherPriority.Normal, token);
+        }
+
+        private static void ValidateAvalonDockLayout(string layout) {
+            var document = XDocument.Parse(layout);
+            if (document.Root?.Name.LocalName != "LayoutRoot") {
+                throw new InvalidDataException("The selected file does not contain an AvalonDock LayoutRoot.");
             }
+        }
+
+        private string SerializeAvalonDockLayout() {
+            var serializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
+            using (var writer = new StringWriter()) {
+                serializer.Serialize(writer);
+                return writer.ToString();
+            }
+        }
+
+        private void DeserializeAvalonDockLayout(string layout) {
+            foreach (var item in Anchorables) {
+                item.IsVisible = false;
+            }
+
+            var serializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
+            var retryRequired = false;
+            var dupeCheck = new HashSet<string>();
+            serializer.LayoutSerializationCallback += (s, args) => {
+                if (args?.Model == null) {
+                    args.Cancel = true;
+                    return;
+                }
+
+                if (!dupeCheck.Add(args.Model.ContentId)) {
+                    Logger.Trace($"Duplicate entry detected for content id: {args.Model.ContentId}");
+                    args.Cancel = true;
+                    return;
+                }
+
+                if (args.Content == null) {
+                    var context = Anchorables.FirstOrDefault(x => x.ContentId == args.Model.ContentId);
+                    if (context == null) {
+                        Logger.Debug($"Content not found for content id: {args.Model.ContentId}");
+                        args.Cancel = true;
+                    } else {
+                        Logger.Trace($"Manually setting content for id: {args.Model.ContentId}");
+                        args.Content = context;
+                        retryRequired = true;
+                    }
+                }
+            };
+
+            using (var reader = new StringReader(layout)) {
+                serializer.Deserialize(reader);
+            }
+
+            if (retryRequired) {
+                Logger.Debug("The dock did not succeed to load. Trying again");
+                foreach (var item in Anchorables) {
+                    item.IsVisible = false;
+                }
+
+                dupeCheck.Clear();
+                var retrySerializer = new AvalonDock.Layout.Serialization.XmlLayoutSerializer(_dockmanager);
+                retrySerializer.LayoutSerializationCallback += (s, args) => {
+                    if (args?.Model == null) {
+                        args.Cancel = true;
+                        return;
+                    }
+
+                    if (!dupeCheck.Add(args.Model.ContentId)) {
+                        Logger.Trace($"Duplicate entry detected for content id: {args.Model.ContentId}");
+                        args.Cancel = true;
+                        return;
+                    }
+
+                    if (args.Content is IDockableVM dockable) {
+                        dockable.IsVisible = true;
+                        args.Content = dockable;
+                    }
+                };
+
+                using (var reader = new StringReader(layout)) {
+                    retrySerializer.Deserialize(reader);
+                }
+            }
+
+            _dockloaded = true;
+        }
+
+        private void LoadDefaultLayout() {
+            DeserializeAvalonDockLayout(Properties.Resources.avalondock);
         }
 
         public void SaveAvalonDockLayout() {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,7 @@ This allows you to safely return to a stable release if needed.
 - Native Nikon and Canon camera drivers can now be configured to use the file format selection, such as FITS or XISF, instead of always saving native camera RAW files.
 - Sky brightness readings in the Weather device windows have been increased from 2 decimal places to 5 so that measurements obtained in low light conditions are adequately displayed.
 - Improved Sky Atlas search performance.
+- Added a Utility sequencer instruction that loads a saved Imaging tab layout during a sequence.
 - **Offline framing sky map improvements**
     - All map layers and camera framing rectangles now refresh continuously while dragging, with substantially lower rendering overhead, fewer temporary allocations and bounded decoded-image memory use.
     - Drag updates are now scheduled at up to 60 FPS in both rendering modes. Software-only rendering composites cached map tiles into one reusable full-viewport surface using a reduced-resolution scratch frame, substantially improving responsiveness when hardware acceleration is disabled while keeping targets, framing overlays and annotations aligned.


### PR DESCRIPTION
## 🚀 Purpose

Adds a Utility sequencer instruction that loads an existing `.dock.config` Imaging layout. Supports deferred loading, persistence and rollback without switching tabs.

## 🧪 How Was It Tested?

- Targeted tests: 188 passed
- Full suite: 5,490 passed, 16 skipped
- `NINA.Sequencer`, `NINA` and `NINA.Test` builds passed
- Includes validation, serialization, mediator, AvalonDock rollback/deferred-load and runtime XAML tests

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to implement and test this change.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes
- [x] Plugin API compatibility reviewed
  - [ ] No breaking changes to interfaces
  - [ ] No changes to method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [ ] Documentation updated (not applicable)

## 🔗 Related Issues

Addresses the sequencer portion of #321.

## 📸 Screenshots

Not included.

## 📝 Additional Notes

Adds methods to `IApplicationMediator`, `IApplicationVM` and `IDockManagerVM`. Existing manual layout commands remain unchanged.