### PR TITLE
Show camera readout mode in simple sequencer details

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -2643,6 +2643,9 @@ Calculated HFR: {2}
   <data name="LblReadoutMode" xml:space="preserve">
     <value>Mode</value>
   </data>
+  <data name="LblReadout" xml:space="preserve">
+    <value>Readout</value>
+  </data>
   <data name="LblReadoutModeTooltip" xml:space="preserve">
     <value>A numeric value corresponding to your camera's readout mode</value>
   </data>

--- a/NINA.Test/View/AnchorableSequenceViewTest.cs
+++ b/NINA.Test/View/AnchorableSequenceViewTest.cs
@@ -1,0 +1,210 @@
+#region "copyright"
+
+/*
+    Copyright (c) 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.View;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Threading;
+
+namespace NINA.Test.View {
+
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    [NonParallelizable]
+    public class AnchorableSequenceViewTest {
+
+        [Test]
+        public void ReadoutRow_WithMultipleModes_DisplaysConfiguredSequenceModeAndTracksBoundaryChanges() {
+            EnsureApplicationResources();
+            CameraInfo cameraInfo = new CameraInfo {
+                Connected = true,
+                ReadoutModes = new List<string> { "Fast", "11M Mode" },
+                ReadoutModeForNormalImages = 0
+            };
+            SequenceContext context = new SequenceContext(cameraInfo, 1);
+            AnchorableSequenceView view = CreateView(context);
+            using TestWindow host = Layout(view);
+
+            UniformGrid readoutRow = FindReadoutRow(view);
+            TextBlock value = FindReadoutValue(readoutRow);
+
+            readoutRow.Parent.Should().BeOfType<Border>().Subject.Visibility.Should().Be(Visibility.Visible);
+            value.Text.Should().Be("11M Mode");
+
+            context.ActiveProfile.CameraSettings.ReadoutModeForNormalImages = 0;
+            Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+
+            value.Text.Should().Be("Fast");
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        public void ReadoutRow_WithFewerThanTwoModes_IsCollapsed(int modeCount) {
+            EnsureApplicationResources();
+            CameraInfo cameraInfo = new CameraInfo {
+                Connected = true,
+                ReadoutModes = Enumerable.Range(0, modeCount).Select(index => $"Mode {index}").ToList(),
+                ReadoutModeForNormalImages = 0
+            };
+            AnchorableSequenceView view = CreateView(new SequenceContext(cameraInfo, 0));
+            using TestWindow host = Layout(view);
+
+            FindReadoutRow(view).Parent.Should().BeOfType<Border>().Subject.Visibility.Should().Be(Visibility.Collapsed);
+        }
+
+        private static AnchorableSequenceView CreateView(SequenceContext context) {
+            return new AnchorableSequenceView {
+                DataContext = context
+            };
+        }
+
+        private static TestWindow Layout(AnchorableSequenceView view) {
+            TestWindow host = new TestWindow {
+                Width = 400,
+                Height = 700,
+                Content = view
+            };
+            host.Show();
+            host.Measure(new Size(host.Width, host.Height));
+            host.Arrange(new Rect(0, 0, host.Width, host.Height));
+            host.UpdateLayout();
+            Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+            host.UpdateLayout();
+            return host;
+        }
+
+        private static UniformGrid FindReadoutRow(AnchorableSequenceView view) {
+            TextBlock label = FindLogicalDescendants<TextBlock>(view)
+                .Single(textBlock => textBlock.Text == "Readout");
+            return label.Parent.Should().BeOfType<UniformGrid>().Subject;
+        }
+
+        private static TextBlock FindReadoutValue(UniformGrid row) {
+            return FindLogicalDescendants<TextBlock>(row)
+                .Single(textBlock => textBlock.Text != "Readout");
+        }
+
+        private static IEnumerable<T> FindLogicalDescendants<T>(DependencyObject root) where T : DependencyObject {
+            foreach (object childObject in LogicalTreeHelper.GetChildren(root)) {
+                if (childObject is not DependencyObject child) {
+                    continue;
+                }
+                if (child is T match) {
+                    yield return match;
+                }
+                foreach (T descendant in FindLogicalDescendants<T>(child)) {
+                    yield return descendant;
+                }
+            }
+        }
+
+        private static void EnsureApplicationResources() {
+            const string resourcesLoadedMarker = "AnchorableSequenceViewTest.ResourcesLoaded";
+            Application app = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+            if (app.Resources.Contains(resourcesLoadedMarker)) {
+                return;
+            }
+
+            string[] resourceSources = [
+                "/NINA.WPF.Base;component/Resources/StaticResources/ProfileService.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/SVGDictionary.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Brushes.xaml",
+                "/NINA.WPF.Base;component/Resources/StaticResources/Converters.xaml",
+                "/NINA;component/Resources/StaticResources/DataTemplates.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Button.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Path.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBlock.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TextBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/TabControl.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/CheckBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/DataGrid.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ListView.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/GroupBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/RepeatButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ToggleButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Slider.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Expander.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ScrollViewer.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ComboBox.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/GridSplitter.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ProgressBar.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/Tooltip.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/CancellableButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/DatePicker.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/StepperControl.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ContextMenu.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/SplitButton.xaml",
+                "/NINA.WPF.Base;component/Resources/Styles/ColorPicker.xaml",
+                "/NINA;component/Resources/Styles/Window.xaml",
+                "/NINA;component/Resources/Styles/AvalonDock.xaml",
+                "/NINA;component/Resources/Styles/Oxyplot.xaml",
+                "/NINA;component/Resources/Styles/Markdown.xaml"
+            ];
+
+            foreach (string resourceSource in resourceSources) {
+                app.Resources.MergedDictionaries.Add(new ResourceDictionary {
+                    Source = new Uri(resourceSource, UriKind.Relative)
+                });
+            }
+            app.Resources[resourcesLoadedMarker] = true;
+        }
+
+        private sealed class SequenceContext {
+
+            public SequenceContext(CameraInfo cameraInfo, short? configuredReadoutMode) {
+                CameraInfo = cameraInfo;
+                ActiveProfile = new ProfileContext(configuredReadoutMode);
+            }
+
+            public CameraInfo CameraInfo { get; }
+            public ProfileContext ActiveProfile { get; }
+        }
+
+        private sealed class ProfileContext {
+
+            public ProfileContext(short? configuredReadoutMode) {
+                CameraSettings = new CameraSettingsContext { ReadoutModeForNormalImages = configuredReadoutMode };
+            }
+
+            public CameraSettingsContext CameraSettings { get; }
+        }
+
+        private sealed class CameraSettingsContext : NINA.Core.Utility.BaseINPC {
+            private short? readoutModeForNormalImages;
+
+            public short? ReadoutModeForNormalImages {
+                get => readoutModeForNormalImages;
+                set {
+                    if (readoutModeForNormalImages != value) {
+                        readoutModeForNormalImages = value;
+                        RaisePropertyChanged();
+                    }
+                }
+            }
+        }
+
+        private sealed class TestWindow : Window, IDisposable {
+
+            public void Dispose() {
+                Close();
+            }
+        }
+    }
+}

--- a/NINA.Test/View/NinaConverterBehaviorTest.cs
+++ b/NINA.Test/View/NinaConverterBehaviorTest.cs
@@ -66,6 +66,26 @@ namespace NINA.Test.View {
         }
 
         /// <summary>
+        /// Verifies readout mode display resolves both valid boundaries and safely rejects incomplete or out-of-range bindings.
+        /// </summary>
+        [Test]
+        public void ReadoutModeNameConverter_ResolvesValidIndicesAndRejectsInvalidInputs() {
+            var converter = new ReadoutModeNameConverter();
+            string[] modes = ["Fast", "11M Mode"];
+
+            converter.Convert(new object[] { modes, (short)0, (short)1 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be("Fast");
+            converter.Convert(new object[] { modes, (short)1, (short)0 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be("11M Mode");
+            converter.Convert(new object[] { modes, DependencyProperty.UnsetValue, (short)1 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be("11M Mode");
+            converter.Convert(new object[] { modes, (short)-1, (short)0 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be(string.Empty);
+            converter.Convert(new object[] { modes, (short)2, (short)0 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be(string.Empty);
+            converter.Convert(new object[] { null, (short)0, (short)0 }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be(string.Empty);
+            converter.Convert(new object[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue }, typeof(string), null, CultureInfo.InvariantCulture).Should().Be(string.Empty);
+
+            Action convertBack = () => converter.ConvertBack("Fast", new[] { typeof(string), typeof(short), typeof(short) }, null, CultureInfo.InvariantCulture);
+            convertBack.Should().Throw<NotSupportedException>();
+        }
+
+        /// <summary>
         /// Verifies sequence-mode visibility converters expose rotate-only controls while hiding mutually exclusive standard-mode controls.
         /// </summary>
         [Test]

--- a/NINA/View/Imaging/AnchorableSequenceView.xaml
+++ b/NINA/View/Imaging/AnchorableSequenceView.xaml
@@ -45,6 +45,7 @@
                 </Style.Triggers>
             </Style>
             <sequencer:InverseSequenceModeIsRotateToVisibilityConverter x:Key="InverseSequenceModeIsRotateToVisibilityConverter" />
+            <sequencer:ReadoutModeNameConverter x:Key="ReadoutModeNameConverter" />
             <sequencer:SequenceModeIsRotateToVisibilityConverter x:Key="SequenceModeIsRotateToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
@@ -160,6 +161,23 @@
                         <UniformGrid VerticalAlignment="Center" Columns="2">
                             <TextBlock Text="{ns:Loc LblMode}" />
                             <TextBlock Margin="5,0,0,0" Text="{Binding ActiveTarget.Mode}" />
+                        </UniformGrid>
+                    </Border>
+                    <Border
+                        Margin="0,5,0,0"
+                        BorderThickness="0"
+                        Visibility="{Binding Data.ReadoutModes, Source={StaticResource CameraInfo}, Converter={StaticResource CollectionContainsMoreThanOneItemToVisibilityConverter}}">
+                        <UniformGrid VerticalAlignment="Center" Columns="2">
+                            <TextBlock Text="{ns:Loc LblReadout}" />
+                            <TextBlock Margin="5,0,0,0">
+                                <TextBlock.Text>
+                                    <MultiBinding Converter="{StaticResource ReadoutModeNameConverter}">
+                                        <Binding Path="Data.ReadoutModes" Source="{StaticResource CameraInfo}" />
+                                        <Binding Path="ActiveProfile.CameraSettings.ReadoutModeForNormalImages" />
+                                        <Binding Path="Data.ReadoutModeForNormalImages" Source="{StaticResource CameraInfo}" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
                         </UniformGrid>
                     </Border>
                     <StackPanel DataContext="{Binding ActiveTarget.ActiveExposure}" Orientation="Vertical">

--- a/NINA/View/Sequencer/SimpleSequencer/ReadoutModeNameConverter.cs
+++ b/NINA/View/Sequencer/SimpleSequencer/ReadoutModeNameConverter.cs
@@ -1,0 +1,50 @@
+#region "copyright"
+
+/*
+    Copyright (c) 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace NINA.View.SimpleSequencer {
+
+    internal sealed class ReadoutModeNameConverter : IMultiValueConverter {
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            if (values.Length < 2 || values[0] is not IEnumerable<string> modes) {
+                return string.Empty;
+            }
+
+            short modeIndex;
+            if (values[1] is short configuredModeIndex) {
+                modeIndex = configuredModeIndex;
+            } else if (values.Length >= 3 && values[2] is short cameraModeIndex) {
+                modeIndex = cameraModeIndex;
+            } else {
+                return string.Empty;
+            }
+
+            if (modeIndex < 0) {
+                return string.Empty;
+            }
+
+            return modes.ElementAtOrDefault(modeIndex) ?? string.Empty;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,7 @@ This allows you to safely return to a stable release if needed.
 
 ## Improvements
 - URLs throughout the application can now be copied from their right-click context menu.
+- The simple sequencer's Active Sequence Details now shows the configured camera readout mode when multiple modes are available.
 - Mount Dither can now enforce a configurable minimum movement between exposures, preventing randomly selected offsets that are too small to be useful.
 - PHD2 users can optionally show guide-star mass and SNR in the guide graphs, using PHD2-style independent scaling in the upper half of the chart.
 - **Autofocus after HFR Increase Trigger**


### PR DESCRIPTION
## 🚀 Purpose

Show the configured camera readout mode in Simple Sequencer's Active Sequence Details. 

## 🧪 How Was It Tested?

- NINA build: 0 errors
- Focused UI/converter tests: 12 passed
- Full suite: 5,494 passed, 16 skipped

## 🤖 AI / Tooling Disclosure

OpenAI Codex.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark and Night themes
- [x] Plugin API compatibility reviewed
  - [x] No breaking interface changes
  - [x] No method/class signature changes
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation not applicable

## 🔗 Related Issues

Closes #332

## 📸 Screenshots

Not included.

## 📝 Additional Notes

Implemented entirely in the app UI layer.