### PR TITLE
Vectorize star detection and several image stats calculations

### DIFF
--- a/NINA.Image/ImageAnalysis/StarDetection.cs
+++ b/NINA.Image/ImageAnalysis/StarDetection.cs
@@ -200,7 +200,7 @@ namespace NINA.Image.ImageAnalysis {
                 this.Eccentricity = CalculateEccentricity(radialSamples, this.Position);
             }
 
-            internal bool InsideCircle(double x, double y, double centerX, double centerY, double radius) {
+            internal static bool InsideCircle(double x, double y, double centerX, double centerY, double radius) {
                 return Math.Pow(x - centerX, 2) + Math.Pow(y - centerY, 2) <= Math.Pow(radius, 2);
             }
 
@@ -347,7 +347,7 @@ namespace NINA.Image.ImageAnalysis {
                 return (currentCenter, lastTotalFlux);
             }
 
-            private double GetWindowSigma(double radius) {
+            private static double GetWindowSigma(double radius) {
                 return Math.Max(radius / 2d, 1d);
             }
 
@@ -388,7 +388,7 @@ namespace NINA.Image.ImageAnalysis {
                 return samples;
             }
 
-            private double CalculateHalfFluxRadius(List<RadialSample> samples, double totalFlux) {
+            private static double CalculateHalfFluxRadius(List<RadialSample> samples, double totalFlux) {
                 // Curve-of-growth HFR: sort background-subtracted flux by radius and interpolate
                 // the radius at which the enclosed flux reaches 50% of the total enclosed flux.
                 // This follows the standard half-light / half-flux radius definition rather than
@@ -481,7 +481,7 @@ namespace NINA.Image.ImageAnalysis {
                 return double.NaN;
             }
 
-            private double CalculateEccentricity(List<RadialSample> samples, Point center) {
+            private static double CalculateEccentricity(List<RadialSample> samples, Point center) {
                 // Eccentricity from background-subtracted, flux-weighted second central moments
                 // within the local measurement aperture:
                 // e = sqrt(1 - lambda_minor / lambda_major), where the lambdas are the
@@ -655,7 +655,7 @@ namespace NINA.Image.ImageAnalysis {
             return result;
         }
 
-        private bool InROI(Bitmap bitmapToAnalyze, StarDetectionParams p, Blob blob) {
+        private static bool InROI(Bitmap bitmapToAnalyze, StarDetectionParams p, Blob blob) {
             return DetectionUtility.InROI(
                 new Size(width: bitmapToAnalyze.Width, height: bitmapToAnalyze.Height),
                 blob: blob.Rectangle,
@@ -663,7 +663,7 @@ namespace NINA.Image.ImageAnalysis {
                 innerCropRatio: p.InnerCropRatio);
         }
 
-        private List<DetectedStar> IdentifyStars(StarDetectionParams p, State state, BlobCounter blobCounter, Bitmap bitmapToAnalyze, StarDetectionResult result, CancellationToken token, out int detectedStars) {
+        private static List<DetectedStar> IdentifyStars(StarDetectionParams p, State state, BlobCounter blobCounter, Bitmap bitmapToAnalyze, StarDetectionResult result, CancellationToken token, out int detectedStars) {
             using (MyStopWatch.Measure()) {
                 detectedStars = 0;
                 Blob[] blobs = blobCounter.GetObjectsInformation();
@@ -722,7 +722,7 @@ namespace NINA.Image.ImageAnalysis {
                         for (int y = largeRect.Y; y < largeRect.Y + largeRect.Height; y++) {
                             var pixelValue = state._iarr.FlatArray[x + (state.imageProperties.Width * y)];
                             if (x >= s.Rectangle.X && x < s.Rectangle.X + s.Rectangle.Width && y >= s.Rectangle.Y && y < s.Rectangle.Y + s.Rectangle.Height) { //We're in the small rectangle directly surrounding the star
-                                if (s.InsideCircle(x, y, s.Position.X, s.Position.Y, s.Radius)) { // We're in the inner sanctum of the star
+                                if (Star.InsideCircle(x, y, s.Position.X, s.Position.Y, s.Radius)) { // We're in the inner sanctum of the star
                                     starPixelSum += pixelValue;
                                     starPixelCount++;
                                     innerStarPixelValues.Add(pixelValue);
@@ -806,14 +806,14 @@ namespace NINA.Image.ImageAnalysis {
             }
         }
 
-        private double CalculateEccentricity(double width, double height) {
+        private static double CalculateEccentricity(double width, double height) {
             var x = Math.Max(width, height);
             var y = Math.Min(width, height);
             double focus = Math.Sqrt(Math.Pow(x, 2) - Math.Pow(y, 2));
             return focus / x;
         }
 
-        private (double Background, double Sigma) EstimateBackground(List<double> pixelValues) {
+        private static (double Background, double Sigma) EstimateBackground(List<double> pixelValues) {
             // Robust local sky estimate from a sigma-clipped median. Sigma clipping is standard
             // practice for astronomical background estimation in the presence of source pixels
             // and outliers; see the Astropy CCD Reduction Guide:
@@ -874,7 +874,7 @@ namespace NINA.Image.ImageAnalysis {
             return (finalMedian, StandardDeviation(values, finalMedian));
         }
 
-        private double MedianFromSorted(List<double> values) {
+        private static double MedianFromSorted(List<double> values) {
             if (values.Count == 0) {
                 return 0d;
             }
@@ -887,7 +887,7 @@ namespace NINA.Image.ImageAnalysis {
             return values[middle];
         }
 
-        private double StandardDeviation(List<double> values, double mean) {
+        private static double StandardDeviation(List<double> values, double mean) {
             if (values.Count == 0) {
                 return 0d;
             }
@@ -917,7 +917,7 @@ namespace NINA.Image.ImageAnalysis {
             return Math.Sqrt(sumSquares / values.Count);
         }
 
-        private BlobCounter DetectStructures(Bitmap bmp, CancellationToken token) {
+        private static BlobCounter DetectStructures(Bitmap bmp, CancellationToken token) {
             using (MyStopWatch.Measure()) {
                 /* detect structures */
                 BlobCounter blobCounter = new BlobCounter();
@@ -929,7 +929,7 @@ namespace NINA.Image.ImageAnalysis {
             }
         }
 
-        private void PrepareForStructureDetection(Bitmap bmp, StarDetectionParams p, CancellationToken token) {
+        private static void PrepareForStructureDetection(Bitmap bmp, StarDetectionParams p, CancellationToken token) {
             using (MyStopWatch.Measure()) {
                 using (MyStopWatch.Measure("PrepareForStructureDetection - CannyEdge")) {
                     if (p.NoiseReduction == NoiseReductionEnum.None || p.NoiseReduction == NoiseReductionEnum.Median) {
@@ -954,7 +954,7 @@ namespace NINA.Image.ImageAnalysis {
             }
         }
 
-        private Bitmap ReduceNoise(Bitmap bitmapToAnalyze, StarDetectionParams p) {
+        private static Bitmap ReduceNoise(Bitmap bitmapToAnalyze, StarDetectionParams p) {
             using (MyStopWatch.Measure()) {
                 if (bitmapToAnalyze.Width > _maxWidth) {
                     Bitmap bmp;

--- a/NINA.Image/ImageAnalysis/StarDetection.cs
+++ b/NINA.Image/ImageAnalysis/StarDetection.cs
@@ -376,22 +376,64 @@ namespace NINA.Image.ImageAnalysis {
                 // moment-based shape formalism used in source extraction; see
                 // Bertin & Arnouts (1996), SExtractor, A&AS 117, 393,
                 // https://doi.org/10.1051/aas:1996164
-                double momentXX = 0;
-                double momentYY = 0;
-                double momentXY = 0;
-                double totalFlux = 0;
+
+                // Pack positive-flux samples into parallel SoA arrays so Vector<double> can
+                // operate on contiguous single-field spans (RadialSample is AoS and cannot be
+                // cast directly).
+                var count = 0;
+                var fluxArr = new double[samples.Count];
+                var dxArr = new double[samples.Count];
+                var dyArr = new double[samples.Count];
 
                 foreach (var sample in samples) {
                     if (sample.PositiveFlux <= 0) {
                         continue;
                     }
+                    fluxArr[count] = sample.PositiveFlux;
+                    dxArr[count] = sample.PosX - center.X;
+                    dyArr[count] = sample.PosY - center.Y;
+                    count++;
+                }
 
-                    var dx = sample.PosX - center.X;
-                    var dy = sample.PosY - center.Y;
-                    totalFlux += sample.PositiveFlux;
-                    momentXX += sample.PositiveFlux * dx * dx;
-                    momentYY += sample.PositiveFlux * dy * dy;
-                    momentXY += sample.PositiveFlux * dx * dy;
+                if (count == 0) {
+                    return double.NaN;
+                }
+
+                var fluxSpan = fluxArr.AsSpan(0, count);
+                var dxSpan = dxArr.AsSpan(0, count);
+                var dySpan = dyArr.AsSpan(0, count);
+
+                var vectorSize = Vector<double>.Count;
+                var vTotalFlux = Vector<double>.Zero;
+                var vMomentXX = Vector<double>.Zero;
+                var vMomentYY = Vector<double>.Zero;
+                var vMomentXY = Vector<double>.Zero;
+                int i = 0;
+
+                for (; i <= count - vectorSize; i += vectorSize) {
+                    var vFlux = new Vector<double>(fluxSpan.Slice(i, vectorSize));
+                    var vDx = new Vector<double>(dxSpan.Slice(i, vectorSize));
+                    var vDy = new Vector<double>(dySpan.Slice(i, vectorSize));
+                    vTotalFlux += vFlux;
+                    vMomentXX += vFlux * vDx * vDx;
+                    vMomentYY += vFlux * vDy * vDy;
+                    vMomentXY += vFlux * vDx * vDy;
+                }
+
+                double totalFlux = Vector.Dot(vTotalFlux, Vector<double>.One);
+                double momentXX = Vector.Dot(vMomentXX, Vector<double>.One);
+                double momentYY = Vector.Dot(vMomentYY, Vector<double>.One);
+                double momentXY = Vector.Dot(vMomentXY, Vector<double>.One);
+
+                // Scalar tail for remaining elements that do not fill a full vector
+                for (; i < count; i++) {
+                    var f = fluxSpan[i];
+                    var ddx = dxSpan[i];
+                    var ddy = dySpan[i];
+                    totalFlux += f;
+                    momentXX += f * ddx * ddx;
+                    momentYY += f * ddy * ddy;
+                    momentXY += f * ddx * ddy;
                 }
 
                 if (totalFlux <= 0) {

--- a/NINA.Image/ImageAnalysis/StarDetection.cs
+++ b/NINA.Image/ImageAnalysis/StarDetection.cs
@@ -35,7 +35,7 @@ using Point = Accord.Point;
 namespace NINA.Image.ImageAnalysis {
 
     public class StarDetection : IStarDetection {
-        private static readonly int _maxWidth = 1552;
+        private const int _maxWidth = 1552;
 
         public string Name => "NINA";
 
@@ -159,16 +159,31 @@ namespace NINA.Image.ImageAnalysis {
                     return;
                 }
 
-                var centroidRadius = GetMeasurementRadius(this.Position, pixelData);
-                var centroid = CalculateCentroid(pixelData, this.Position, centroidRadius, iterate: true);
-                if (centroid.TotalFlux <= 0) {
+                // Convert AoS pixel data to SoA layout for vectorized operations
+                var pixelCount = pixelData.Count;
+                var posXArr = new double[pixelCount];
+                var posYArr = new double[pixelCount];
+                var valuesArr = new double[pixelCount];
+                for (int i = 0; i < pixelCount; i++) {
+                    var pd = pixelData[i];
+                    posXArr[i] = pd.PosX;
+                    posYArr[i] = pd.PosY;
+                    valuesArr[i] = pd.Value;
+                }
+                ReadOnlySpan<double> posXSpan = posXArr;
+                ReadOnlySpan<double> posYSpan = posYArr;
+                ReadOnlySpan<double> valuesSpan = valuesArr;
+
+                var centroidRadius = GetMeasurementRadius(this.Position, posXSpan, posYSpan);
+                var (Center, TotalFlux) = CalculateCentroid(posXSpan, posYSpan, valuesSpan, this.Position, centroidRadius, iterate: true);
+                if (TotalFlux <= 0) {
                     return;
                 }
 
-                this.Position = centroid.Center;
+                this.Position = Center;
 
-                var measurementRadius = GetMeasurementRadius(this.Position, pixelData);
-                var radialSamples = CollectRadialSamples(pixelData, this.Position, measurementRadius);
+                var measurementRadius = GetMeasurementRadius(this.Position, posXSpan, posYSpan);
+                var radialSamples = CollectRadialSamples(posXSpan, posYSpan, valuesSpan, this.Position, measurementRadius);
                 if (radialSamples.Count == 0) {
                     return;
                 }
@@ -189,11 +204,39 @@ namespace NINA.Image.ImageAnalysis {
                 return Math.Pow(x - centerX, 2) + Math.Pow(y - centerY, 2) <= Math.Pow(radius, 2);
             }
 
-            private double GetMeasurementRadius(Point center, List<PixelData> pixelData) {
-                var minX = pixelData.Min(p => p.PosX);
-                var maxX = pixelData.Max(p => p.PosX);
-                var minY = pixelData.Min(p => p.PosY);
-                var maxY = pixelData.Max(p => p.PosY);
+            private double GetMeasurementRadius(Point center, ReadOnlySpan<double> posX, ReadOnlySpan<double> posY) {
+                var vectorSize = Vector<double>.Count;
+                var vMinX = new Vector<double>(double.MaxValue);
+                var vMaxX = new Vector<double>(double.MinValue);
+                var vMinY = new Vector<double>(double.MaxValue);
+                var vMaxY = new Vector<double>(double.MinValue);
+                int i = 0;
+
+                for (; i <= posX.Length - vectorSize; i += vectorSize) {
+                    var vx = new Vector<double>(posX.Slice(i, vectorSize));
+                    var vy = new Vector<double>(posY.Slice(i, vectorSize));
+                    vMinX = Vector.Min(vMinX, vx);
+                    vMaxX = Vector.Max(vMaxX, vx);
+                    vMinY = Vector.Min(vMinY, vy);
+                    vMaxY = Vector.Max(vMaxY, vy);
+                }
+
+                double minX = double.MaxValue, maxX = double.MinValue;
+                double minY = double.MaxValue, maxY = double.MinValue;
+                for (int j = 0; j < vectorSize; j++) {
+                    minX = Math.Min(minX, vMinX[j]);
+                    maxX = Math.Max(maxX, vMaxX[j]);
+                    minY = Math.Min(minY, vMinY[j]);
+                    maxY = Math.Max(maxY, vMaxY[j]);
+                }
+
+                for (; i < posX.Length; i++) {
+                    minX = Math.Min(minX, posX[i]);
+                    maxX = Math.Max(maxX, posX[i]);
+                    minY = Math.Min(minY, posY[i]);
+                    maxY = Math.Max(maxY, posY[i]);
+                }
+
                 var availableRadius = Math.Min(
                     Math.Min(center.X - minX, maxX - center.X),
                     Math.Min(center.Y - minY, maxY - center.Y)) - 0.5d;
@@ -202,7 +245,7 @@ namespace NINA.Image.ImageAnalysis {
                 return Math.Max(1d, Math.Min(requestedRadius, availableRadius));
             }
 
-            private (Point Center, double TotalFlux) CalculateCentroid(List<PixelData> pixelData, Point center, double radius, bool iterate) {
+            private (Point Center, double TotalFlux) CalculateCentroid(ReadOnlySpan<double> posX, ReadOnlySpan<double> posY, ReadOnlySpan<double> values, Point center, double radius, bool iterate) {
                 // Windowed centroiding with a circular Gaussian weight follows the standard
                 // weighted-moment source-extraction approach used in SExtractor. See
                 // Bertin & Arnouts (1996), https://doi.org/10.1051/aas:1996164 and
@@ -211,32 +254,81 @@ namespace NINA.Image.ImageAnalysis {
                 var currentCenter = center;
                 var maxIterations = iterate ? CentroidMaxIterations : 1;
                 var lastTotalFlux = 0d;
+                var radiusSq = radius * radius;
+                var negHalfInvSigmaSq = -0.5d / (sigma * sigma);
+                var count = posX.Length;
+
+                // Scratch arrays allocated once, reused across centroid iterations
+                var fPosX = new double[count];
+                var fPosY = new double[count];
+                var fFlux = new double[count];
+                var fWeightedFlux = new double[count];
 
                 for (var iteration = 0; iteration < maxIterations; iteration++) {
-                    double sumWeightedFlux = 0;
-                    double sumX = 0;
-                    double sumY = 0;
-                    double sumFlux = 0;
+                    var filteredCount = 0;
+                    var cx = (double)currentCenter.X;
+                    var cy = (double)currentCenter.Y;
 
-                    foreach (var data in pixelData) {
-                        var dx = data.PosX - currentCenter.X;
-                        var dy = data.PosY - currentCenter.Y;
-                        var distanceSquared = (dx * dx) + (dy * dy);
-                        if (distanceSquared > radius * radius) {
+                    // Scalar pre-filter: compact qualifying pixels into contiguous spans
+                    // and compute Gaussian window weight (Math.Exp is not vectorizable
+                    // without System.Numerics.Tensors)
+                    for (int i = 0; i < count; i++) {
+                        var dx = posX[i] - cx;
+                        var dy = posY[i] - cy;
+                        var distSq = (dx * dx) + (dy * dy);
+                        if (distSq > radiusSq) {
                             continue;
                         }
 
-                        var flux = data.Value - SurroundingMean;
+                        var flux = values[i] - SurroundingMean;
                         if (flux <= 0) {
                             continue;
                         }
 
-                        var window = Math.Exp(-0.5d * distanceSquared / (sigma * sigma));
-                        var weightedFlux = flux * window;
-                        sumWeightedFlux += weightedFlux;
-                        sumX += data.PosX * weightedFlux;
-                        sumY += data.PosY * weightedFlux;
-                        sumFlux += flux;
+                        var window = Math.Exp(distSq * negHalfInvSigmaSq);
+                        fPosX[filteredCount] = posX[i];
+                        fPosY[filteredCount] = posY[i];
+                        fFlux[filteredCount] = flux;
+                        fWeightedFlux[filteredCount] = flux * window;
+                        filteredCount++;
+                    }
+
+                    if (filteredCount == 0) {
+                        return (currentCenter, 0);
+                    }
+
+                    // Vectorized accumulation over the filtered SoA spans
+                    var fPosXSpan = fPosX.AsSpan(0, filteredCount);
+                    var fPosYSpan = fPosY.AsSpan(0, filteredCount);
+                    var fFluxSpan = fFlux.AsSpan(0, filteredCount);
+                    var fWeightedFluxSpan = fWeightedFlux.AsSpan(0, filteredCount);
+
+                    var vectorSize = Vector<double>.Count;
+                    var vSumWeightedFlux = Vector<double>.Zero;
+                    var vSumX = Vector<double>.Zero;
+                    var vSumY = Vector<double>.Zero;
+                    var vSumFlux = Vector<double>.Zero;
+                    int vi = 0;
+
+                    for (; vi <= filteredCount - vectorSize; vi += vectorSize) {
+                        var vWF = new Vector<double>(fWeightedFluxSpan.Slice(vi, vectorSize));
+                        vSumWeightedFlux += vWF;
+                        vSumX += new Vector<double>(fPosXSpan.Slice(vi, vectorSize)) * vWF;
+                        vSumY += new Vector<double>(fPosYSpan.Slice(vi, vectorSize)) * vWF;
+                        vSumFlux += new Vector<double>(fFluxSpan.Slice(vi, vectorSize));
+                    }
+
+                    double sumWeightedFlux = Vector.Dot(vSumWeightedFlux, Vector<double>.One);
+                    double sumX = Vector.Dot(vSumX, Vector<double>.One);
+                    double sumY = Vector.Dot(vSumY, Vector<double>.One);
+                    double sumFlux = Vector.Dot(vSumFlux, Vector<double>.One);
+
+                    // Scalar tail for remaining elements
+                    for (; vi < filteredCount; vi++) {
+                        sumWeightedFlux += fWeightedFluxSpan[vi];
+                        sumX += fPosXSpan[vi] * fWeightedFluxSpan[vi];
+                        sumY += fPosYSpan[vi] * fWeightedFluxSpan[vi];
+                        sumFlux += fFluxSpan[vi];
                     }
 
                     if (sumWeightedFlux <= 0) {
@@ -259,17 +351,38 @@ namespace NINA.Image.ImageAnalysis {
                 return Math.Max(radius / 2d, 1d);
             }
 
-            private List<RadialSample> CollectRadialSamples(List<PixelData> pixelData, Point center, double radius) {
-                var samples = new List<RadialSample>();
+            private List<RadialSample> CollectRadialSamples(ReadOnlySpan<double> posX, ReadOnlySpan<double> posY, ReadOnlySpan<double> values, Point center, double radius) {
+                var count = posX.Length;
+                var distArr = new double[count];
 
-                foreach (var data in pixelData) {
-                    var distance = Math.Sqrt(Math.Pow(data.PosX - center.X, 2.0d) + Math.Pow(data.PosY - center.Y, 2.0d));
-                    if (distance > radius) {
+                // Vectorized batch distance computation: dist = sqrt(dx² + dy²)
+                var vectorSize = Vector<double>.Count;
+                var vCenterX = new Vector<double>(center.X);
+                var vCenterY = new Vector<double>(center.Y);
+                int i = 0;
+
+                for (; i <= count - vectorSize; i += vectorSize) {
+                    var vDx = new Vector<double>(posX.Slice(i, vectorSize)) - vCenterX;
+                    var vDy = new Vector<double>(posY.Slice(i, vectorSize)) - vCenterY;
+                    var vDistSq = (vDx * vDx) + (vDy * vDy);
+                    Vector.SquareRoot(vDistSq).CopyTo(distArr.AsSpan(i, vectorSize));
+                }
+
+                // Scalar tail
+                for (; i < count; i++) {
+                    var dx = posX[i] - center.X;
+                    var dy = posY[i] - center.Y;
+                    distArr[i] = Math.Sqrt((dx * dx) + (dy * dy));
+                }
+
+                var samples = new List<RadialSample>();
+                for (int j = 0; j < count; j++) {
+                    if (distArr[j] > radius) {
                         continue;
                     }
 
-                    var flux = data.Value - SurroundingMean;
-                    samples.Add(new RadialSample(distance, flux, Math.Max(flux, 0), data.PosX, data.PosY));
+                    var flux = values[j] - SurroundingMean;
+                    samples.Add(new RadialSample(distArr[j], flux, Math.Max(flux, 0), (int)posX[j], (int)posY[j]));
                 }
 
                 return samples;

--- a/NINA.Image/ImageAnalysis/StarDetection.cs
+++ b/NINA.Image/ImageAnalysis/StarDetection.cs
@@ -24,6 +24,8 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
@@ -673,9 +675,24 @@ namespace NINA.Image.ImageAnalysis {
                 values.Sort();
                 var median = MedianFromSorted(values);
                 var deviations = new List<double>(values.Count);
-                for (var index = 0; index < values.Count; index++) {
-                    deviations.Add(Math.Abs(values[index] - median));
+                CollectionsMarshal.SetCount(deviations, values.Count);
+                var deviationsSpan = CollectionsMarshal.AsSpan(deviations);
+                var valuesSpan = CollectionsMarshal.AsSpan(values);
+                var vMedian = new Vector<double>(median);
+                var vectorSize = Vector<double>.Count;
+                int devIdx = 0;
+
+                // Vectorized computation of MAD
+                for (; devIdx <= valuesSpan.Length - vectorSize; devIdx += vectorSize) {
+                    var v = new Vector<double>(valuesSpan.Slice(devIdx, vectorSize));
+                    Vector.Abs(v - vMedian).CopyTo(deviationsSpan.Slice(devIdx, vectorSize));
                 }
+
+                // Handle any remaining elements that don't fit into a vector
+                for (; devIdx < valuesSpan.Length; devIdx++) {
+                    deviationsSpan[devIdx] = Math.Abs(valuesSpan[devIdx] - median);
+                }
+
                 deviations.Sort();
                 var mad = MedianFromSorted(deviations);
                 var sigma = mad > 0 ? 1.4826d * mad : StandardDeviation(values, median);
@@ -720,9 +737,25 @@ namespace NINA.Image.ImageAnalysis {
                 return 0d;
             }
 
-            double sumSquares = 0d;
-            for (var index = 0; index < values.Count; index++) {
-                var delta = values[index] - mean;
+            var span = CollectionsMarshal.AsSpan(values);
+            var vMean = new Vector<double>(mean);
+            var vSumSquares = Vector<double>.Zero;
+            var vectorSize = Vector<double>.Count;
+            int i = 0;
+
+            // Use vectorized operations to compute the sum of squared deviations from the mean.
+            // CPUs with AVX2 (Haswell microarch and later) can do 8 doubles at a time.
+            for (; i <= span.Length - vectorSize; i += vectorSize) {
+                var v = new Vector<double>(span.Slice(i, vectorSize));
+                var delta = v - vMean;
+                vSumSquares += delta * delta;
+            }
+
+            double sumSquares = Vector.Dot(vSumSquares, Vector<double>.One);
+
+            // Handle any remaining elements that don't fit into a vector
+            for (; i < span.Length; i++) {
+                var delta = span[i] - mean;
                 sumSquares += delta * delta;
             }
 

--- a/NINA.Image/ImageAnalysis/StarDetection.cs
+++ b/NINA.Image/ImageAnalysis/StarDetection.cs
@@ -33,7 +33,7 @@ using Point = Accord.Point;
 namespace NINA.Image.ImageAnalysis {
 
     public class StarDetection : IStarDetection {
-        private static int _maxWidth = 1552;
+        private static readonly int _maxWidth = 1552;
 
         public string Name => "NINA";
 
@@ -122,6 +122,7 @@ namespace NINA.Image.ImageAnalysis {
         }
 
         public class Star {
+
             // Measure shape/flux out to 1.5x the detected star radius so the aperture includes
             // most of the stellar profile wings without expanding too far into local background
             // or neighboring sources.
@@ -131,6 +132,7 @@ namespace NINA.Image.ImageAnalysis {
             // sub-pixel resolution for the FWHM half-maximum crossing while still smoothing
             // pixel-grid noise.
             private const double RadialProfileBinWidth = 0.5d;
+
             private const int CentroidMaxIterations = 3;
             private const double CentroidConvergencePixels = 0.01d;
 
@@ -139,7 +141,7 @@ namespace NINA.Image.ImageAnalysis {
             public double MeanBrightness { get; set; }
             public double SurroundingMean { get; set; }
             public double MaxPixelValue { get; set; }
-            public Point Position { get;set; }
+            public Point Position { get; set; }
             public double HFR { get; private set; }
             public double FWHM { get; private set; }
             public double Eccentricity { get; private set; }
@@ -182,7 +184,7 @@ namespace NINA.Image.ImageAnalysis {
             }
 
             internal bool InsideCircle(double x, double y, double centerX, double centerY, double radius) {
-                return (Math.Pow(x - centerX, 2) + Math.Pow(y - centerY, 2) <= Math.Pow(radius, 2));
+                return Math.Pow(x - centerX, 2) + Math.Pow(y - centerY, 2) <= Math.Pow(radius, 2);
             }
 
             private double GetMeasurementRadius(Point center, List<PixelData> pixelData) {
@@ -217,7 +219,7 @@ namespace NINA.Image.ImageAnalysis {
                     foreach (var data in pixelData) {
                         var dx = data.PosX - currentCenter.X;
                         var dy = data.PosY - currentCenter.Y;
-                        var distanceSquared = dx * dx + dy * dy;
+                        var distanceSquared = (dx * dx) + (dy * dy);
                         if (distanceSquared > radius * radius) {
                             continue;
                         }
@@ -300,7 +302,7 @@ namespace NINA.Image.ImageAnalysis {
                     }
 
                     var fraction = (targetFlux - previousFlux) / (cumulativeFlux - previousFlux);
-                    return previousRadius + fraction * (sample.Distance - previousRadius);
+                    return previousRadius + (fraction * (sample.Distance - previousRadius));
                 }
 
                 return samples.Max(sample => sample.Distance);
@@ -353,7 +355,7 @@ namespace NINA.Image.ImageAnalysis {
                         }
 
                         var fraction = (halfMaximum - previousValue) / (value - previousValue);
-                        var halfMaxRadius = previousRadius + fraction * (radius - previousRadius);
+                        var halfMaxRadius = previousRadius + (fraction * (radius - previousRadius));
                         return 2d * halfMaxRadius;
                     }
 
@@ -399,7 +401,7 @@ namespace NINA.Image.ImageAnalysis {
                 momentXY /= totalFlux;
 
                 var trace = momentXX + momentYY;
-                var determinantTerm = (momentXX - momentYY) * (momentXX - momentYY) + 4d * momentXY * momentXY;
+                var determinantTerm = ((momentXX - momentYY) * (momentXX - momentYY)) + (4d * momentXY * momentXY);
                 var root = Math.Sqrt(Math.Max(0d, determinantTerm));
                 var major = (trace + root) / 2d;
                 var minor = (trace - root) / 2d;
@@ -426,7 +428,7 @@ namespace NINA.Image.ImageAnalysis {
             }
         }
 
-        public record PixelData (int PosX, int PosY, double Value);
+        public record PixelData(int PosX, int PosY, double Value);
         private record RadialSample(double Distance, double RawFlux, double PositiveFlux, int PosX, int PosY);
 
         public async Task<StarDetectionResult> Detect(IRenderedImage image, PixelFormat pf, StarDetectionParams p, IProgress<ApplicationStatus> progress, CancellationToken token) {
@@ -583,7 +585,7 @@ namespace NINA.Image.ImageAnalysis {
                         continue;
                     }
 
-                    s.MeanBrightness = starPixelSum / (double)starPixelCount;
+                    s.MeanBrightness = starPixelSum / starPixelCount;
                     if (backgroundPixelValues.Count == 0) {
                         continue;
                     }
@@ -594,9 +596,9 @@ namespace NINA.Image.ImageAnalysis {
                     double largeRectStdev = backgroundStats.Sigma;
                     int minimumNumberOfPixels = (int)Math.Ceiling(Math.Max(state._originalBitmapSource.PixelWidth, state._originalBitmapSource.PixelHeight) / 1000d);
 
-                    if (s.MeanBrightness >= largeRectMean + Math.Min(0.1 * largeRectMean, largeRectStdev) && innerStarPixelValues.Count(pv => pv > largeRectMean + 1.5 * largeRectStdev) > minimumNumberOfPixels) {
+                    if (s.MeanBrightness >= largeRectMean + Math.Min(0.1 * largeRectMean, largeRectStdev) && innerStarPixelValues.Count(pv => pv > largeRectMean + (1.5 * largeRectStdev)) > minimumNumberOfPixels) {
                         s.Calculate(pixelDataList);
-                        //It's a local maximum, and has enough bright pixels, so likely to be a star.                        
+                        //It's a local maximum, and has enough bright pixels, so likely to be a star.
                         if (s.Position.X > (s.Rectangle.X + 1) && s.Position.Y > (s.Rectangle.Y + 1) && s.Position.X < (s.Rectangle.X + s.Rectangle.Width - 2) && s.Position.Y < (s.Rectangle.Y + s.Rectangle.Height - 2)) {
                             // Only add star when centroid is not touching the rectangle edges
                             sumRadius += s.Radius;
@@ -613,13 +615,13 @@ namespace NINA.Image.ImageAnalysis {
 
                 //Now that we have a properly filtered star list, let's compute stats and further filter out from the mean
                 if (starList.Count > 0) {
-                    double avg = sumRadius / (double)starList.Count;
-                    double stdev = Math.Sqrt((sumSquares - starList.Count * avg * avg) / starList.Count);
+                    double avg = sumRadius / starList.Count;
+                    double stdev = Math.Sqrt((sumSquares - (starList.Count * avg * avg)) / starList.Count);
                     if (p.Sensitivity != StarSensitivityEnum.Highest) {
-                        starList = starList.Where(s => s.Radius <= avg + 1.5 * stdev && s.Radius >= avg - 1.5 * stdev).ToList<Star>();
+                        starList = starList.Where(s => s.Radius <= avg + (1.5 * stdev) && s.Radius >= avg - (1.5 * stdev)).ToList<Star>();
                     } else {
                         //More sensitivity means getting fainter and smaller stars, and maybe some noise, skewing the distribution towards low radius. Let's be more permissive towards the large star end.
-                        starList = starList.Where(s => s.Radius <= avg + 2 * stdev && s.Radius >= avg - 1.5 * stdev).ToList<Star>();
+                        starList = starList.Where(s => s.Radius <= avg + (2 * stdev) && s.Radius >= avg - (1.5 * stdev)).ToList<Star>();
                     }
                 }
 
@@ -633,7 +635,7 @@ namespace NINA.Image.ImageAnalysis {
                         if (starList.Count <= p.NumberOfAFStars) {
                             result.BrightestStarPositions = starList.ConvertAll(s => s.Position);
                         } else {
-                            starList = starList.OrderByDescending(s => s.Radius * 0.3 + s.MeanBrightness * 0.7).Take(p.NumberOfAFStars).ToList<Star>();
+                            starList = starList.OrderByDescending(s => (s.Radius * 0.3) + (s.MeanBrightness * 0.7)).Take(p.NumberOfAFStars).ToList<Star>();
                             result.BrightestStarPositions = starList.ConvertAll(i => i.Position);
                         }
                         return starList.Select(s => s.ToDetectedStar()).ToList();

--- a/NINA.Test/Image/ImageData/ImageStatisticsTest.cs
+++ b/NINA.Test/Image/ImageData/ImageStatisticsTest.cs
@@ -1,0 +1,266 @@
+#region "copyright"
+
+/*
+    Copyright © 2016 - 2026 Stefan Berg <isbeorn86+NINA@googlemail.com> and the N.I.N.A. contributors
+
+    This file is part of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using FluentAssertions;
+using NINA.Image.ImageData;
+using NINA.Image.Interfaces;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace NINA.Test.Image.ImageData {
+
+    [TestFixture]
+    public class ImageStatisticsTest {
+
+        /* All test images are at least 64x64 pixels. An odd pixel count keeps the median on an
+         * actual (integer) sample value, which is the case the histogram based median/MAD walk
+         * is defined for, so the odd sized cases use a 65x65 frame. */
+        private const int EvenWidth = 64;
+
+        private const int EvenHeight = 64;
+        private const int EvenPixelCount = EvenWidth * EvenHeight;
+
+        private const int OddWidth = 65;
+        private const int OddHeight = 65;
+        private const int OddPixelCount = OddWidth * OddHeight;
+
+        [OneTimeSetUp]
+        public void WarmUp() {
+            /* run once so that JIT and first-use allocation costs are not attributed to the
+             * first test that happens to execute */
+            ImageStatistics.Create(Properties(EvenWidth, EvenHeight), new ushort[EvenPixelCount]);
+
+            TestContext.Out.WriteLine($"Stopwatch.IsHighResolution: {Stopwatch.IsHighResolution}, Stopwatch.Frequency: {Stopwatch.Frequency} Hz ({1e9d / Stopwatch.Frequency:F1} ns/tick)");
+        }
+
+        private static ImageProperties Properties(int width, int height, int bitDepth = 16) {
+            return new ImageProperties(width: width, height: height, bitDepth: bitDepth, isBayered: false, gain: 0, offset: 0);
+        }
+
+        /// <summary>
+        /// Invokes <see cref="ImageStatistics.Create(ImageProperties, ushort[])"/> and records the
+        /// wall clock duration of that single call using the platform high resolution timer.
+        /// </summary>
+        private static IImageStatistics CreateMeasured(ImageProperties properties, ushort[] data) {
+            var stopwatch = Stopwatch.StartNew();
+            var statistics = ImageStatistics.Create(properties, data);
+            var elapsedTicks = stopwatch.ElapsedTicks;
+
+            var elapsedMicroseconds = elapsedTicks * 1_000_000d / Stopwatch.Frequency;
+            TestContext.Out.WriteLine(
+                $"{TestContext.CurrentContext.Test.Name}: ImageStatistics.Create over {properties.Width}x{properties.Height} " +
+                $"({data.Length} pixels) took {elapsedMicroseconds / 1000d:F4} ms ({elapsedMicroseconds:F1} us, {elapsedTicks} ticks)");
+
+            return statistics;
+        }
+
+        [Test]
+        public void Create_SequentialValues_ComputesAllStatistics() {
+            /* 65x65 = 4225 pixels holding the values 1..4225, each exactly once */
+            var data = new ushort[OddPixelCount];
+            for (var i = 0; i < data.Length; i++) {
+                data[i] = (ushort)(i + 1);
+            }
+
+            var statistics = CreateMeasured(Properties(OddWidth, OddHeight), data);
+
+            statistics.BitDepth.Should().Be(16);
+            statistics.Min.Should().Be(1);
+            statistics.MinOccurrences.Should().Be(1);
+            statistics.Max.Should().Be(OddPixelCount);
+            statistics.MaxOccurrences.Should().Be(1);
+            /* mean and median of 1..n are both (n + 1) / 2 */
+            statistics.Mean.Should().BeApproximately((OddPixelCount + 1) / 2d, 1e-9);
+            statistics.Median.Should().BeApproximately((OddPixelCount + 1) / 2d, 1e-9);
+            /* deviations from the median are 0, 1, 1, 2, 2, ... so the MAD lands on (n - 1) / 4 */
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately((OddPixelCount - 1) / 4d, 1e-9);
+            /* population standard deviation of 1..n is sqrt((n^2 - 1) / 12) */
+            statistics.StDev.Should().BeApproximately(Math.Sqrt((((double)OddPixelCount * OddPixelCount) - 1d) / 12d), 1e-9);
+        }
+
+        [Test]
+        public void Create_RepeatedExtremes_CountsMinAndMaxOccurrences() {
+            /* 65x65 = 4225 pixels: 1500x value 5, 725x value 7, 2000x value 9 */
+            var data = BuildHistogramImage((5, 1500), (7, 725), (9, 2000));
+            data.Length.Should().Be(OddPixelCount);
+
+            var statistics = CreateMeasured(Properties(OddWidth, OddHeight), data);
+
+            statistics.Min.Should().Be(5);
+            statistics.MinOccurrences.Should().Be(1500);
+            statistics.Max.Should().Be(9);
+            statistics.MaxOccurrences.Should().Be(2000);
+            /* the middle sample falls inside the run of sevens */
+            statistics.Median.Should().BeApproximately(7d, 1e-9);
+            statistics.Mean.Should().BeApproximately(ReferenceMean(data), 1e-9);
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately(2d, 1e-9);
+            statistics.StDev.Should().BeApproximately(ReferenceStandardDeviation(data), 1e-6);
+        }
+
+        [Test]
+        public void Create_ExtremesDiscoveredLate_ResetsOccurrenceCounters() {
+            /* the running min/max are only established part way through the image, so the
+             * occurrence counters have to be reset when a new extreme shows up */
+            var data = new ushort[EvenPixelCount];
+            Array.Fill(data, (ushort)500);
+            data[100] = 100;
+            data[101] = 100;
+            data[102] = 100;
+            data[EvenPixelCount - 2] = 900;
+            data[EvenPixelCount - 1] = 900;
+
+            var statistics = CreateMeasured(Properties(EvenWidth, EvenHeight), data);
+
+            statistics.Min.Should().Be(100);
+            statistics.MinOccurrences.Should().Be(3);
+            statistics.Max.Should().Be(900);
+            statistics.MaxOccurrences.Should().Be(2);
+        }
+
+        [Test]
+        public void Create_EvenNumberOfValues_InterpolatesMedianBetweenCenterValues() {
+            /* 64x64 = 4096 pixels holding the values 1..4096, each exactly once */
+            var data = new ushort[EvenPixelCount];
+            for (var i = 0; i < data.Length; i++) {
+                data[i] = (ushort)(i + 1);
+            }
+
+            var statistics = CreateMeasured(Properties(EvenWidth, EvenHeight), data);
+
+            /* even sample count, so the median is interpolated between the two center values */
+            statistics.Median.Should().BeApproximately((EvenPixelCount + 1) / 2d, 1e-9);
+            statistics.Mean.Should().BeApproximately((EvenPixelCount + 1) / 2d, 1e-9);
+            statistics.Min.Should().Be(1);
+            statistics.MinOccurrences.Should().Be(1);
+            statistics.Max.Should().Be(EvenPixelCount);
+            statistics.MaxOccurrences.Should().Be(1);
+            statistics.StDev.Should().BeApproximately(ReferenceStandardDeviation(data), 1e-6);
+        }
+
+        [Test]
+        public void Create_ConstantImage_HasZeroDispersion() {
+            var data = new ushort[EvenPixelCount];
+            Array.Fill(data, (ushort)1234);
+
+            var statistics = CreateMeasured(Properties(EvenWidth, EvenHeight), data);
+
+            statistics.Min.Should().Be(1234);
+            statistics.MinOccurrences.Should().Be(EvenPixelCount);
+            statistics.Max.Should().Be(1234);
+            statistics.MaxOccurrences.Should().Be(EvenPixelCount);
+            statistics.Mean.Should().BeApproximately(1234d, 1e-9);
+            statistics.Median.Should().BeApproximately(1234d, 1e-9);
+            statistics.StDev.Should().BeApproximately(0d, 1e-9);
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately(0d, 1e-9);
+        }
+
+        [Test]
+        public void Create_ZeroImage_HasZeroStatistics() {
+            var data = new ushort[EvenPixelCount];
+
+            var statistics = CreateMeasured(Properties(EvenWidth, EvenHeight), data);
+
+            statistics.Min.Should().Be(0);
+            statistics.MinOccurrences.Should().Be(EvenPixelCount);
+            statistics.Max.Should().Be(0);
+            statistics.MaxOccurrences.Should().Be(EvenPixelCount);
+            statistics.Mean.Should().BeApproximately(0d, 1e-9);
+            statistics.Median.Should().BeApproximately(0d, 1e-9);
+            statistics.StDev.Should().BeApproximately(0d, 1e-9);
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately(0d, 1e-9);
+        }
+
+        [TestCase(42)]
+        [TestCase(1337)]
+        [TestCase(20260424)]
+        public void Create_RandomImage_MatchesReferenceImplementations(int seed) {
+            /* 101x101 = 10201 pixels of uniform noise */
+            const int width = 101;
+            const int height = 101;
+            var random = new Random(seed);
+            var data = new ushort[width * height];
+            for (var i = 0; i < data.Length; i++) {
+                data[i] = (ushort)random.Next(0, 60000);
+            }
+
+            var statistics = CreateMeasured(Properties(width, height), data);
+
+            var min = data.Min();
+            var max = data.Max();
+            statistics.Min.Should().Be(min);
+            statistics.MinOccurrences.Should().Be(data.Count(value => value == min));
+            statistics.Max.Should().Be(max);
+            statistics.MaxOccurrences.Should().Be(data.Count(value => value == max));
+            statistics.Mean.Should().BeApproximately(ReferenceMean(data), 1e-6);
+            statistics.Median.Should().BeApproximately(ReferenceMedian(data), 1e-6);
+            statistics.StDev.Should().BeApproximately(ReferenceStandardDeviation(data), 1e-6);
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately(ReferenceMedianAbsoluteDeviation(data), 1e-6);
+        }
+
+        [Test]
+        public void Create_NarrowDistribution_ComputesMedianAbsoluteDeviation() {
+            /* 65x65 = 4225 samples centred on 3000 and spread symmetrically by +/-1..2112 */
+            const ushort center = 3000;
+            var spread = (OddPixelCount - 1) / 2;
+            var data = new ushort[OddPixelCount];
+            data[0] = center;
+            for (var i = 1; i <= spread; i++) {
+                data[(2 * i) - 1] = (ushort)(center - i);
+                data[2 * i] = (ushort)(center + i);
+            }
+
+            var statistics = CreateMeasured(Properties(OddWidth, OddHeight), data);
+
+            statistics.Min.Should().Be(center - spread);
+            statistics.Max.Should().Be(center + spread);
+            statistics.Median.Should().BeApproximately(center, 1e-9);
+            statistics.Mean.Should().BeApproximately(center, 1e-9);
+            statistics.MedianAbsoluteDeviation.Should().BeApproximately(ReferenceMedianAbsoluteDeviation(data), 1e-9);
+            statistics.StDev.Should().BeApproximately(ReferenceStandardDeviation(data), 1e-6);
+        }
+
+        private static ushort[] BuildHistogramImage(params (ushort Value, int Occurrences)[] bins) {
+            return bins.SelectMany(bin => Enumerable.Repeat(bin.Value, bin.Occurrences)).ToArray();
+        }
+
+        private static double ReferenceMean(ushort[] data) {
+            return data.Sum(value => (double)value) / data.Length;
+        }
+
+        private static double ReferenceStandardDeviation(ushort[] data) {
+            var mean = ReferenceMean(data);
+            var sumSquares = data.Sum(value => (value - mean) * (value - mean));
+            return Math.Sqrt(sumSquares / data.Length);
+        }
+
+        private static double ReferenceMedian(ushort[] data) {
+            var sorted = data.OrderBy(value => value).ToArray();
+            var middle = sorted.Length / 2;
+            return sorted.Length % 2 == 0
+                ? (sorted[middle - 1] + sorted[middle]) / 2d
+                : sorted[middle];
+        }
+
+        private static double ReferenceMedianAbsoluteDeviation(ushort[] data) {
+            var median = ReferenceMedian(data);
+            var deviations = data.Select(value => Math.Abs(value - median)).OrderBy(value => value).ToArray();
+            var middle = deviations.Length / 2;
+            return deviations.Length % 2 == 0
+                ? (deviations[middle - 1] + deviations[middle]) / 2d
+                : deviations[middle];
+        }
+    }
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -69,6 +69,7 @@ This allows you to safely return to a stable release if needed.
 - Clicking on slew Alt/Az in the Mount equipment page with Mount drivers that do not support slewing to Alt/Az, will now fallback to slewing to RA/Dec coordinates instead of doing nothing.
 - The manual focuser step buttons now use configurable multipliers. Users can adjust the small step (default 0.5x) and large step (default 5.0x) multipliers in Options > Imaging > Autofocus.
 - Debayer algorithm has been optimized to work fast even on older CPUs
+- Star detection and image statistics calculations have been optimized to process pixels in parallel using SIMD vectorization, resulting in a significant speedup on most CPUs.
 - DSLR RAW conversion now uses LibRaw instead of the legacy DCRaw and FreeImage converters.
 - Native Nikon and Canon camera drivers can now be configured to use the file format selection, such as FITS or XISF, instead of always saving native camera RAW files.
 - Sky brightness readings in the Weather device windows have been increased from 2 decimal places to 5 so that measurements obtained in low light conditions are adequately displayed.


### PR DESCRIPTION
## Purpose

This PR contains several commits that vectorizes NINA's built-in star detection and the SD, MAD, and Eccentricity calculations using `System.Numerics` and its [Vector](https://learn.microsoft.com/en-us/dotnet/api/system.numerics.vector?view=net-10.0) class.  The upside of using this class is that the SIMD instruction sets that are available across CPU architectures and mircroarchitectures is transparently handled by the class, relieving us from having to maintain the scalar code paths in addition to vectorized ones for various SSSE, AVX, AVX2, and AVX-512 instruction sets on x64. 

Using a 16MP test image taken from a random sample of my own images, I observed various aspects of vectorized star detection take 1/2 to approaching 1/3 as long as the existing scalar methods. A comparative example of stopwatch timings for a single exposure done through NINA's camera simulator:

Scalar (current `develop` branch)
```
2026-09-12T21:25:03.6303|TRACE|ImageUtility.cs|Stretch|39|Start: 13.09.2026 01:25:03.555; Stopped: 13.09.2026 01:25:03.630; Elapsed: 00:00:00.0750948
2026-09-12T21:25:03.6328|TRACE|StarDetection.cs|GetInitialState|119|Star Detection initialized using resizeFactor: 0.3333333333333333, minimum star size: 2
2026-09-12T21:25:03.7007|TRACE|ImageUtility.cs|Convert16BppTo8Bpp|39|Start: 13.09.2026 01:25:03.632; Stopped: 13.09.2026 01:25:03.700; Elapsed: 00:00:00.0678250
2026-09-12T21:25:04.3564|TRACE|DetectionUtility.cs|ResizeForDetection|39|Start: 13.09.2026 01:25:03.700; Stopped: 13.09.2026 01:25:04.356; Elapsed: 00:00:00.6555493
2026-09-12T21:25:05.1968|TRACE|StarDetection.cs|PrepareForStructureDetection - CannyEdge|39|Start: 13.09.2026 01:25:04.356; Stopped: 13.09.2026 01:25:05.196; Elapsed: 00:00:00.8403240
2026-09-12T21:25:05.2287|TRACE|StarDetection.cs|PrepareForStructureDetection - SISThreshold|39|Start: 13.09.2026 01:25:05.196; Stopped: 13.09.2026 01:25:05.228; Elapsed: 00:00:00.0318679
2026-09-12T21:25:05.2524|TRACE|StarDetection.cs|PrepareForStructureDetection - BinaryDilation3x3|39|Start: 13.09.2026 01:25:05.228; Stopped: 13.09.2026 01:25:05.252; Elapsed: 00:00:00.0236509
2026-09-12T21:25:05.2525|TRACE|StarDetection.cs|PrepareForStructureDetection|39|Start: 13.09.2026 01:25:04.356; Stopped: 13.09.2026 01:25:05.252; Elapsed: 00:00:00.8960016
2026-09-12T21:25:05.3059|TRACE|StarDetection.cs|DetectStructures|39|Start: 13.09.2026 01:25:05.252; Stopped: 13.09.2026 01:25:05.305; Elapsed: 00:00:00.0532406
2026-09-12T21:25:05.5865|TRACE|StarDetection.cs|IdentifyStars|39|Start: 13.09.2026 01:25:05.307; Stopped: 13.09.2026 01:25:05.586; Elapsed: 00:00:00.2790341
2026-09-12T21:25:05.5904|INFO|StarDetection.cs|Detect|482|Average HFR: 7.182668712090384, Average FWHM: 4.248626164385457, Average Eccentricity: 0.45493136856647864, HFR σ: 1.1150106952513503, Detected Stars 156, Sensitivity High, ResizeFactor: 0.33
2026-09-12T21:25:05.5905|TRACE|StarDetection.cs|Detect|39|Start: 13.09.2026 01:25:03.632; Stopped: 13.09.2026 01:25:05.590; Elapsed: 00:00:01.9575865
```

Vectorized:
```
2026-09-12T21:23:30.5427|TRACE|ImageUtility.cs|Stretch|39|Start: 13.09.2026 01:23:30.513; Stopped: 13.09.2026 01:23:30.542; Elapsed: 00:00:00.0289982
2026-09-12T21:23:30.5454|TRACE|StarDetection.cs|GetInitialState|121|Star Detection initialized using resizeFactor: 0.3333333333333333, minimum star size: 2
2026-09-12T21:23:30.5836|TRACE|ImageUtility.cs|Convert16BppTo8Bpp|39|Start: 13.09.2026 01:23:30.545; Stopped: 13.09.2026 01:23:30.583; Elapsed: 00:00:00.0381541
2026-09-12T21:23:30.7455|TRACE|DetectionUtility.cs|ResizeForDetection|39|Start: 13.09.2026 01:23:30.583; Stopped: 13.09.2026 01:23:30.745; Elapsed: 00:00:00.1618166
2026-09-12T21:23:31.1128|TRACE|StarDetection.cs|PrepareForStructureDetection - CannyEdge|39|Start: 13.09.2026 01:23:30.745; Stopped: 13.09.2026 01:23:31.112; Elapsed: 00:00:00.3672267
2026-09-12T21:23:31.1197|TRACE|StarDetection.cs|PrepareForStructureDetection - SISThreshold|39|Start: 13.09.2026 01:23:31.112; Stopped: 13.09.2026 01:23:31.119; Elapsed: 00:00:00.0068572
2026-09-12T21:23:31.1238|TRACE|StarDetection.cs|PrepareForStructureDetection - BinaryDilation3x3|39|Start: 13.09.2026 01:23:31.119; Stopped: 13.09.2026 01:23:31.123; Elapsed: 00:00:00.0040642
2026-09-12T21:23:31.1238|TRACE|StarDetection.cs|PrepareForStructureDetection|39|Start: 13.09.2026 01:23:30.745; Stopped: 13.09.2026 01:23:31.123; Elapsed: 00:00:00.3782387
2026-09-12T21:23:31.1307|TRACE|StarDetection.cs|DetectStructures|39|Start: 13.09.2026 01:23:31.123; Stopped: 13.09.2026 01:23:31.130; Elapsed: 00:00:00.0068802
2026-09-12T21:23:31.2129|TRACE|StarDetection.cs|IdentifyStars|39|Start: 13.09.2026 01:23:31.130; Stopped: 13.09.2026 01:23:31.212; Elapsed: 00:00:00.0821346
2026-09-12T21:23:31.2131|INFO|StarDetection.cs|Detect|641|Average HFR: 7.182668712090384, Average FWHM: 4.248626164385457, Average Eccentricity: 0.45493136856647864, HFR σ: 1.1150106952513503, Detected Stars 156, Sensitivity High, ResizeFactor: 0.33
2026-09-12T21:23:31.2131|TRACE|StarDetection.cs|Detect|39|Start: 13.09.2026 01:23:30.545; Stopped: 13.09.2026 01:23:31.213; Elapsed: 00:00:00.6676701
```

Stopwatch timings across both app variants were fairly consistent during continuous looping exposures.

## 🧪 How Was It Tested?

1. I used Copilot to create `NINA.Test/Image/ImageData/ImageStatisticsTest.cs` in order to establish the behavior and timing of the new vectorized code. I then cherry-picked that to a copy of the current `develop` branch and ran those tests there. The same tests under both existing scalar and new vectorized code passed.
2. I've ran the vectoized code under many nights of regular imaging with satisfactory results.

## 🤖 AI / Tooling Disclosure

Vectorized functions created by hand, however `ImageStatisticsTest.cs` was done using Copilot/Claude Opus 5.

## ✅ PR Checklist

- [x] All unit tests pass
- [ ] UI changes tested across Light, Dark, and Night themes (if applicable)
- [x] Plugin API compatibility reviewed  
  - [x] No breaking changes to interfaces  
  - [x] No changes to method/class signatures (especially optional parameters)
- [x] `RELEASE_NOTES.md` updated (if applicable)
- [ ] [Documentation](https://github.com/isbeorn/nina.docs) updated (if applicable)

## 🔗 Related Issues

<!-- List related GitHub issues this PR closes or is connected to. Use GitHub keywords (e.g., "Closes #123"). -->

## 📸 Screenshots

<!-- If your PR includes UI changes, include before/after screenshots or videos -->

## 📝 Additional Notes

<!-- Add any extra context, caveats, or considerations for reviewers here -->
