### PR TITLE
Fix dome park completion and enforce a 10-minute timeout

### DIFF
--- a/NINA.Core/Locale/Locale.resx
+++ b/NINA.Core/Locale/Locale.resx
@@ -7073,6 +7073,12 @@ Additionally, it is essential that the ASCOM driver used also supports this 32-b
   <data name="LblTelescopeParkTimeout" xml:space="preserve">
     <value>Telescope park has timed out after {0} minutes.</value>
   </data>
+  <data name="LblDomeParkTimeout" xml:space="preserve">
+    <value>Dome park has timed out after {0} minutes.</value>
+  </data>
+  <data name="LblDomeParkFailed" xml:space="preserve">
+    <value>Dome stopped moving but the driver did not confirm it is parked.</value>
+  </data>
   <data name="LblTelescopeUnparkTimeout" xml:space="preserve">
     <value>Telescope unpark has timed out after {0} minutes.</value>
   </data>

--- a/NINA.Equipment/Equipment/MyDome/AscomDome.cs
+++ b/NINA.Equipment/Equipment/MyDome/AscomDome.cs
@@ -315,38 +315,78 @@ namespace NINA.Equipment.Equipment.MyDome {
         public async Task Park(CancellationToken ct) {
             if (ShouldBeConnected) {
                 if (CanPark) {
-                    // ASCOM domes make no promise that a slew operation can take place if one is already in progress, so we do a hard abort up front to ensure Park works
-                    if (Slewing == true) {
-                        Logger.Info("Dome shutter or rotator slewing when a park was requested. Aborting all movement");
-
-                        await device?.AbortSlewAsync(ct);
-                        InvalidatePropertyCache();
-                        await Task.Delay(TimeSpan.FromSeconds(1), ct);
-                    }
-
                     ct.ThrowIfCancellationRequested();
-                    using (ct.Register(() => device?.AbortSlew())) {
+                    TimeSpan timeout = TimeSpan.FromMinutes(10);
+                    using CancellationTokenSource parkCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    parkCancellation.CancelAfter(timeout);
+                    CancellationToken parkToken = parkCancellation.Token;
+                    var parkDevice = device;
+                    using CancellationTokenRegistration abortRegistration = parkToken.Register(() => {
+                        try {
+                            parkDevice?.AbortSlew();
+                        } catch (Exception ex) {
+                            Logger.Error("Failed to abort dome parking", ex);
+                        }
+                    });
+
+                    try {
+                        // ASCOM domes make no promise that a slew operation can take place if one is already in progress, so we do a hard abort up front to ensure Park works
+                        if (Slewing == true) {
+                            Logger.Info("Dome shutter or rotator slewing when a park was requested. Aborting all movement");
+                            await parkDevice.AbortSlewAsync(parkToken);
+                            InvalidatePropertyCache();
+                            await Task.Delay(TimeSpan.FromSeconds(1), parkToken);
+                        }
+
+                        parkToken.ThrowIfCancellationRequested();
                         if (AtPark) {
                             Logger.Info("Dome already AtPark. Not sending a Park command");
                         } else {
-                            await (device?.ParkAsync(ct) ?? Task.CompletedTask);
+                            await parkDevice.ParkAsync(parkToken);
                             InvalidatePropertyCache();
                         }
 
+                        parkToken.ThrowIfCancellationRequested();
                         if (CanSetShutter) {
                             if (ShutterStatus == ShutterState.ShutterClosed || ShutterStatus == ShutterState.ShutterClosing) {
                                 Logger.Info($"Not closing dome shutter, since it is already {ShutterStatus}");
                             } else {
                                 Logger.Info($"Closing shutter, since it is currently {ShutterStatus}");
-                                await Task.Run(() => device?.CloseShutter(), ct);
-                                ct.ThrowIfCancellationRequested();
+                                await Task.Run(() => parkDevice.CloseShutter(), parkToken);
                             }
                         }
-                        await Task.Delay(TimeSpan.FromSeconds(3), ct);
-                        while (Slewing && !ct.IsCancellationRequested) {
-                            await Task.Delay(TimeSpan.FromSeconds(1), ct);
+
+                        await Task.Delay(TimeSpan.FromSeconds(3), parkToken);
+                        while (parkDevice.Slewing) {
+                            if (device != parkDevice || !ShouldBeConnected || !parkDevice.Connected) {
+                                throw new ASCOM.NotConnectedException();
+                            }
+                            await Task.Delay(TimeSpan.FromSeconds(1), parkToken);
                         }
+                        parkToken.ThrowIfCancellationRequested();
+                        if (device != parkDevice || !ShouldBeConnected || !parkDevice.Connected) {
+                            throw new ASCOM.NotConnectedException();
+                        }
+
+                        // ASCOM ParkAsync only waits for Slewing to stop. Check AtPark once after movement
+                        // stops, without the display cache or its last-known-value fallback on driver errors.
+                        if (!parkDevice.AtPark) {
+                            string message = Loc.Instance["LblDomeParkFailed"];
+                            Logger.Error("Dome park failed: driver reports AtPark=false after Slewing stopped");
+                            Notification.ShowError(message);
+                            throw new InvalidOperationException(message);
+                        }
+                        parkToken.ThrowIfCancellationRequested();
+                        InvalidatePropertyCache();
+                    } catch (OperationCanceledException ex) {
                         ct.ThrowIfCancellationRequested();
+                        if (!parkCancellation.IsCancellationRequested) {
+                            throw;
+                        }
+                        string message = string.Format(Loc.Instance["LblDomeParkTimeout"], timeout.TotalMinutes);
+                        Logger.Error($"Dome park timed out after {timeout.TotalMinutes} minutes");
+                        Notification.ShowError(message);
+                        throw new TimeoutException(message, ex);
                     }
                 } else {
                     Logger.Warning("Dome cannot find park");

--- a/NINA.Test/Dome/AscomDomeTest.cs
+++ b/NINA.Test/Dome/AscomDomeTest.cs
@@ -1,0 +1,400 @@
+#region "copyright"
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+#endregion "copyright"
+
+using ASCOM.Common.DeviceInterfaces;
+using Moq;
+using NINA.Core.Model;
+using NINA.Core.Utility;
+using NINA.Equipment.Equipment.MyDome;
+using NINA.Equipment.Interfaces;
+using NINA.Equipment.Interfaces.Mediator;
+using NINA.Equipment.Interfaces.ViewModel;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer.Container;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.SequenceItem.Dome;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Mediator;
+using NINA.WPF.Base.ViewModel.Equipment.Dome;
+using System.Diagnostics;
+
+namespace NINA.Test.Dome {
+    [TestFixture]
+    [NonParallelizable]
+    public class AscomDomeTest {
+        private Mock<IDomeV3> driver = null!;
+        private TestDome dome = null!;
+        private TaskCompletionSource parkRequested = null!;
+        private TaskCompletionSource finalMovementRead = null!;
+        private volatile bool atPark;
+        private volatile bool atHome;
+        private volatile bool slewing;
+        private volatile bool shutterCommandSent;
+        private volatile ASCOM.Common.DeviceInterfaces.ShutterState shutterState;
+
+        [SetUp]
+        public async Task SetUp() {
+            atPark = false;
+            atHome = false;
+            slewing = false;
+            shutterCommandSent = false;
+            shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Open;
+            parkRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            finalMovementRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            driver = new Mock<IDomeV3>();
+            driver.SetupProperty(d => d.Connected, false);
+            driver.SetupGet(d => d.CanPark).Returns(true);
+            driver.SetupGet(d => d.AtPark).Returns(() => atPark);
+            driver.SetupGet(d => d.AtHome).Returns(() => atHome);
+            driver.SetupGet(d => d.Slewing).Returns(() => {
+                bool value = slewing;
+                if (shutterCommandSent) {
+                    finalMovementRead.TrySetResult();
+                }
+                return value;
+            });
+            driver.SetupGet(d => d.ShutterStatus).Returns(() => shutterState);
+            driver.Setup(d => d.Park()).Callback(() => parkRequested.TrySetResult());
+            driver.Setup(d => d.AbortSlew()).Callback(() => slewing = false);
+            driver.Setup(d => d.CloseShutter()).Callback(() => shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Closing);
+            dome = new TestDome(driver.Object);
+            Assert.That(await dome.Connect(CancellationToken.None), Is.True);
+        }
+
+        [TearDown]
+        public void TearDown() {
+            dome.Dispose();
+        }
+
+        [TestCase(false, false)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(true, true)]
+        public async Task Park_MovementStoppedButNotParked_FailsRegardlessOfAtHome(bool home, bool canSetShutter) {
+            atHome = home;
+            driver.SetupGet(d => d.CanSetShutter).Returns(canSetShutter);
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = dome.Park(cancellation.Token);
+            try {
+                Assert.ThrowsAsync<InvalidOperationException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(8)));
+                driver.Verify(d => d.Park(), Times.Once);
+                driver.Verify(d => d.CloseShutter(), canSetShutter ? Times.Once() : Times.Never());
+                driver.Verify(d => d.AbortSlew(), Times.Never);
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+            }
+        }
+
+        [TestCase(false, false)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(true, true)]
+        public async Task Park_MovementStoppedAndParked_SucceedsRegardlessOfAtHome(bool home, bool canSetShutter) {
+            atHome = home;
+            driver.SetupGet(d => d.CanSetShutter).Returns(canSetShutter);
+            driver.Setup(d => d.Park()).Callback(() => atPark = true);
+
+            await dome.Park(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(8));
+
+            driver.Verify(d => d.Park(), Times.Once);
+            driver.Verify(d => d.CloseShutter(), canSetShutter ? Times.Once() : Times.Never());
+            driver.Verify(d => d.AbortSlew(), Times.Never);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task Park_AlreadyParked_DoesNotSendParkButPreservesShutterClosure(bool canSetShutter) {
+            atPark = true;
+            driver.SetupGet(d => d.CanSetShutter).Returns(canSetShutter);
+
+            await dome.Park(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(8));
+
+            driver.Verify(d => d.Park(), Times.Never);
+            driver.Verify(d => d.CloseShutter(), canSetShutter ? Times.Once() : Times.Never());
+            driver.Verify(d => d.AbortSlew(), Times.Never);
+        }
+
+        [TestCase(ASCOM.Common.DeviceInterfaces.ShutterState.Closed)]
+        [TestCase(ASCOM.Common.DeviceInterfaces.ShutterState.Closing)]
+        public async Task Park_ShutterAlreadyClosedOrClosing_DoesNotSendCloseShutter(ASCOM.Common.DeviceInterfaces.ShutterState state) {
+            atPark = true;
+            shutterState = state;
+            driver.SetupGet(d => d.CanSetShutter).Returns(true);
+
+            await dome.Park(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(8));
+
+            driver.Verify(d => d.CloseShutter(), Times.Never);
+        }
+
+        [Test]
+        public async Task Park_InitiallyMoving_AbortsBeforeIssuingPark() {
+            slewing = true;
+            driver.Setup(d => d.Park()).Callback(() => {
+                Assert.That(slewing, Is.False);
+                atPark = true;
+            });
+
+            await dome.Park(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+            driver.Verify(d => d.AbortSlew(), Times.Once);
+            driver.Verify(d => d.Park(), Times.Once);
+        }
+
+        [Test]
+        public async Task Park_StillMoving_DoesNotCheckAtParkUntilMovementStops() {
+            KeepMovingAfterShutterCommand();
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = dome.Park(cancellation.Token);
+            try {
+                await finalMovementRead.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                atPark = true;
+                Task first = await Task.WhenAny(parking, Task.Delay(TimeSpan.FromSeconds(1)));
+                Assert.That(first, Is.Not.SameAs(parking), "AtPark cannot complete parking while the driver is still moving.");
+                driver.VerifyGet(d => d.AtPark, Times.Once, "Only the pre-command already-parked check may run before movement stops.");
+                slewing = false;
+                await parking.WaitAsync(TimeSpan.FromSeconds(5));
+                driver.VerifyGet(d => d.AtPark, Times.Exactly(2));
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+            }
+        }
+
+        [TestCase(false, false)]
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        [TestCase(true, true)]
+        public async Task Park_CancelledDuringHelperOrConfirmation_AbortsAndPreservesCancellation(bool duringHelper, bool abortFails) {
+            if (!duringHelper) {
+                KeepMovingAfterShutterCommand();
+            }
+            driver.Setup(d => d.Park()).Callback(() => {
+                slewing = duringHelper;
+                parkRequested.TrySetResult();
+            });
+            if (abortFails) {
+                driver.Setup(d => d.AbortSlew()).Throws(new InvalidOperationException("Abort failed"));
+            }
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = dome.Park(cancellation.Token);
+            try {
+                await (duringHelper ? parkRequested.Task : finalMovementRead.Task).WaitAsync(TimeSpan.FromSeconds(8));
+                await cancellation.CancelAsync();
+
+                OperationCanceledException? error = Assert.CatchAsync<OperationCanceledException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(5)));
+                Assert.That(error!.CancellationToken, Is.EqualTo(cancellation.Token));
+                driver.Verify(d => d.AbortSlew(), Times.Once);
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+            }
+        }
+
+        [Test]
+        public void Park_AlreadyCancelled_DoesNotSendCommands() {
+            using CancellationTokenSource cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(() => dome.Park(cancellation.Token));
+
+            driver.Verify(d => d.Park(), Times.Never);
+            driver.Verify(d => d.AbortSlew(), Times.Never);
+            driver.Verify(d => d.CloseShutter(), Times.Never);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task Park_ConnectionLostDuringConfirmation_Fails(bool dispose) {
+            KeepMovingAfterShutterCommand();
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = dome.Park(cancellation.Token);
+            try {
+                await finalMovementRead.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (dispose) {
+                    dome.Disconnect();
+                } else {
+                    driver.Object.Connected = false;
+                }
+                atPark = true;
+
+                Assert.ThrowsAsync<ASCOM.NotConnectedException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(5)));
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task Park_ConfirmationReadFails_DoesNotUseCachedSuccess(bool failSlewing) {
+            KeepMovingAfterShutterCommand();
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = dome.Park(cancellation.Token);
+            try {
+                await finalMovementRead.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                atPark = true;
+                Assert.That(dome.AtPark, Is.True);
+                Assert.That(dome.Slewing, Is.True);
+                InvalidOperationException expected = new InvalidOperationException("Driver state unavailable");
+                if (failSlewing) {
+                    driver.SetupGet(d => d.Slewing).Throws(expected);
+                } else {
+                    driver.SetupGet(d => d.AtPark).Throws(expected);
+                    slewing = false;
+                }
+
+                Exception? actual = Assert.ThrowsAsync<InvalidOperationException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(5)));
+                Assert.That(actual, Is.SameAs(expected));
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+            }
+        }
+
+        [Test]
+        public async Task ParkDome_Sequence_WaitsBeforeRunningNextInstructionAndRaisingParked() {
+            KeepMovingAfterShutterCommand();
+            shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Closed;
+            driver.SetupGet(d => d.CanSetShutter).Returns(true);
+            driver.SetupGet(d => d.CanSetAzimuth).Returns(true);
+            driver.Setup(d => d.OpenShutter()).Callback(() => shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Open);
+            (DomeVM vm, DomeMediator mediator) = await CreateViewModel();
+            int parkedEvents = 0;
+            vm.Parked += (_, _) => { Interlocked.Increment(ref parkedEvents); return Task.CompletedTask; };
+            ParkDome park = new ParkDome(mediator);
+            Mock<SequenceItem> next = new Mock<SequenceItem> { CallBase = true };
+            next.Setup(i => i.Execute(It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            SequentialContainer sequence = new SequentialContainer();
+            sequence.Items.Add(new OpenDomeShutter(mediator));
+            sequence.Items.Add(new SlewDomeAzimuth(mediator) { AzimuthDegrees = 160 });
+            sequence.Items.Add(park);
+            sequence.Items.Add(next.Object);
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task running = sequence.Execute(null, cancellation.Token);
+            try {
+                await finalMovementRead.Task.WaitAsync(TimeSpan.FromSeconds(12));
+                atHome = true;
+                Task first = await Task.WhenAny(running, Task.Delay(TimeSpan.FromSeconds(1)));
+                Assert.That(first, Is.Not.SameAs(running));
+                Assert.That(parkedEvents, Is.Zero);
+                driver.Verify(d => d.OpenShutter(), Times.Once);
+                driver.Verify(d => d.SlewToAzimuth(160), Times.Once);
+                driver.Verify(d => d.CloseShutter(), Times.Once);
+                next.Verify(i => i.Execute(It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Never);
+
+                shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Closed;
+                atPark = true;
+                slewing = false;
+                await running.WaitAsync(TimeSpan.FromSeconds(5));
+
+                Assert.That(parkedEvents, Is.EqualTo(1));
+                next.Verify(i => i.Execute(It.IsAny<IProgress<ApplicationStatus>>(), It.IsAny<CancellationToken>()), Times.Once);
+            } finally {
+                await CancelAndObserve(cancellation, running);
+                await vm.Disconnect();
+            }
+        }
+
+        [TestCase("cancel")]
+        [TestCase("driver error")]
+        [TestCase("not parked")]
+        public async Task ParkDome_CancellationOrFailure_DoesNotRaiseParked(string outcome) {
+            KeepMovingAfterShutterCommand();
+            (DomeVM vm, DomeMediator mediator) = await CreateViewModel();
+            int parkedEvents = 0;
+            vm.Parked += (_, _) => { Interlocked.Increment(ref parkedEvents); return Task.CompletedTask; };
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            Task parking = new ParkDome(mediator).Execute(null, cancellation.Token);
+            try {
+                await finalMovementRead.Task.WaitAsync(TimeSpan.FromSeconds(8));
+                if (outcome == "cancel") {
+                    await cancellation.CancelAsync();
+                    Assert.CatchAsync<OperationCanceledException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(5)));
+                } else {
+                    if (outcome == "driver error") {
+                        driver.SetupGet(d => d.AtPark).Throws(new InvalidOperationException("Driver state unavailable"));
+                    }
+                    slewing = false;
+                    Assert.ThrowsAsync<InvalidOperationException>(async () => await parking.WaitAsync(TimeSpan.FromSeconds(5)));
+                }
+                Assert.That(parkedEvents, Is.Zero);
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+                await vm.Disconnect();
+            }
+        }
+
+        [Test]
+        [Explicit("Exercises the actual fixed 10-minute park timeout. Run explicitly before merging changes to parking.")]
+        public async Task ParkDome_MovementNeverStops_TimesOutAfterTenMinutesAndAborts() {
+            KeepMovingAfterShutterCommand();
+            (DomeVM vm, DomeMediator mediator) = await CreateViewModel();
+            int parkedEvents = 0;
+            vm.Parked += (_, _) => { Interlocked.Increment(ref parkedEvents); return Task.CompletedTask; };
+            using CancellationTokenSource cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(11));
+            Stopwatch elapsed = Stopwatch.StartNew();
+            Task parking = new ParkDome(mediator).Execute(null, cancellation.Token);
+            try {
+                TimeoutException? error = Assert.ThrowsAsync<TimeoutException>(async () => await parking);
+
+                Assert.That(elapsed.Elapsed, Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(599)));
+                Assert.That(elapsed.Elapsed, Is.LessThan(TimeSpan.FromSeconds(630)));
+                Assert.That(error!.Message, Does.Contain("10"));
+                Assert.That(parkedEvents, Is.Zero);
+                driver.Verify(d => d.AbortSlew(), Times.Once);
+            } finally {
+                await CancelAndObserve(cancellation, parking);
+                await vm.Disconnect();
+            }
+        }
+
+        private void KeepMovingAfterShutterCommand() {
+            driver.SetupGet(d => d.CanSetShutter).Returns(true);
+            driver.Setup(d => d.CloseShutter()).Callback(() => {
+                shutterState = ASCOM.Common.DeviceInterfaces.ShutterState.Closing;
+                slewing = true;
+                shutterCommandSent = true;
+            });
+        }
+
+        private async Task<(DomeVM, DomeMediator)> CreateViewModel() {
+            Mock<IProfileService> profile = new Mock<IProfileService>();
+            profile.SetupProperty(p => p.ActiveProfile.DomeSettings.Id);
+            profile.SetupGet(p => p.ActiveProfile.ApplicationSettings.DevicePollingInterval).Returns(1);
+            Mock<IDeviceChooserVM> chooser = new Mock<IDeviceChooserVM>();
+            chooser.SetupGet(c => c.SelectedDevice).Returns(dome);
+            Mock<IDeviceUpdateTimer> timer = new Mock<IDeviceUpdateTimer>();
+            Mock<IDeviceUpdateTimerFactory> timerFactory = new Mock<IDeviceUpdateTimerFactory>();
+            timerFactory.Setup(f => f.Create(It.IsAny<Func<Dictionary<string, object>>>(), It.IsAny<Action<Dictionary<string, object>>>(), It.IsAny<double>(), It.IsAny<string>()))
+                .Returns(timer.Object);
+            DomeMediator mediator = new DomeMediator();
+            DomeVM vm = new DomeVM(profile.Object, mediator, Mock.Of<IApplicationStatusMediator>(), Mock.Of<ITelescopeMediator>(),
+                chooser.Object, Mock.Of<IDomeFollower>(), Mock.Of<ISafetyMonitorMediator>(), Mock.Of<IApplicationResourceDictionary>(), timerFactory.Object);
+            Assert.That(await vm.Connect(), Is.True);
+            return (vm, mediator);
+        }
+
+        private static async Task CancelAndObserve(CancellationTokenSource cancellation, Task operation) {
+            await cancellation.CancelAsync();
+            // Observe failures during cleanup without replacing the assertion or driver error under test.
+            try { await operation.WaitAsync(TimeSpan.FromSeconds(5)); } catch (Exception) { }
+        }
+
+        private sealed class TestDome : AscomDome {
+            private readonly IDomeV3 driver;
+
+            public TestDome(IDomeV3 driver) : base("Test.Dome", "Test dome") {
+                this.driver = driver;
+            }
+
+            protected override IDomeV3 GetInstance() {
+                return driver;
+            }
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ This allows you to safely return to a stable release if needed.
 - The application now runs on .NET 10, bringing performance improvements and access to the latest runtime features.
 
 ## Bugfixes
+- Dome parking now checks that the driver reports it is parked after movement stops and reports a failure if it is not. A fixed 10-minute timeout aborts parking if it does not complete.
 - ASCOM and Alpaca cameras now apply their reported Bayer X/Y offsets when automatically debayering previews, so non-RGGB phases display the correct colors while preserving the original image metadata.
 - The Connect All and Disconnect All commands can no longer run at the same time, preventing conflicting device operations during slow connections.
 - Cached Offline Sky Map and Sky Atlas image tiles now keep a stable orientation across zoom levels instead of occasionally rotating by 180 degrees.


### PR DESCRIPTION
## 🚀 Purpose

Dome parking could report success when movement stopped even though the driver still reported `AtPark=false`. Parking now waits for `Slewing` to stop, then checks live `AtPark` once and fails if it is false.

A fixed 10-minute timeout aborts parking and reports a timeout separately from caller cancellation. Existing pre-park checks, the asynchronous pre-park abort and shutter-command order are preserved.

## 🧪 How Was It Tested?

- Reproduced premature completion against the original adapter with failing regression tests.
- Application and test project builds passed.
- Targeted dome, dome sequencer and dome trigger tests: 115 passed.
- Full regression suite: 5,556 passed, 16 existing image and autofocus cases skipped and no failures.
- Explicit timeout test passed after the actual 10-minute wait, verifying `AbortSlew`, `TimeoutException` and no `Parked` event.
- Replayed open shutter, slew, park and a following instruction through the real sequencer, mediator, VM and adapter using an in-process simulated ASCOM driver.
- Covered successful and failed final parking checks, no `AtPark` polling during the final movement wait, shutter support enabled and disabled, cancellation, abort errors, connection loss and state-read errors.

## 🤖 AI / Tooling Disclosure

Assisted by OpenAI Codex.

## ✅ PR Checklist

- [x] All unit tests pass (existing skipped cases documented above)
- [ ] UI changes tested across Light, Dark and Night themes (not applicable; no visual changes)
- [x] Plugin API compatibility reviewed
  - [x] No breaking changes to interfaces
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (not applicable; bugfix covered by release notes)

## 🔗 Related Issues

Closes #41.

## 📸 Screenshots

Not applicable; no visual changes.

## 📝 Additional Notes

-