### PR TITLE
Fix ASCOM Bayer offset handling during automatic debayering

### DIFF
--- a/NINA.Image/ImageAnalysis/BayerPatternUtility.cs
+++ b/NINA.Image/ImageAnalysis/BayerPatternUtility.cs
@@ -1,0 +1,53 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Enum;
+
+namespace NINA.Image.ImageAnalysis {
+
+    public static class BayerPatternUtility {
+
+        public static SensorType ApplyOffsets(SensorType bayerPattern, int offsetX, int offsetY) {
+            if (offsetX % 2 != 0) {
+                bayerPattern = bayerPattern switch {
+                    SensorType.RGGB => SensorType.GRBG,
+                    SensorType.GRBG => SensorType.RGGB,
+                    SensorType.GBRG => SensorType.BGGR,
+                    SensorType.BGGR => SensorType.GBRG,
+                    SensorType.GRGB => SensorType.RGBG,
+                    SensorType.RGBG => SensorType.GRGB,
+                    SensorType.GBGR => SensorType.BGRG,
+                    SensorType.BGRG => SensorType.GBGR,
+                    _ => bayerPattern
+                };
+            }
+
+            if (offsetY % 2 != 0) {
+                bayerPattern = bayerPattern switch {
+                    SensorType.RGGB => SensorType.GBRG,
+                    SensorType.GBRG => SensorType.RGGB,
+                    SensorType.GRBG => SensorType.BGGR,
+                    SensorType.BGGR => SensorType.GRBG,
+                    SensorType.GRGB => SensorType.GBGR,
+                    SensorType.GBGR => SensorType.GRGB,
+                    SensorType.RGBG => SensorType.BGRG,
+                    SensorType.BGRG => SensorType.RGBG,
+                    _ => bayerPattern
+                };
+            }
+
+            return bayerPattern;
+        }
+    }
+}

--- a/NINA.Test/Image/ImageAnalysis/BayerPatternUtilityTest.cs
+++ b/NINA.Test/Image/ImageAnalysis/BayerPatternUtilityTest.cs
@@ -1,0 +1,61 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Core.Enum;
+using NINA.Image.ImageAnalysis;
+
+namespace NINA.Test.Image.ImageAnalysis {
+
+    [TestFixture]
+    public class BayerPatternUtilityTest {
+
+        [TestCase(0, 0, SensorType.RGGB)]
+        [TestCase(1, 0, SensorType.GRBG)]
+        [TestCase(0, 1, SensorType.GBRG)]
+        [TestCase(1, 1, SensorType.BGGR)]
+        [TestCase(2, 4, SensorType.RGGB)]
+        [TestCase(3, 4, SensorType.GRBG)]
+        [TestCase(2, 5, SensorType.GBRG)]
+        [TestCase(3, 5, SensorType.BGGR)]
+        public void ApplyOffsets_RggbPattern_ResolvesOffsetParity(int offsetX, int offsetY, SensorType expected) {
+            BayerPatternUtility.ApplyOffsets(SensorType.RGGB, offsetX, offsetY).Should().Be(expected);
+        }
+
+        [TestCase(SensorType.RGGB)]
+        [TestCase(SensorType.GRBG)]
+        [TestCase(SensorType.GBRG)]
+        [TestCase(SensorType.BGGR)]
+        [TestCase(SensorType.GRGB)]
+        [TestCase(SensorType.RGBG)]
+        [TestCase(SensorType.GBGR)]
+        [TestCase(SensorType.BGRG)]
+        public void ApplyOffsets_RepeatingAxisShift_RestoresPattern(SensorType pattern) {
+            SensorType horizontalShift = BayerPatternUtility.ApplyOffsets(pattern, 1, 0);
+            SensorType verticalShift = BayerPatternUtility.ApplyOffsets(pattern, 0, 1);
+
+            BayerPatternUtility.ApplyOffsets(horizontalShift, 1, 0).Should().Be(pattern);
+            BayerPatternUtility.ApplyOffsets(verticalShift, 0, 1).Should().Be(pattern);
+        }
+
+        [TestCase(SensorType.Monochrome)]
+        [TestCase(SensorType.Color)]
+        [TestCase(SensorType.CMYG)]
+        [TestCase(SensorType.CMYG2)]
+        [TestCase(SensorType.LRGB)]
+        public void ApplyOffsets_NonRgbBayerCategory_RemainsUnchanged(SensorType pattern) {
+            BayerPatternUtility.ApplyOffsets(pattern, 1, 1).Should().Be(pattern);
+        }
+    }
+}

