### PR TITLE
Make Cool Camera wait for target temperature from either direction

### DIFF
--- a/NINA.Test/ViewModel/CameraVMTest.cs
+++ b/NINA.Test/ViewModel/CameraVMTest.cs
@@ -247,6 +247,96 @@ namespace NINA.Test.ViewModel {
             cameraMediator.Verify(x => x.Broadcast(It.Is<CameraInfo>(info => info.BinX == 2 && info.BinY == 2)), Times.Never);
         }
 
+        [Test]
+        [TestCase(0, -10)]
+        [TestCase(-20, -10)]
+        public async Task CoolCamera_WhenTemperatureStartsOutsideTolerance_WaitsInEitherDirection(double currentTemperature, double targetTemperature) {
+            CameraVM vm = CreateVm();
+            Mock<ICamera> camera = CreateCamera(connects: true);
+            camera.SetupGet(x => x.Temperature).Returns(currentTemperature);
+            deviceChooser.SetupGet(x => x.SelectedDevice).Returns(camera.Object);
+            await vm.Connect();
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+
+            Func<Task> coolCamera = () => vm.CoolCamera(
+                targetTemperature,
+                TimeSpan.Zero,
+                new Progress<ApplicationStatus>(),
+                cancellationTokenSource.Token);
+
+            await coolCamera.Should().ThrowAsync<OperationCanceledException>();
+            camera.VerifySet(x => x.TemperatureSetPoint = currentTemperature, Times.Once);
+        }
+
+        [Test]
+        [TestCase(-11, -10)]
+        [TestCase(-9, -10)]
+        public async Task CoolCamera_WhenTemperatureIsAtToleranceBoundary_CompletesImmediately(double currentTemperature, double targetTemperature) {
+            CameraVM vm = CreateVm();
+            Mock<ICamera> camera = CreateCamera(connects: true);
+            camera.SetupGet(x => x.Temperature).Returns(currentTemperature);
+            deviceChooser.SetupGet(x => x.SelectedDevice).Returns(camera.Object);
+            await vm.Connect();
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+
+            bool success = await vm.CoolCamera(
+                targetTemperature,
+                TimeSpan.Zero,
+                new Progress<ApplicationStatus>(),
+                cancellationTokenSource.Token);
+
+            success.Should().BeTrue();
+            camera.VerifySet(x => x.TemperatureSetPoint = targetTemperature, Times.Once);
+        }
+
+        [Test]
+        public async Task CoolCamera_WhenTemperatureIsPastOppositeToleranceBoundary_ContinuesWaiting() {
+            const double currentTemperature = -12;
+            const double targetTemperature = -10;
+            CameraVM vm = CreateVm();
+            Mock<ICamera> camera = CreateCamera(connects: true);
+            camera.SetupGet(x => x.Temperature).Returns(currentTemperature);
+            deviceChooser.SetupGet(x => x.SelectedDevice).Returns(camera.Object);
+            await vm.Connect();
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+
+            Func<Task> coolCamera = () => vm.CoolCamera(
+                targetTemperature,
+                TimeSpan.Zero,
+                new Progress<ApplicationStatus>(),
+                cancellationTokenSource.Token);
+
+            await coolCamera.Should().ThrowAsync<OperationCanceledException>();
+            camera.VerifySet(x => x.TemperatureSetPoint = currentTemperature, Times.Once);
+        }
+
+        [Test]
+        public async Task CoolCamera_WhenRampIsShorterThanCheckpoint_AppliesExactTargetBeforeWaiting() {
+            const double currentTemperature = 0;
+            const double targetTemperature = -10;
+            List<double> setPoints = new();
+            CameraVM vm = CreateVm();
+            Mock<ICamera> camera = CreateCamera(connects: true);
+            camera.SetupGet(x => x.Temperature).Returns(currentTemperature);
+            camera.SetupSet(x => x.TemperatureSetPoint = It.IsAny<double>()).Callback<double>(setPoint => setPoints.Add(setPoint));
+            deviceChooser.SetupGet(x => x.SelectedDevice).Returns(camera.Object);
+            await vm.Connect();
+            using CancellationTokenSource cancellationTokenSource = new();
+            cancellationTokenSource.Cancel();
+
+            Func<Task> coolCamera = () => vm.CoolCamera(
+                targetTemperature,
+                TimeSpan.FromSeconds(10),
+                new Progress<ApplicationStatus>(),
+                cancellationTokenSource.Token);
+
+            await coolCamera.Should().ThrowAsync<OperationCanceledException>();
+            setPoints.Should().Equal(targetTemperature, currentTemperature);
+        }
+
         private CameraVM CreateVm() {
             return new CameraVM(profileService.Object, cameraMediator.Object, filterWheelMediator.Object, applicationStatusMediator.Object, deviceChooser.Object);
         }