--- a/NINA.Test/ViewModel/ImageControlVMBayerPatternTest.cs
+++ b/NINA.Test/ViewModel/ImageControlVMBayerPatternTest.cs
@@ -1,0 +1,151 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using Moq;
+using NINA.Core.Enum;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MyCamera;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NINA.Profile.Interfaces;
+using NINA.ViewModel;
+using NINA.WPF.Base.Interfaces.Mediator;
+using System.Threading;
+using System.Windows;
+using System.Windows.Media;
+
+namespace NINA.Test.ViewModel {
+
+    [TestFixture]
+    [NonParallelizable]
+    [Apartment(ApartmentState.STA)]
+    public class ImageControlVMBayerPatternTest {
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp() {
+            var application = Application.Current ?? new Application { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+
+            application.Resources["PuzzlePieceSVG"] = new GeometryGroup();
+            application.Resources["PictureSVG"] = new GeometryGroup();
+        }
+
+        [TestCase(0, 0, SensorType.RGGB)]
+        [TestCase(1, 0, SensorType.GRBG)]
+        [TestCase(0, 1, SensorType.GBRG)]
+        [TestCase(1, 1, SensorType.BGGR)]
+        public async Task PrepareImage_AutoPatternWithBayerOffsets_UsesShiftedMetadataPattern(
+            int offsetX,
+            int offsetY,
+            SensorType expectedPattern) {
+            var (sut, _) = CreateImageControl(BayerPatternEnum.Auto);
+            var metadata = new ImageMetaData();
+            metadata.Camera.SensorType = SensorType.RGGB;
+            metadata.Camera.BayerOffsetX = offsetX;
+            metadata.Camera.BayerOffsetY = offsetY;
+
+            SensorType selectedPattern = await PrepareImage(sut, metadata);
+
+            selectedPattern.Should().Be(expectedPattern);
+            metadata.Camera.SensorType.Should().Be(SensorType.RGGB);
+            metadata.Camera.BayerOffsetX.Should().Be(offsetX);
+            metadata.Camera.BayerOffsetY.Should().Be(offsetY);
+        }
+
+        [Test]
+        public async Task PrepareImage_AutoPatternWithoutUsableMetadata_UsesShiftedCameraPattern() {
+            var (sut, _) = CreateImageControl(BayerPatternEnum.Auto);
+            sut.UpdateDeviceInfo(new CameraInfo {
+                SensorType = SensorType.RGGB,
+                BayerOffsetX = 0,
+                BayerOffsetY = 1
+            });
+            var metadata = new ImageMetaData();
+
+            SensorType selectedPattern = await PrepareImage(sut, metadata);
+
+            selectedPattern.Should().Be(SensorType.GBRG);
+        }
+
+        [Test]
+        public async Task PrepareImage_ExplicitPattern_IgnoresMetadataAndCameraOffsets() {
+            var (sut, _) = CreateImageControl(BayerPatternEnum.BGGR);
+            sut.UpdateDeviceInfo(new CameraInfo {
+                SensorType = SensorType.RGGB,
+                BayerOffsetX = 1,
+                BayerOffsetY = 0
+            });
+            var metadata = new ImageMetaData();
+            metadata.Camera.SensorType = SensorType.RGGB;
+            metadata.Camera.BayerOffsetX = 0;
+            metadata.Camera.BayerOffsetY = 1;
+
+            SensorType selectedPattern = await PrepareImage(sut, metadata);
+
+            selectedPattern.Should().Be(SensorType.BGGR);
+        }
+
+        private static (ImageControlVM ImageControl, Mock<ICameraMediator> CameraMediator) CreateImageControl(
+            BayerPatternEnum configuredPattern) {
+            var imageSettings = new Mock<IImageSettings>();
+            imageSettings.SetupGet(x => x.DebayerImage).Returns(true);
+            imageSettings.SetupGet(x => x.AutoStretch).Returns(false);
+            imageSettings.SetupGet(x => x.DetectStars).Returns(false);
+
+            var cameraSettings = new Mock<ICameraSettings>();
+            cameraSettings.SetupGet(x => x.BayerPattern).Returns(configuredPattern);
+
+            var profile = new Mock<IProfile>();
+            profile.SetupGet(x => x.ImageSettings).Returns(imageSettings.Object);
+            profile.SetupGet(x => x.CameraSettings).Returns(cameraSettings.Object);
+
+            var profileService = new Mock<IProfileService>();
+            profileService.SetupGet(x => x.ActiveProfile).Returns(profile.Object);
+
+            var cameraMediator = new Mock<ICameraMediator>();
+            var imageControl = new ImageControlVM(
+                profileService.Object,
+                cameraMediator.Object,
+                Mock.Of<ITelescopeMediator>(),
+                Mock.Of<IImagingMediator>(),
+                Mock.Of<IApplicationStatusMediator>());
+
+            cameraMediator.Verify(x => x.RegisterConsumer(imageControl), Times.Once);
+            return (imageControl, cameraMediator);
+        }
+
+        private static async Task<SensorType> PrepareImage(ImageControlVM imageControl, ImageMetaData metadata) {
+            var imageData = new Mock<IImageData>();
+            imageData.SetupGet(x => x.Properties).Returns(new ImageProperties(2, 2, 16, true, 0, 0));
+            imageData.SetupGet(x => x.MetaData).Returns(metadata);
+
+            SensorType? selectedPattern = null;
+            var debayeredImage = new Mock<IDebayeredImage>();
+            var renderedImage = new Mock<IRenderedImage>();
+            renderedImage
+                .Setup(x => x.Debayer(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<SensorType>()))
+                .Callback<bool, bool, SensorType>((_, _, pattern) => selectedPattern = pattern)
+                .Returns(debayeredImage.Object);
+            imageData.Setup(x => x.RenderImage()).Returns(renderedImage.Object);
+
+            await imageControl.PrepareImage(
+                imageData.Object,
+                new PrepareImageParameters(autoStretch: false, detectStars: false),
+                CancellationToken.None);
+
+            return selectedPattern ?? throw new AssertionException("Debayer was not invoked.");
+        }
+    }
+}

--- a/NINA/ViewModel/ImageControlVM.cs
+++ b/NINA/ViewModel/ImageControlVM.cs
@@ -609,17 +609,25 @@ namespace NINA.ViewModel {
                     var starDetection = profileService.ActiveProfile.ImageSettings.DebayeredHFR && detectStars;
 
                     var bayerPattern = cameraInfo.SensorType;
+                    int bayerOffsetX = cameraInfo.BayerOffsetX;
+                    int bayerOffsetY = cameraInfo.BayerOffsetY;
                     if (profileService.ActiveProfile.CameraSettings.BayerPattern != BayerPatternEnum.Auto) {
                         bayerPattern = (SensorType)profileService.ActiveProfile.CameraSettings.BayerPattern;
+                        bayerOffsetX = 0;
+                        bayerOffsetY = 0;
                     } else {
                         // Raw decoders can report the Bayer phase at the visible image origin.
                         // Prefer that concrete pattern over Auto defaults, but ignore placeholder sensor categories.
-                        var imageSensorType = data.MetaData?.Camera?.SensorType;
+                        var imageCamera = data.MetaData?.Camera;
+                        var imageSensorType = imageCamera?.SensorType;
                         if (imageSensorType.HasValue && imageSensorType.Value != SensorType.Monochrome && imageSensorType.Value != SensorType.Color) {
                             bayerPattern = imageSensorType.Value;
+                            bayerOffsetX = imageCamera.BayerOffsetX;
+                            bayerOffsetY = imageCamera.BayerOffsetY;
                         }
                     }
 
+                    bayerPattern = BayerPatternUtility.ApplyOffsets(bayerPattern, bayerOffsetX, bayerOffsetY);
                     renderedImage = renderedImage.Debayer(saveColorChannels: unlinkedStretch, saveLumChannel: starDetection, bayerPattern: bayerPattern);
                 }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- ASCOM and Alpaca cameras now apply their reported Bayer X/Y offsets when automatically debayering previews, so non-RGGB phases display the correct colors while preserving the original image metadata.
 - The Connect All and Disconnect All commands can no longer run at the same time, preventing conflicting device operations during slow connections.
 - Cached Offline Sky Map and Sky Atlas image tiles now keep a stable orientation across zoom levels instead of occasionally rotating by 180 degrees.
 - Center After Drift triggers in completed or otherwise inactive sequence containers no longer consume images or publish drift results while a later container is running.


### PR DESCRIPTION
## 🚀 Purpose

Fix automatic debayering for ASCOM cameras with non-zero Bayer offsets. Automatic mode now resolves the effective pattern from metadata or camera offsets, while explicit overrides remain unchanged.

## 🧪 How Was It Tested?

- Regression coverage for all Bayer offset combinations and explicit overrides
- Focused tests: 78 passed
- Full suite: 5,523 passed

## 🤖 AI / Tooling Disclosure

OpenAI Codex assisted with implementation and tests

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [x] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

Closes #79

## 📸 Screenshots

Not applicable.

## 📝 Additional Notes

The original Bayer pattern and offsets remain preserved in image metadata and FITS/XISF headers.