--- a/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
+++ b/NINA.WPF.Base/ViewModel/Equipment/Camera/CameraVM.cs
@@ -148,7 +148,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                 });
 
                 Cam.CoolerOn = true;
-                return await RegulateTemperature(temperature, duration, true, progressRouter, ct);
+                return await RegulateTemperature(temperature, duration, progressRouter, ct);
             } catch (CannotReachTargetTemperatureException) {
                 Logger.Error($"Could not reach target temperature. Target Temp: {temperature}, Current Temp: {Cam.Temperature}");
                 Notification.ShowError(Loc.Instance["LblCouldNotReachTargetTemperature"]);
@@ -174,7 +174,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                     using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                     try {
                         timeoutCts.CancelAfter(duration + TimeSpan.FromMinutes(15));
-                        await RegulateTemperature(20, duration, false, progressRouter, timeoutCts.Token);
+                        await RegulateTemperature(20, duration, progressRouter, timeoutCts.Token);
                     } catch (OperationCanceledException) {
                         if (ct.IsCancellationRequested == true) {
                             throw;
@@ -195,7 +195,7 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
             }
         }
 
-        private async Task<bool> RegulateTemperature(double temperature, TimeSpan duration, bool cooling, IProgress<double> progress, CancellationToken ct) {
+        private async Task<bool> RegulateTemperature(double temperature, TimeSpan duration, IProgress<double> progress, CancellationToken ct) {
             try {
                 double currentTemp = Cam.Temperature;
                 var totalDeltaTemp = Math.Abs(currentTemp - temperature);
@@ -223,16 +223,15 @@ namespace NINA.WPF.Base.ViewModel.Equipment.Camera {
                         await CoreUtil.Wait(interval, ct);
                         currentTemp = Cam.Temperature;
                     }
-                } else {
-                    Cam.TemperatureSetPoint = temperature;
                 }
+                Cam.TemperatureSetPoint = temperature;
 
                 // Wait for final step
                 var timeout = TimeSpan.FromMinutes(2);
                 var idleTime = TimeSpan.Zero;
                 var progressThreshold = 0.5d;
                 var previousTemperature = currentTemp;
-                while ((cooling && currentTemp > (temperature + 1)) || (!cooling && currentTemp < (temperature - 1))) {
+                while (Math.Abs(currentTemp - temperature) > 1) {
                     var progressTemp = Math.Abs(currentTemp - temperature);
                     progress.Report((totalDeltaTemp - progressTemp) / totalDeltaTemp);
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,7 @@ This allows you to safely return to a stable release if needed.
 - Canceling a native Nikon automatic shutter exposure no longer sends an unsupported Bulb termination command that could terminate N.I.N.A.
 
 ## Improvements
+- "Cool Camera" now waits until the sensor enters the target temperature tolerance whether approaching from above or below.
 - The Legacy Sequencer can now reset progress for every target in the current Target Set with one confirmed action.
 - URLs throughout the application can now be copied from their right-click context menu.
 - The simple sequencer's Active Sequence Details now shows the configured camera readout mode when multiple modes are available.


### PR DESCRIPTION
## 🚀 Purpose

Make "Cool Camera" wait until the sensor enters the +/-1 C target tolerance from either direction. Also ensure stepped ramps apply the exact final setpoint.

## 🧪 How Was It Tested?

- 137 camera and sequencer-camera tests passed
- NINA.WPF.Base and NINA.Sequencer builds passed

## 🤖 AI / Tooling Disclosure

OpenAI Codex was used to implement and test this change.

## ✅ PR Checklist

- [x] All unit tests pass
- [x] UI changes tested (not applicable)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures
- [x] `RELEASE_NOTES.md` updated
- [x] Documentation updated (not applicable)

## 🔗 Related Issues

Closes #39

## 📸 Screenshots

Not applicable.

## 📝 Additional Notes

-